### PR TITLE
Add mailbox patch metadata patch file

### DIFF
--- a/patches/08-patch-metadata.patch
+++ b/patches/08-patch-metadata.patch
@@ -1,0 +1,121 @@
+From a27e7d293d5fcca48941478807aa5e93e31cf891 Mon Sep 17 00:00:00 2001
+From: Codex <codex@openai.com>
+Date: Sun, 11 Jan 2026 18:37:35 +0000
+Subject: [PATCH] feat: patch-metadata
+
+---
+ Trio/Sources/Helpers/BuildDetails.swift       | 12 +++++++
+ .../View/Subviews/SubmodulesView.swift        | 31 +++++++++++++++++++
+ scripts/capture-build-details.sh              | 29 ++++++++++++++++-
+ 3 files changed, 71 insertions(+), 1 deletion(-)
+
+diff --git a/Trio/Sources/Helpers/BuildDetails.swift b/Trio/Sources/Helpers/BuildDetails.swift
+index 0ed3f632..352dc4a0 100644
+--- a/Trio/Sources/Helpers/BuildDetails.swift
++++ b/Trio/Sources/Helpers/BuildDetails.swift
+@@ -50,6 +50,18 @@ class BuildDetails: Injectable {
+         return result
+     }
+ 
++    var patches: [(name: String, subject: String, fromSHA: String)] {
++        guard let patches = dict["com-trio-patches"] as? [[String: Any]] else {
++            return []
++        }
++        return patches.map { patch in
++            let name = patch["name"] as? String ?? String(localized: "Unknown")
++            let subject = patch["subject"] as? String ?? ""
++            let fromSHA = patch["from_sha"] as? String ?? String(localized: "Unknown")
++            return (name: name, subject: subject, fromSHA: fromSHA)
++        }
++    }
++
+     // Determine if the build is from TestFlight
+     func isTestFlightBuild() -> Bool {
+         #if targetEnvironment(simulator)
+diff --git a/Trio/Sources/Modules/Settings/View/Subviews/SubmodulesView.swift b/Trio/Sources/Modules/Settings/View/Subviews/SubmodulesView.swift
+index 3584d247..373c72d1 100644
+--- a/Trio/Sources/Modules/Settings/View/Subviews/SubmodulesView.swift
++++ b/Trio/Sources/Modules/Settings/View/Subviews/SubmodulesView.swift
+@@ -13,6 +13,13 @@ struct SubmodulesView: View {
+                     KeyValueRow(key: name, value: info.commitSHA)
+                 }
+             }
++            if !buildDetails.patches.isEmpty {
++                Section(header: Text("Patches")) {
++                    ForEach(Array(buildDetails.patches.enumerated()), id: \.offset) { _, patch in
++                        PatchRow(name: patch.name, subject: patch.subject, sha: patch.fromSHA)
++                    }
++                }
++            }
+         }
+         .listStyle(.insetGrouped)
+         .navigationTitle("Submodules")
+@@ -35,3 +42,27 @@ struct KeyValueRow: View {
+         }
+     }
+ }
++
++struct PatchRow: View {
++    let name: String
++    let subject: String
++    let sha: String
++
++    var body: some View {
++        HStack {
++            VStack(alignment: .leading, spacing: 2) {
++                Text(name)
++                    .foregroundColor(.primary)
++                if !subject.isEmpty {
++                    Text(subject)
++                        .font(.footnote)
++                        .foregroundColor(.secondary)
++                }
++            }
++            Spacer()
++            Text(sha)
++                .foregroundColor(.secondary)
++                .multilineTextAlignment(.trailing)
++        }
++    }
++}
+diff --git a/scripts/capture-build-details.sh b/scripts/capture-build-details.sh
+index 89520d4e..609117f3 100755
+--- a/scripts/capture-build-details.sh
++++ b/scripts/capture-build-details.sh
+@@ -62,4 +62,31 @@ echo "${submodules_info}" | while IFS="|" read -r submodule_name sub_branch sub_
+     /usr/libexec/PlistBuddy -c "Add :${submodules_key}:${submodule_name}:commit_sha string ${sub_sha}" "${info_plist_path}"
+ done
+ 
+-echo "BuildDetails.plist has been updated at: ${info_plist_path}"
+\ No newline at end of file
++# --- Patch details ---
++patches_key="com-trio-patches"
++if /usr/libexec/PlistBuddy -c "Print :${patches_key}" "${info_plist_path}" 2>/dev/null; then
++    /usr/libexec/PlistBuddy -c "Delete :${patches_key}" "${info_plist_path}"
++fi
++/usr/libexec/PlistBuddy -c "Add :${patches_key} array" "${info_plist_path}"
++
++patch_files=$(find patches -maxdepth 1 -type f \( -name '*.patch' -o -name '*.am.patch' \) -print | sort)
++patch_index=0
++printf '%s\n' "${patch_files}" | while IFS= read -r patch_file; do
++    if [ -z "${patch_file}" ]; then
++        continue
++    fi
++    patch_name=$(basename "${patch_file}")
++    patch_from_sha=$(awk 'NR==1 {print $2}' "${patch_file}")
++    patch_subject=$(awk -F 'Subject: ' '/^Subject: / {print $2; exit}' "${patch_file}")
++    patch_name_escaped=$(printf '%s' "${patch_name}" | sed 's/"/\\"/g')
++    patch_from_sha_escaped=$(printf '%s' "${patch_from_sha}" | sed 's/"/\\"/g')
++    patch_subject_escaped=$(printf '%s' "${patch_subject}" | sed 's/"/\\"/g')
++
++    /usr/libexec/PlistBuddy -c "Add :${patches_key}:${patch_index} dict" "${info_plist_path}"
++    /usr/libexec/PlistBuddy -c "Add :${patches_key}:${patch_index}:name string \"${patch_name_escaped}\"" "${info_plist_path}"
++    /usr/libexec/PlistBuddy -c "Add :${patches_key}:${patch_index}:from_sha string \"${patch_from_sha_escaped}\"" "${info_plist_path}"
++    /usr/libexec/PlistBuddy -c "Add :${patches_key}:${patch_index}:subject string \"${patch_subject_escaped}\"" "${info_plist_path}"
++    patch_index=$((patch_index + 1))
++done
++
++echo "BuildDetails.plist has been updated at: ${info_plist_path}"
+-- 
+2.43.0
+

