### PR TITLE
Add clean‑room Dexcom G7 direct BLE observer (watch extension)

### DIFF
--- a/Trio Watch App Extension/G7DirectBLE/G7DirectBLEManager.swift
+++ b/Trio Watch App Extension/G7DirectBLE/G7DirectBLEManager.swift
@@ -1,0 +1,417 @@
+import CoreBluetooth
+import Foundation
+
+final class G7DirectBLEManager: NSObject {
+    static let shared = G7DirectBLEManager()
+
+    private let centralQueue = DispatchQueue(label: "trio.watch.g7.ble.central")
+    private lazy var central = CBCentralManager(delegate: self, queue: centralQueue, options: [
+        CBCentralManagerOptionRestoreIdentifierKey: "trio.watch.g7.ble.central"
+    ])
+
+    private var peripheral: CBPeripheral?
+    private var authCharacteristic: CBCharacteristic?
+    private var controlCharacteristic: CBCharacteristic?
+    private var backfillCharacteristic: CBCharacteristic?
+
+    private var isActiveScene = false
+    private var isAuthReady = false
+    private var connectAttemptStartedAt: Date?
+    private var connectBackoff: TimeInterval = 2
+    private var connectTimeoutTimer: DispatchSourceTimer?
+    private var egvRequestTimer: DispatchSourceTimer?
+
+    private let dataService = CBUUID(string: "F8083532-849E-531C-C594-30F1F86A4EA5")
+    private let authCharacteristicID = CBUUID(string: "F8083533-849E-531C-C594-30F1F86A4EA5")
+    private let controlCharacteristicID = CBUUID(string: "F8083534-849E-531C-C594-30F1F86A4EA5")
+    private let backfillCharacteristicID = CBUUID(string: "F8083535-849E-531C-C594-30F1F86A4EA5")
+    private let jpakeCharacteristicID = CBUUID(string: "F8083536-849E-531C-C594-30F1F86A4EA5")
+
+    private let egvRequestOpcode: UInt8 = 0x4E
+
+    override private init() {
+        super.init()
+    }
+
+    func onSceneActive() {
+        isActiveScene = true
+        Task { await log("event=g7_ble_lifecycle scene=active") }
+        centralQueue.async { [weak self] in
+            self?.startIfPossible()
+        }
+    }
+
+    func onSceneInactive() {
+        isActiveScene = false
+        Task { await log("event=g7_ble_lifecycle scene=inactive ble_continues=true") }
+    }
+
+    func stop() {
+        centralQueue.async { [weak self] in
+            guard let self else { return }
+            self.isActiveScene = false
+            self.cancelTimers()
+            if let peripheral = self.peripheral {
+                self.central.cancelPeripheralConnection(peripheral)
+            }
+            self.peripheral = nil
+            self.authCharacteristic = nil
+            self.controlCharacteristic = nil
+            self.backfillCharacteristic = nil
+            self.isAuthReady = false
+            TrioComplicationDataStore.shared.setDirectBLEStatus(.off)
+        }
+    }
+
+    private func startIfPossible() {
+        guard isActiveScene else { return }
+
+        guard central.state == .poweredOn else {
+            Task { await log("event=g7_ble_blocked_unavailable state=\(central.state.rawValue)") }
+            TrioComplicationDataStore.shared.setDirectBLEStatus(.unavailable)
+            return
+        }
+
+        TrioComplicationDataStore.shared.setDirectBLEStatus(.searching)
+
+        let retrieved = central.retrieveConnectedPeripherals(withServices: [dataService])
+        if let candidate = retrieved.first {
+            Task { await log("event=g7_ble_connect_attempt source=retrieved_data_service id=\(candidate.identifier.uuidString)") }
+            connect(candidate)
+            return
+        }
+
+        Task { await log("event=g7_ble_scan_start mode=allow_duplicates") }
+        central.scanForPeripherals(withServices: nil, options: [CBCentralManagerScanOptionAllowDuplicatesKey: true])
+    }
+
+    private func connect(_ peripheral: CBPeripheral) {
+        self.peripheral = peripheral
+        peripheral.delegate = self
+        connectAttemptStartedAt = Date()
+        TrioComplicationDataStore.shared.setDirectBLEStatus(.connecting)
+        central.connect(peripheral, options: [CBConnectPeripheralOptionNotifyOnDisconnectionKey: true])
+        armConnectTimeout()
+    }
+
+    private func armConnectTimeout() {
+        connectTimeoutTimer?.cancel()
+        let timer = DispatchSource.makeTimerSource(queue: centralQueue)
+        timer.schedule(deadline: .now() + 12)
+        timer.setEventHandler { [weak self] in
+            guard let self else { return }
+            Task { await self.log("event=g7_ble_connect_failed error_domain=timeout error_code=1001 error_desc=connect_timeout") }
+            self.handleReconnect(reason: "connect_timeout")
+        }
+        connectTimeoutTimer = timer
+        timer.resume()
+    }
+
+    private func armEGVRequestTimer() {
+        egvRequestTimer?.cancel()
+        let timer = DispatchSource.makeTimerSource(queue: centralQueue)
+        timer.schedule(deadline: .now() + 2, repeating: 120)
+        timer.setEventHandler { [weak self] in
+            self?.sendEGVRequest(reason: "timer")
+        }
+        egvRequestTimer = timer
+        timer.resume()
+    }
+
+    private func sendEGVRequest(reason: String) {
+        guard let peripheral, let controlCharacteristic else {
+            Task { await log("event=g7_ble_blocked_control_not_ready reason=\(reason)") }
+            return
+        }
+
+        let payload = Data([egvRequestOpcode])
+        peripheral.writeValue(payload, for: controlCharacteristic, type: .withResponse)
+        Task {
+            await log("event=g7_ble_egv_request_sent opcode=0x4E reason=\(reason) write_type=with_response")
+        }
+    }
+
+    private func handleReconnect(reason: String) {
+        cancelTimers()
+        authCharacteristic = nil
+        controlCharacteristic = nil
+        backfillCharacteristic = nil
+        isAuthReady = false
+
+        TrioComplicationDataStore.shared.setDirectBLEStatus(.stalled)
+
+        connectBackoff = min(connectBackoff * 1.5, 15)
+        let wait = connectBackoff
+
+        Task { await log("event=g7_ble_retry_scheduled reason=\(reason) delay=\(Int(wait))") }
+
+        centralQueue.asyncAfter(deadline: .now() + wait) { [weak self] in
+            self?.startIfPossible()
+        }
+    }
+
+    private func cancelTimers() {
+        connectTimeoutTimer?.cancel()
+        connectTimeoutTimer = nil
+        egvRequestTimer?.cancel()
+        egvRequestTimer = nil
+    }
+
+    private func handleAuthNotification(_ data: Data) {
+        let bytes = [UInt8](data)
+        let opcode = bytes.first ?? 0
+
+        Task {
+            await log("event=g7_ble_auth_payload_received opcode=0x\(String(format: "%02X", opcode)) bytes=\(bytes.count)")
+        }
+
+        if bytes.count > 1 {
+            isAuthReady = true
+            enableControlAndRequestIfReady(trigger: "auth_notify")
+        }
+    }
+
+    private func enableControlAndRequestIfReady(trigger: String) {
+        guard let peripheral, let service = peripheral.services?.first(where: { $0.uuid == dataService }) else {
+            Task { await log("event=g7_ble_blocked_no_service trigger=\(trigger)") }
+            return
+        }
+
+        guard isAuthReady else {
+            Task { await log("event=g7_ble_blocked_auth_incomplete trigger=\(trigger)") }
+            return
+        }
+
+        if let control = controlCharacteristic {
+            peripheral.setNotifyValue(true, for: control)
+            Task { await log("event=g7_ble_control_notify_enabled trigger=\(trigger)") }
+            sendEGVRequest(reason: "auth_ready")
+            armEGVRequestTimer()
+            TrioComplicationDataStore.shared.setDirectBLEStatus(.active)
+            return
+        }
+
+        peripheral.discoverCharacteristics(nil, for: service)
+    }
+
+    private func parseEGV(_ payload: Data) -> TrioComplicationSnapshot? {
+        let bytes = [UInt8](payload)
+        guard bytes.count >= 10 else { return nil }
+
+        let glucose = Int(bytes[2]) | (Int(bytes[3]) << 8)
+        let trendRaw = Int8(bitPattern: bytes[6])
+        let age = Int(bytes[8])
+
+        let trend = mapTrend(rate: trendRaw)
+        let readingDate = Date().addingTimeInterval(TimeInterval(-age * 60))
+
+        return TrioComplicationSnapshot(
+            glucose: "\(glucose)",
+            trend: trend,
+            readingDate: readingDate,
+            date: Date(),
+            source: .directBLE
+        )
+    }
+
+    private func mapTrend(rate: Int8) -> String {
+        switch rate {
+        case 3...: return "DoubleUp"
+        case 2: return "SingleUp"
+        case 1: return "FortyFiveUp"
+        case 0: return "Flat"
+        case -1: return "FortyFiveDown"
+        case -2: return "SingleDown"
+        default: return "DoubleDown"
+        }
+    }
+
+    private func snapshotSourceTag() -> String {
+        if let source = TrioComplicationDataStore.shared.latestSnapshot()?.source {
+            return source.rawValue
+        }
+        return "none"
+    }
+
+    private func log(_ message: String, function: String = #function, file: String = #fileID, line: Int = #line) async {
+        await WatchLogger.shared.log(message, function: function, file: file, line: line)
+    }
+}
+
+extension G7DirectBLEManager: CBCentralManagerDelegate {
+    func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        Task { await log("event=g7_ble_central_state state=\(central.state.rawValue)") }
+        if central.state == .poweredOn {
+            startIfPossible()
+        } else {
+            TrioComplicationDataStore.shared.setDirectBLEStatus(.unavailable)
+        }
+    }
+
+    func centralManager(_ central: CBCentralManager, willRestoreState dict: [String: Any]) {
+        Task { await log("event=g7_ble_restore keys=\(dict.keys.joined(separator: ","))") }
+    }
+
+    func centralManager(
+        _: CBCentralManager,
+        didDiscover peripheral: CBPeripheral,
+        advertisementData: [String: Any],
+        rssi RSSI: NSNumber
+    ) {
+        let name = peripheral.name ?? (advertisementData[CBAdvertisementDataLocalNameKey] as? String) ?? "unknown"
+        let hasFebc = (advertisementData[CBAdvertisementDataServiceUUIDsKey] as? [CBUUID])?.contains(CBUUID(string: "FEBC")) == true
+        let likelyG7 = name.lowercased().contains("dexcom") || name.uppercased().contains("DXCM") || hasFebc
+
+        Task {
+            await log("event=g7_ble_peripheral_discovered id=\(peripheral.identifier.uuidString) name=\(name) rssi=\(RSSI.intValue) has_febc=\(hasFebc)")
+        }
+
+        guard likelyG7 else {
+            Task { await log("event=g7_ble_peripheral_skipped reason=name_advertisement_no_match") }
+            return
+        }
+
+        central.stopScan()
+        Task { await log("event=g7_ble_scan_stopped reason=candidate_found") }
+        Task { await log("event=g7_ble_connect_attempt source=scan id=\(peripheral.identifier.uuidString)") }
+        connect(peripheral)
+    }
+
+    func centralManager(_: CBCentralManager, didConnect peripheral: CBPeripheral) {
+        connectBackoff = 2
+        connectTimeoutTimer?.cancel()
+        TrioComplicationDataStore.shared.setDirectBLEStatus(.connecting)
+
+        let elapsed = connectAttemptStartedAt.map { Int(Date().timeIntervalSince($0) * 1000) } ?? -1
+        Task { await log("event=g7_ble_did_connect latency_ms=\(elapsed)") }
+
+        peripheral.discoverServices(nil)
+    }
+
+    func centralManager(_: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {
+        let nsError = error as NSError?
+        Task {
+            await log(
+                "event=g7_ble_connect_failed error_domain=\(nsError?.domain ?? "unknown") error_code=\(nsError?.code ?? -1) error_desc=\(nsError?.localizedDescription ?? "none") id=\(peripheral.identifier.uuidString)"
+            )
+        }
+        handleReconnect(reason: "did_fail_to_connect")
+    }
+
+    func centralManager(_: CBCentralManager, didDisconnectPeripheral _: CBPeripheral, error: Error?) {
+        let nsError = error as NSError?
+        Task {
+            await log("event=g7_ble_session_outcome outcome=incomplete final_stage=disconnect error=\(nsError?.localizedDescription ?? "none")")
+        }
+        handleReconnect(reason: "disconnect")
+    }
+}
+
+extension G7DirectBLEManager: CBPeripheralDelegate {
+    func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
+        if let error {
+            Task { await log("event=g7_ble_services_discovered status=error error=\(error.localizedDescription)") }
+            handleReconnect(reason: "discover_services_error")
+            return
+        }
+
+        let uuids = peripheral.services?.map { $0.uuid.uuidString }.joined(separator: ",") ?? "none"
+        Task { await log("event=g7_ble_services_discovered status=ok services=\(uuids)") }
+
+        peripheral.services?.forEach { service in
+            peripheral.discoverCharacteristics(nil, for: service)
+        }
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
+        if let error {
+            Task { await log("event=g7_ble_characteristics_discovered status=error error=\(error.localizedDescription)") }
+            return
+        }
+
+        let chars = service.characteristics ?? []
+        let characteristicIDs = chars.map { $0.uuid.uuidString }.joined(separator: ",")
+        Task { await log("event=g7_ble_characteristics_discovered service=\(service.uuid.uuidString) chars=\(characteristicIDs)") }
+
+        for characteristic in chars {
+            switch characteristic.uuid {
+            case authCharacteristicID:
+                authCharacteristic = characteristic
+                peripheral.setNotifyValue(true, for: characteristic)
+                Task { await log("event=g7_ble_auth_notify_enabled") }
+            case controlCharacteristicID:
+                controlCharacteristic = characteristic
+            case backfillCharacteristicID:
+                backfillCharacteristic = characteristic
+                Task { await log("event=g7_ble_backfill_discovered action=log_only") }
+            case jpakeCharacteristicID:
+                Task { await log("event=g7_ble_jpake_skipped reason=observer_only") }
+            default:
+                continue
+            }
+        }
+
+        enableControlAndRequestIfReady(trigger: "characteristics_discovered")
+    }
+
+    func peripheral(_: CBPeripheral, didUpdateNotificationStateFor characteristic: CBCharacteristic, error: Error?) {
+        if let error {
+            Task { await log("event=g7_ble_notify_enable_failed char=\(characteristic.uuid.uuidString) error=\(error.localizedDescription)") }
+            return
+        }
+
+        Task {
+            await log("event=g7_ble_notify_enabled char=\(characteristic.uuid.uuidString) enabled=\(characteristic.isNotifying)")
+        }
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
+        if let error {
+            Task { await log("event=g7_ble_update_value_error char=\(characteristic.uuid.uuidString) error=\(error.localizedDescription)") }
+            return
+        }
+
+        guard let data = characteristic.value else { return }
+
+        if characteristic.uuid == authCharacteristicID {
+            handleAuthNotification(data)
+            return
+        }
+
+        if characteristic.uuid == controlCharacteristicID {
+            let opcode = data.first ?? 0
+            Task { await log("event=g7_ble_control_payload_received opcode=0x\(String(format: "%02X", opcode)) bytes=\(data.count)") }
+
+            guard opcode == egvRequestOpcode, let snapshot = parseEGV(data) else {
+                return
+            }
+
+            TrioComplicationDataStore.shared.save(snapshot, triggerReload: true, minInterval: 5)
+            TrioComplicationDataStore.shared.setDirectBLEStatus(.active)
+            TrioComplicationDataStore.shared.setLastDirectBLEEvent(at: Date())
+
+            Task {
+                await log("event=g7_ble_egv_received glucose=\(snapshot.glucose) trend=\(snapshot.trend) reading_date=\(snapshot.readingDate.timeIntervalSince1970)")
+                await log("event=g7_ble_snapshot_saved source=directBLE previous_source=\(snapshotSourceTag())")
+            }
+
+            Task { @MainActor in
+                NotificationCenter.default.post(name: .g7DirectBLESnapshotSaved, object: snapshot)
+            }
+        }
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?) {
+        if let error {
+            Task { await log("event=g7_ble_control_write_failed char=\(characteristic.uuid.uuidString) error=\(error.localizedDescription)") }
+            handleReconnect(reason: "control_write_failed")
+            return
+        }
+        Task { await log("event=g7_ble_control_write_ok char=\(characteristic.uuid.uuidString)") }
+        _ = peripheral
+    }
+}
+
+extension Notification.Name {
+    static let g7DirectBLESnapshotSaved = Notification.Name("g7DirectBLESnapshotSaved")
+}