--- a/patches/08-patch-metadata.patch
+++ b/patches/08-patch-metadata.patch
@@ -1,23 +1,23 @@
-From a27e7d293d5fcca48941478807aa5e93e31cf891 Mon Sep 17 00:00:00 2001
-From: Codex <codex@openai.com>
-Date: Sun, 11 Jan 2026 18:37:35 +0000
+From ea52559315d36f905c38391b34da1894c71db3c3 Mon Sep 17 00:00:00 2001
+From: Trio Patch Bot <patch-bot@users.noreply.github.com>
+Date: Sun, 11 Jan 2026 20:18:31 +0000
 Subject: [PATCH] feat: patch-metadata
 
 ---
- Trio/Sources/Helpers/BuildDetails.swift       | 12 +++++++
- .../View/Subviews/SubmodulesView.swift        | 31 +++++++++++++++++++
- scripts/capture-build-details.sh              | 29 ++++++++++++++++-
- 3 files changed, 71 insertions(+), 1 deletion(-)
+ Trio/Sources/Helpers/BuildDetails.swift       | 13 ++++++
+ .../View/Subviews/SubmodulesView.swift        | 43 +++++++++++++++++++
+ scripts/capture-build-details.sh              | 32 +++++++++++++-
+ 3 files changed, 87 insertions(+), 1 deletion(-)
 
 diff --git a/Trio/Sources/Helpers/BuildDetails.swift b/Trio/Sources/Helpers/BuildDetails.swift
-index 0ed3f632..352dc4a0 100644
+index 0ed3f632..3fe1f6f5 100644
 --- a/Trio/Sources/Helpers/BuildDetails.swift
 +++ b/Trio/Sources/Helpers/BuildDetails.swift
-@@ -50,6 +50,18 @@ class BuildDetails: Injectable {
+@@ -50,6 +50,19 @@ class BuildDetails: Injectable {
          return result
      }
  
-+    var patches: [(name: String, subject: String, fromSHA: String)] {
++    var patches: [(name: String, subject: String, fromSHA: String, date: String)] {
 +        guard let patches = dict["com-trio-patches"] as? [[String: Any]] else {
 +            return []
 +        }
@@ -25,7 +25,8 @@ index 0ed3f632..352dc4a0 100644
 +            let name = patch["name"] as? String ?? String(localized: "Unknown")
 +            let subject = patch["subject"] as? String ?? ""
 +            let fromSHA = patch["from_sha"] as? String ?? String(localized: "Unknown")
-+            return (name: name, subject: subject, fromSHA: fromSHA)
++            let date = patch["date"] as? String ?? String(localized: "Unknown")
++            return (name: name, subject: subject, fromSHA: fromSHA, date: date)
 +        }
 +    }
 +
@@ -33,24 +34,29 @@ index 0ed3f632..352dc4a0 100644
      func isTestFlightBuild() -> Bool {
          #if targetEnvironment(simulator)
 diff --git a/Trio/Sources/Modules/Settings/View/Subviews/SubmodulesView.swift b/Trio/Sources/Modules/Settings/View/Subviews/SubmodulesView.swift
-index 3584d247..373c72d1 100644
+index 3584d247..19bddc45 100644
 --- a/Trio/Sources/Modules/Settings/View/Subviews/SubmodulesView.swift
 +++ b/Trio/Sources/Modules/Settings/View/Subviews/SubmodulesView.swift
-@@ -13,6 +13,13 @@ struct SubmodulesView: View {
+@@ -13,6 +13,18 @@ struct SubmodulesView: View {
                      KeyValueRow(key: name, value: info.commitSHA)
                  }
              }
 +            if !buildDetails.patches.isEmpty {
 +                Section(header: Text("Patches")) {
 +                    ForEach(Array(buildDetails.patches.enumerated()), id: \.offset) { _, patch in
-+                        PatchRow(name: patch.name, subject: patch.subject, sha: patch.fromSHA)
++                        PatchRow(
++                            name: patch.name,
++                            subject: patch.subject,
++                            sha: patch.fromSHA,
++                            date: patch.date
++                        )
 +                    }
 +                }
 +            }
          }
          .listStyle(.insetGrouped)
          .navigationTitle("Submodules")
-@@ -35,3 +42,27 @@ struct KeyValueRow: View {
+@@ -35,3 +47,34 @@ struct KeyValueRow: View {
          }
      }
  }
@@ -59,6 +65,7 @@ index 3584d247..373c72d1 100644
 +    let name: String
 +    let subject: String
 +    let sha: String
++    let date: String
 +
 +    var body: some View {
 +        HStack {
@@ -72,17 +79,23 @@ index 3584d247..373c72d1 100644
 +                }
 +            }
 +            Spacer()
-+            Text(sha)
-+                .foregroundColor(.secondary)
-+                .multilineTextAlignment(.trailing)
++            VStack(alignment: .trailing, spacing: 2) {
++                Text(sha)
++                    .foregroundColor(.secondary)
++                if !date.isEmpty {
++                    Text(date)
++                        .font(.footnote)
++                        .foregroundColor(.secondary)
++                }
++            }
 +        }
 +    }
 +}
 diff --git a/scripts/capture-build-details.sh b/scripts/capture-build-details.sh
-index 89520d4e..609117f3 100755
+index 89520d4e..3c4e00a4 100755
 --- a/scripts/capture-build-details.sh
 +++ b/scripts/capture-build-details.sh
-@@ -62,4 +62,31 @@ echo "${submodules_info}" | while IFS="|" read -r submodule_name sub_branch sub_
+@@ -62,4 +62,34 @@ echo "${submodules_info}" | while IFS="|" read -r submodule_name sub_branch sub_
      /usr/libexec/PlistBuddy -c "Add :${submodules_key}:${submodule_name}:commit_sha string ${sub_sha}" "${info_plist_path}"
  done
  
@@ -103,14 +116,17 @@ index 89520d4e..609117f3 100755
 +    fi
 +    patch_name=$(basename "${patch_file}")
 +    patch_from_sha=$(awk 'NR==1 {print $2}' "${patch_file}")
++    patch_date=$(awk -F 'Date: ' '/^Date: / {print $2; exit}' "${patch_file}")
 +    patch_subject=$(awk -F 'Subject: ' '/^Subject: / {print $2; exit}' "${patch_file}")
 +    patch_name_escaped=$(printf '%s' "${patch_name}" | sed 's/"/\\"/g')
 +    patch_from_sha_escaped=$(printf '%s' "${patch_from_sha}" | sed 's/"/\\"/g')
++    patch_date_escaped=$(printf '%s' "${patch_date}" | sed 's/"/\\"/g')
 +    patch_subject_escaped=$(printf '%s' "${patch_subject}" | sed 's/"/\\"/g')
 +
 +    /usr/libexec/PlistBuddy -c "Add :${patches_key}:${patch_index} dict" "${info_plist_path}"
 +    /usr/libexec/PlistBuddy -c "Add :${patches_key}:${patch_index}:name string \"${patch_name_escaped}\"" "${info_plist_path}"
 +    /usr/libexec/PlistBuddy -c "Add :${patches_key}:${patch_index}:from_sha string \"${patch_from_sha_escaped}\"" "${info_plist_path}"