--- a/Trio Watch App Extension/TrioWatchApp.swift
+++ b/Trio Watch App Extension/TrioWatchApp.swift
@@ -13,6 +13,17 @@ import UserNotifications
             TrioMainWatchView()
         }
         .onChange(of: scenePhase) { _, newScenePhase in
+            switch newScenePhase {
+            case .active:
+                G7DirectBLEManager.shared.onSceneActive()
+            case .inactive:
+                G7DirectBLEManager.shared.onSceneInactive()
+            case .background:
+                G7DirectBLEManager.shared.onSceneInactive()
+            @unknown default:
+                break
+            }
+
             if newScenePhase == .background {
                 Task {
                     await WatchLogger.shared.flushPersistedLogs()

--- a/Trio Watch App Extension/Views/TrioMainWatchView.swift
+++ b/Trio Watch App Extension/Views/TrioMainWatchView.swift
@@ -59,6 +59,19 @@ struct TrioMainWatchView: View {
         endPoint: .bottom
     )
 
+    private var directBLEIndicatorText: String {
+        let status = TrioComplicationDataStore.shared.directBLEStatus().rawValue
+        let source = state.displayedReadingSource.rawValue
+        let ageText: String
+        if let lastEvent = TrioComplicationDataStore.shared.lastDirectBLEEventAt() {
+            let age = max(0, Int(Date().timeIntervalSince(lastEvent) / 60))
+            ageText = "\(age)m"
+        } else {
+            ageText = "--"
+        }
+        return "src:\(source) · ble:\(status) · last:\(ageText)"
+    }
+
     var body: some View {
         NavigationStack(path: $navigationPath) {
             TabView(selection: $currentPage) {
@@ -69,6 +82,15 @@ struct TrioMainWatchView: View {
                         rotationDegrees: rotationDegrees,
                         isWatchStateDated: isWatchStateDated || isSessionUnreachable
                     )
+                    VStack {
+                        Spacer()
+                        Text(directBLEIndicatorText)
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundStyle(.white.opacity(0.8))
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.6)
+                            .padding(.bottom, 8)
+                    }
 
                     if state.showSyncingAnimation {
                         Image(systemName: "iphone.radiowaves.left.and.right")

--- a/Trio Watch App Extension/WatchState.swift
+++ b/Trio Watch App Extension/WatchState.swift
@@ -13,6 +13,9 @@ import WatchConnectivity
     var isReachable = false
 
     var lastWatchStateUpdate: TimeInterval?
+    var displayedReadingSource: TrioReadingSource = .watchConnectivity
+    var directBLEStatus: G7DirectBLEStatus = .off
+    var lastDirectBLEEventAt: Date?
 
     /// main view relevant metrics
     var currentGlucose: String = "--"
@@ -78,6 +81,31 @@ import WatchConnectivity
     override init() {
         super.init()
         setupSession()
+        startDirectBLESnapshotObserver()
+    }
+
+    private func startDirectBLESnapshotObserver() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleDirectBLESnapshot(_:)),
+            name: .g7DirectBLESnapshotSaved,
+            object: nil
+        )
+    }
+
+    @objc private func handleDirectBLESnapshot(_ note: Notification) {
+        guard let snapshot = note.object as? TrioComplicationSnapshot else { return }
+        applyDirectBleSnapshot(snapshot)
+    }
+
+    @MainActor
+    func applyDirectBleSnapshot(_ snapshot: TrioComplicationSnapshot) {
+        currentGlucose = snapshot.glucose
+        trend = snapshot.trend
+        lastWatchStateUpdate = snapshot.readingDate.timeIntervalSince1970
+        displayedReadingSource = .directBLE
+        directBLEStatus = TrioComplicationDataStore.shared.directBLEStatus()
+        lastDirectBLEEventAt = TrioComplicationDataStore.shared.lastDirectBLEEventAt()
     }
 
     /// Configures the WatchConnectivity session if supported on the device
@@ -465,6 +493,7 @@ import WatchConnectivity
 
         if let currentGlucose = message[WatchMessageKeys.currentGlucose] as? String {
             self.currentGlucose = currentGlucose
+            displayedReadingSource = .watchConnectivity
         }
 
         if let currentGlucoseColorString = message[WatchMessageKeys.currentGlucoseColorString] as? String {
@@ -474,6 +503,16 @@ import WatchConnectivity
         if let trend = message[WatchMessageKeys.trend] as? String {
             self.trend = trend
         }
+        if let sourceRaw = message[WatchMessageKeys.readingSource] as? String,
+           let source = TrioReadingSource(rawValue: sourceRaw)
+        {
+            displayedReadingSource = source
+        } else if message[WatchMessageKeys.currentGlucose] != nil {
+            displayedReadingSource = .watchConnectivity
+        }
+
+        directBLEStatus = TrioComplicationDataStore.shared.directBLEStatus()
+        lastDirectBLEEventAt = TrioComplicationDataStore.shared.lastDirectBLEEventAt()
 
         if let delta = message[WatchMessageKeys.delta] as? String {
             self.delta = delta

--- a/Trio Watch Shared/TrioComplicationDataStore.swift
+++ b/Trio Watch Shared/TrioComplicationDataStore.swift
@@ -1,0 +1,118 @@
+import Foundation
+import WidgetKit
+
+public enum TrioReadingSource: String, Codable {
+    case watchConnectivity
+    case healthKit
+    case directBLE
+}
+
+public enum G7DirectBLEStatus: String, Codable {
+    case off
+    case searching
+    case connecting
+    case active
+    case stalled
+    case unavailable
+}
+
+public struct TrioComplicationSnapshot: Codable, Equatable {
+    public var glucose: String
+    public var trend: String
+    public var readingDate: Date
+    public var date: Date
+    public var source: TrioReadingSource
+    public var delta: String?
+
+    public init(
+        glucose: String,
+        trend: String,
+        readingDate: Date,
+        date: Date,
+        source: TrioReadingSource,
+        delta: String? = nil
+    ) {
+        self.glucose = glucose
+        self.trend = trend
+        self.readingDate = readingDate
+        self.date = date
+        self.source = source
+        self.delta = delta
+    }
+}
+
+public final class TrioComplicationDataStore {
+    public static let shared = TrioComplicationDataStore()
+
+    public static let complicationKind = "TrioWatchComplication"
+
+    private let queue = DispatchQueue(label: "TrioComplicationDataStore.queue")
+    private let defaults = UserDefaults.standard
+
+    private let latestSnapshotKey = "trio.complication.snapshot.latest"
+    private let lastSaveKey = "trio.complication.snapshot.lastSave"
+    private let lastDirectBLEEventKey = "trio.complication.directBLE.lastEvent"
+    private let directBLEStatusKey = "trio.complication.directBLE.status"
+
+    private init() {}
+
+    public func latestSnapshot() -> TrioComplicationSnapshot? {
+        queue.sync {
+            guard let data = defaults.data(forKey: latestSnapshotKey) else { return nil }
+            return try? JSONDecoder().decode(TrioComplicationSnapshot.self, from: data)
+        }
+    }
+
+    public func save(_ snapshot: TrioComplicationSnapshot, triggerReload: Bool = true, minInterval: TimeInterval = 30) {
+        let now = Date()
+
+        queue.async {
+            let lastSaveInterval = self.defaults.double(forKey: self.lastSaveKey)
+            let lastSave = Date(timeIntervalSince1970: lastSaveInterval)
+            let elapsed = now.timeIntervalSince(lastSave)
+
+            if elapsed < minInterval {
+                return
+            }
+
+            guard let encoded = try? JSONEncoder().encode(snapshot) else {
+                return
+            }
+
+            self.defaults.set(encoded, forKey: self.latestSnapshotKey)
+            self.defaults.set(now.timeIntervalSince1970, forKey: self.lastSaveKey)
+
+            if snapshot.source == .directBLE {
+                self.defaults.set(now.timeIntervalSince1970, forKey: self.lastDirectBLEEventKey)
+            }
+
+            guard triggerReload else { return }
+            DispatchQueue.main.async {
+                WidgetCenter.shared.reloadTimelines(ofKind: Self.complicationKind)
+            }
+        }
+    }
+
+    public func setDirectBLEStatus(_ status: G7DirectBLEStatus) {
+        defaults.set(status.rawValue, forKey: directBLEStatusKey)
+    }
+
+    public func directBLEStatus() -> G7DirectBLEStatus {
+        guard let raw = defaults.string(forKey: directBLEStatusKey),
+              let status = G7DirectBLEStatus(rawValue: raw)
+        else {
+            return .off
+        }
+        return status
+    }
+
+    public func setLastDirectBLEEvent(at date: Date) {
+        defaults.set(date.timeIntervalSince1970, forKey: lastDirectBLEEventKey)
+    }
+
+    public func lastDirectBLEEventAt() -> Date? {
+        let value = defaults.double(forKey: lastDirectBLEEventKey)
+        guard value > 0 else { return nil }
+        return Date(timeIntervalSince1970: value)
+    }
+}

--- a/Trio/Sources/Models/WatchMessageKeys.swift
+++ b/Trio/Sources/Models/WatchMessageKeys.swift
@@ -35,6 +35,7 @@ enum WatchMessageKeys {
     static let currentGlucoseColorString = "currentGlucoseColorString"
     static let trend = "trend"
     static let delta = "delta"
+    static let readingSource = "readingSource"
     static let iob = "iob"
     static let cob = "cob"
     static let lastLoopTime = "lastLoopTime"

--- a/Trio/Sources/Services/WatchManager/AppleWatchManager.swift
+++ b/Trio/Sources/Services/WatchManager/AppleWatchManager.swift
@@ -439,6 +439,7 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
             WatchMessageKeys.currentGlucoseColorString: state.currentGlucoseColorString ?? "#ffffff",
             WatchMessageKeys.trend: state.trend ?? "",
             WatchMessageKeys.delta: state.delta ?? "",
+            WatchMessageKeys.readingSource: "watchConnectivity",
             WatchMessageKeys.iob: state.iob ?? "",
             WatchMessageKeys.cob: state.cob ?? "",
             WatchMessageKeys.lastLoopTime: state.lastLoopTime ?? "",

--- a/docs/in-progress/watch-g7-direct-ble-observer/01-design.md
+++ b/docs/in-progress/watch-g7-direct-ble-observer/01-design.md
@@ -1,0 +1,84 @@
+# Trio Watch — Dexcom G7 Direct BLE Observer Design
+
+## Mission and premise
+Implement a watch-only observer path that attaches to the same-device BLE session already owned by the Dexcom G7 watch app, requests EGV data over control characteristic writes, and persists readings to the complication store with source attribution.
+
+## Reference note
+The prompt-provided archive path was not available inside this container, so this design follows the required observer constraints from the prompt itself plus Trio codebase integration constraints. No prior Trio `G7DirectBLEManager.swift` implementation was reused.
+
+## Observer sequence
+1. Eager, long-lived `CBCentralManager` with restoration identifier.
+2. On `.active`, attempt `retrieveConnectedPeripherals(withServices:)` for G7 data service first.
+3. If not found, broad scan with tolerant matching (`name` patterns + FEBC adv service).
+4. Connect and discover services/characteristics broadly (`nil` discovery).
+5. Enable auth notifications.
+6. Observe auth payloads (no auth writes).
+7. After auth traffic indicates readiness, enable control notify and send EGV opcode `0x4E`.
+8. Parse control payload to glucose/trend/reading date and save `TrioComplicationSnapshot` with source=`directBLE`.
+9. Keep periodic EGV requests while connected to sustain multiple readings.
+
+## Peripheral discovery / attach strategy
+Chosen order: connected-service retrieval first, then scan fallback. Rationale: retrieval is low-latency and best fit for piggybacking an already-connected session; scan remains the universal fallback and is required for robustness.
+
+## Filtering strategy
+Chosen: DiaBLE-style standalone tolerant matching (name/advertisement), no iPhone-bridged exact-name filter in this pass. Rationale: fewer moving parts and no cross-target dependency for initial attach reliability.
+
+## Auth advance + EGV cadence
+Auth advance condition: first non-empty auth notify payload marks observer-ready. Rationale: avoids strict bonded/authenticated bit-gating that can stall in observer mode.
+
+EGV cadence: immediate request when auth-ready + repeating timer (120s) while connected. Rationale: one-shot-on-connect is not enough for sustained delivery.
+
+## Reconnect policy
+On failure/disconnect: retry with bounded backoff (2s increasing to 15s max), reset backoff on successful connect, never permanently give up while foreground-active.
+
+## Scene/lifecycle
+- `.active`: start/resume observer.
+- `.inactive`: no proactive teardown.
+- `.background`: no teardown beyond existing app behavior.
+- Explicit `stop()` remains hard-off API.
+- `WKExtendedRuntimeSession`: omitted in this pass to keep focus on core attach path.
+
+## UI indicator
+Main watch view adds one inline line: `src:<source> · ble:<status> · last:<minutes>` showing current displayed source, observer status, and recency of last direct BLE event.
+
+## Source attribution model
+`TrioComplicationSnapshot` now carries `source` (`watchConnectivity`, `healthKit`, `directBLE`). Watch UI reads snapshot-derived source and displays it directly.
+
+## Observability plan
+Structured `WatchLogger` events with `event=g7_ble_*`, including:
+- lifecycle, scan start/stop, discovered/skipped, connect attempt source tags
+- services/characteristics discovery, auth/control notify enable
+- auth/control payload receipt, EGV request sends, EGV parse/save
+- connect/disconnect/failure with error fields
+- blocked states and retry schedule
+
+## Open design question answers
+1. **Filtering:** standalone tolerant matching. Minimizes dependency chain and starts working with watch-only deploy.
+2. **Attach strategy:** retrieve-connected first, then scan. Fast-path for session sharing plus reliable fallback.
+3. **Discovery breadth:** broad (`nil`) service/characteristic discovery for compatibility and to avoid missing target chars.
+4. **Timeout/backoff:** connect timeout 12s; retry 2s→15s cap. Aggressive but bounded.
+5. **Central queue:** dedicated serial queue. Keeps BLE deterministic; hops to main actor only for UI/store notification.
+6. **Restoration:** yes; restoration ID included and restore callback logs restored keys.
+7. **connect options:** set disconnect notification option only; no extra options needed for observer POC.
+8. **Auth advance:** observed auth traffic (non-empty payload) enables progress. Avoid over-strict stalls.
+9. **EGV cadence:** auth-ready immediate send + periodic resend timer. Best chance for repeated readings.
+10. **Control write failure:** log detailed failure and reconnect cycle.
+11. **Backfill:** discover and log-only (not startup gating). Keep first pass focused on live EGV reliability.
+12. **Scan after connect:** stop scanning on candidate/connect. Restart only after disconnect/retry.
+13. **Multi-peripheral:** first tolerant match currently wins; diagnostics include id/name/rssi for later tuning.
+14. **Identifier persistence:** not used in pass 1; no persistent identifier cache.
+15. **Delta on watch:** not computed from direct BLE yet; existing pipeline delta remains unchanged.
+16. **Winner policy:** latest-write with `minInterval:5` in store; source attribution preserved in snapshot.
+17. **UI palette:** keep 6-state palette as proposed for glanceability.
+18. **Active-name mid-session:** not applicable (no iPhone-bridged active-name in this pass).
+19. **Attach ladder cadence:** single fast sweep (retrieve→scan), then retry loop on failures.
+
+## Deviations
+- Omitted iPhone-side active peripheral name bridge.
+- Omitted extended runtime handling.
+- Backfill left as discover/log-only.
+
+## Risks / open questions for device test
+- Exact auth advance heuristic may need tightening/loosening by observed payload semantics.
+- Characteristic UUIDs and payload offsets require on-device validation against real traffic.
+- Multi-sensor environments may require stronger disambiguation.

--- a/docs/in-progress/watch-g7-direct-ble-observer/02-implementation-plan.md
+++ b/docs/in-progress/watch-g7-direct-ble-observer/02-implementation-plan.md
@@ -1,0 +1,33 @@
+# Implementation plan
+
+## New files
+- `Trio Watch App Extension/G7DirectBLE/G7DirectBLEManager.swift` — watch observer CoreBluetooth manager, protocol sequencing, reconnect, structured logging.
+- `Trio Watch Shared/TrioComplicationDataStore.swift` — shared snapshot/store with source attribution and direct-BLE status tracking.
+- `docs/in-progress/watch-g7-direct-ble-observer/01-design.md` — design decisions and DQ answers.
+- `docs/in-progress/watch-g7-direct-ble-observer/03-implementation-log.md` — implementation trace and handoff notes.
+
+## Existing files to modify
+- `Trio Watch App Extension/TrioWatchApp.swift` — scene phase start/resume hooks for BLE observer.
+- `Trio Watch App Extension/WatchState.swift` — direct-BLE snapshot application + source/status fields for UI.
+- `Trio Watch App Extension/Views/TrioMainWatchView.swift` — glanceable BLE/source indicator in main view.
+- `Trio/Sources/Models/WatchMessageKeys.swift` — additive `readingSource` key.
+- `Trio/Sources/Services/WatchManager/AppleWatchManager.swift` — populate reading source as `watchConnectivity`.
+
+## Phases
+1. **Scaffold shared data model/store**: snapshot/source/status types + persistence/reload methods.
+2. **Build BLE manager skeleton**: central manager lifecycle, scene hooks, restoration, logging helper.
+3. **Attach strategy**: retrieve-connected fast path, scan fallback, tolerant matching, connect source attribution.
+4. **Discovery/protocol sequence**: discover service/chars, auth notify observe-only, control notify, EGV request writes.
+5. **Parse/store handoff**: EGV parse -> snapshot -> store save + notification broadcast.
+6. **UI integration**: watch state receives direct BLE snapshots and shows source/status/last-event recency in main view.
+7. **Reconnect hardening**: connect timeout + bounded retry backoff + blocked state events.
+8. **Documentation pass**: design/plan/log finalize, explicit constraints and open risks.
+
+## Dependencies and sequencing rationale
+- Store and source model first to avoid ad hoc state threading later.
+- BLE manager before UI to ensure indicator surfaces real state transitions.
+- UI changes after handoff path to keep display model grounded in emitted snapshots.
+
+## Planned tests/checks (non-Xcode)
+- Static review of changed files for observer-only auth posture (no auth writes/J-PAKE writes).
+- Command-line checks: `git diff`, `git status`, targeted grep for forbidden auth-write patterns.

--- a/docs/in-progress/watch-g7-direct-ble-observer/03-implementation-log.md
+++ b/docs/in-progress/watch-g7-direct-ble-observer/03-implementation-log.md
@@ -1,0 +1,58 @@
+# Implementation log
+
+## Branch/base
+- Branch: `feature/watch-g7-direct-ble-observer-a`
+- Base commit at branch cut: `1aa70ac0`
+
+## Phase entries
+
+### Phase 1 — Shared snapshot/store scaffold
+**Done:** Added `TrioComplicationSnapshot`, source enum, BLE status enum, and `TrioComplicationDataStore` with latest snapshot persistence, reload trigger, and direct-BLE status/event helpers.
+**Files:**
+- `Trio Watch Shared/TrioComplicationDataStore.swift`
+
+### Phase 2 — BLE manager lifecycle + attach
+**Done:** Added clean-room `G7DirectBLEManager` with eager restoration-backed central, `.active` startup, retrieve-connected first attach, scan fallback, connect source attribution, and structured `g7_ble_*` logs.
+**Files:**
+- `Trio Watch App Extension/G7DirectBLE/G7DirectBLEManager.swift`
+
+### Phase 3 — Protocol sequence + observer safety
+**Done:** Implemented broad discovery, auth notify observe-only gate, explicit J-PAKE skip logging, control notify enable, active EGV request writes (`0x4E`), EGV parse, snapshot save, and reconnect handling.
+**Files:**
+- `Trio Watch App Extension/G7DirectBLE/G7DirectBLEManager.swift`
+
+### Phase 4 — Watch app integration
+**Done:** Scene-phase hooks call BLE manager active/inactive transitions. `WatchState` now consumes direct-BLE snapshot notifications and tracks source/status/last BLE event for UI.
+**Files:**
+- `Trio Watch App Extension/TrioWatchApp.swift`
+- `Trio Watch App Extension/WatchState.swift`
+
+### Phase 5 — Main view status indicator
+**Done:** Added glanceable line to main watch view: current source + BLE status + last direct BLE event age.
+**Files:**
+- `Trio Watch App Extension/Views/TrioMainWatchView.swift`
+
+### Phase 6 — Phone relay additive source attribution
+**Done:** Added `readingSource` message key and populate as `watchConnectivity` in iPhone watch payload.
+**Files:**
+- `Trio/Sources/Models/WatchMessageKeys.swift`
+- `Trio/Sources/Services/WatchManager/AppleWatchManager.swift`
+
+## Plan deviations
+- The archive path from prompt was not present in container, so implementation proceeded from prompt constraints and Trio integration points without importing external reference files.
+- Backfill behavior kept log-only in this pass.
+- No `WKExtendedRuntimeSession` in this pass.
+
+## Validation performed
+- Static review of all modified files for observer-only auth requirements.
+- Grep checks to ensure no auth-init/J-PAKE ownership write methods were introduced.
+- No Xcode build or project sync commands executed.
+
+## Final handoff state
+**Completed in this pass:** design doc, implementation plan, implementation log, clean-room source implementation, UI status/source indicator, structured logging, scene lifecycle integration.
+
+**Pending (human follow-up):**
+- Xcode target-membership wiring for new Swift files.
+- Project file update in Xcode workflow.
+- Device validation with real Dexcom G7 direct-to-watch session.
+- Optional enhancements: tighter auth readiness predicate, backfill utilization, multi-peripheral disambiguation tuning.


### PR DESCRIPTION
### Motivation
- Provide a watch‑only, observer/eavesdrop path for Dexcom G7 direct‑to‑watch sessions so the Trio Watch App Extension can receive live EGVs and push them into the existing complication pipeline for faster updates.
- Implement the feature as a clean‑room, production‑conscious scaffold (no J‑PAKE/auth ownership, no project file edits) so a human can wire targets and validate on-device in a follow‑up step.

### Description
- Add `G7DirectBLEManager` (`Trio Watch App Extension/G7DirectBLE/G7DirectBLEManager.swift`) implementing an eager, restoration‑backed `CBCentralManager`, `retrieveConnectedPeripherals` → scan attach ladder, broad service/characteristic discovery, observe‑only auth notify, control notify + EGV request writes (`0x4E`), periodic resend timer, reconnect/backoff, and structured `event=g7_ble_*` logs.
- Add shared complication types and store (`Trio Watch Shared/TrioComplicationDataStore.swift`) introducing `TrioComplicationSnapshot`, `TrioReadingSource`, `G7DirectBLEStatus`, snapshot persistence, direct‑BLE status and last‑event helpers, and `WidgetCenter` reload integration.
- Wire watch integration: start/stop hooks in `TrioWatchApp` (scene phase → `G7DirectBLEManager`), `WatchState` observers to apply direct‑BLE snapshots and surface `displayedReadingSource` / `directBLEStatus` / `lastDirectBLEEventAt`, and a compact inline indicator in the main view (`TrioMainWatchView`) showing source, BLE status, and last direct‑BLE event recency.
- Add phone→watch additive support for reading source via `WatchMessageKeys.readingSource` and populate it as `"watchConnectivity"` from the phone path (`AppleWatchManager.watchStateToDictionary`).
- Documentation added under `docs/in-progress/watch-g7-direct-ble-observer/`: `01-design.md`, `02-implementation-plan.md`, and `03-implementation-log.md` describing design decisions, DQ answers, implementation phases, and handoff notes.
- Safety / workflow notes: no edits to `Trio.xcodeproj/project.pbxproj` were made and `scripts/sync_project_files.rb`, `xcodebuild`, and `ci/local-build.sh` were not run in this pass.

### Testing
- Performed static review of modified files and code paths to confirm the observer is read‑only for auth traffic and that no auth‑init / J‑PAKE ownership writes were introduced, and that checks passed.
- Ran targeted grep for forbidden patterns (`sendAuthRequest|jpake|JPAKE|auth_request_sent|auth init|0x03`) against the new BLE manager and verified no auth‑ownership writes appear.
- Confirmed repository status (`git status` / `git diff --stat`) to verify the intended set of files were created/modified; these checks succeeded and no build/test runs were executed as required by workflow constraints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eb78de8b04832496862079fb16fda2)