++    /usr/libexec/PlistBuddy -c "Add :${patches_key}:${patch_index}:date string \"${patch_date_escaped}\"" "${info_plist_path}"
 +    /usr/libexec/PlistBuddy -c "Add :${patches_key}:${patch_index}:subject string \"${patch_subject_escaped}\"" "${info_plist_path}"
 +    patch_index=$((patch_index + 1))
 +done

--- a/patches/08-patch-metadata.patch
+++ b/patches/08-patch-metadata.patch
@@ -1,6 +1,6 @@
-From ea52559315d36f905c38391b34da1894c71db3c3 Mon Sep 17 00:00:00 2001
+From 01a99c750a56b1c521c394a3623b6f02d334d6e4 Mon Sep 17 00:00:00 2001
 From: Trio Patch Bot <patch-bot@users.noreply.github.com>
-Date: Sun, 11 Jan 2026 20:18:31 +0000
+Date: Sun, 11 Jan 2026 20:24:25 +0000
 Subject: [PATCH] feat: patch-metadata
 
 ---
@@ -92,7 +92,7 @@ index 3584d247..19bddc45 100644
 +    }
 +}
 diff --git a/scripts/capture-build-details.sh b/scripts/capture-build-details.sh
-index 89520d4e..3c4e00a4 100755
+index 89520d4e..a72a359e 100755
 --- a/scripts/capture-build-details.sh
 +++ b/scripts/capture-build-details.sh
 @@ -62,4 +62,34 @@ echo "${submodules_info}" | while IFS="|" read -r submodule_name sub_branch sub_
@@ -108,7 +108,7 @@ index 89520d4e..3c4e00a4 100755
 +fi
 +/usr/libexec/PlistBuddy -c "Add :${patches_key} array" "${info_plist_path}"
 +
-+patch_files=$(find patches -maxdepth 1 -type f \( -name '*.patch' -o -name '*.am.patch' \) -print | sort)
++patch_files=$(find patches -maxdepth 1 -type f -name '*.patch' -print | sort)
 +patch_index=0
 +printf '%s\n' "${patch_files}" | while IFS= read -r patch_file; do
 +    if [ -z "${patch_file}" ]; then


### PR DESCRIPTION
### Motivation
- Surface which mailbox-style patches were applied so builds can list included repo patches and aid provenance.
- Capture a stable identifier (`From` SHA) and the patch `Subject` from mailbox patches for traceability.
- Persist patch metadata into the build artifact so the running app can display which patches were included.
- Provide the change as a single mailbox patch artifact in `patches/` so the PR contains only the patch file.

### Description
- Added a `patches` computed property to `BuildDetails` in `Trio/Sources/Helpers/BuildDetails.swift` that reads `com-trio-patches` and returns `(name, subject, fromSHA)` tuples.
- Updated `Trio/Sources/Modules/Settings/View/Subviews/SubmodulesView.swift` to render a new `Patches` section and introduced a `PatchRow` view to show patch filename, subject, and `From` SHA.
- Extended `scripts/capture-build-details.sh` to scan `patches/*.patch` and `patches/*.am.patch`, extract the mailbox `From` SHA and `Subject`, escape strings, and write a `com-trio-patches` array into `BuildDetails.plist` via `PlistBuddy`.
- Added the mailbox patch artifact `patches/08-patch-metadata.patch` containing the code changes as a single-commit mailbox patch.

### Testing
- Ran `./scripts/generate-patch.sh -n -d "patch-metadata"` to generate the mailbox patch and validate its mailbox format, which completed successfully.
- The generation script performed a dry-run application test using `git am` on the target `dev` branch and reported that the patch can be applied successfully.
- The produced patch file `patches/08-patch-metadata.patch` was committed with `git commit` successfully.
- No unit or CI test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6963ebb6018883249bcabe7fd5a7df0d)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds end-to-end support for surfacing applied mailbox patches in app settings.
> 
> - `scripts/capture-build-details.sh`: scans `patches/*.patch`, extracts `From` SHA, `Subject`, and `Date`, and writes a `com-trio-patches` array to `BuildDetails.plist` via PlistBuddy
> - `BuildDetails.swift`: new `patches` computed property exposing `(name, subject, fromSHA, date)` from `com-trio-patches`
> - `SubmodulesView.swift`: renders a new "Patches" section using `PatchRow` to display patch filename, subject, SHA, and date
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15474ffd68095227fd30e7c5dd35d02759983899. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->