### PR TITLE
Add G7 direct BLE observer, complication snapshot store, and UI status wiring

### DIFF
--- a/Trio Watch App Extension/G7DirectBLEObserver.swift
+++ b/Trio Watch App Extension/G7DirectBLEObserver.swift
@@ -1,0 +1,365 @@
+import CoreBluetooth
+import Foundation
+
+@MainActor
+final class G7DirectBLEObserver: NSObject {
+    static let shared = G7DirectBLEObserver()
+
+    enum Status: String {
+        case off
+        case searching
+        case connecting
+        case active
+        case stalled
+        case unavailable
+    }
+
+    private enum Constants {
+        // G7 service/characteristic UUIDs based on G7SensorKit BluetoothServices + DiaBLE DexcomG7 references.
+        static let dataService = CBUUID(string: "F8083532-849E-531C-C594-30F1F86A4EA5")
+        static let authenticationCharacteristic = CBUUID(string: "F8083533-849E-531C-C594-30F1F86A4EA5")
+        static let controlCharacteristic = CBUUID(string: "F8083534-849E-531C-C594-30F1F86A4EA5")
+        static let backfillCharacteristic = CBUUID(string: "F8083535-849E-531C-C594-30F1F86A4EA5")
+        static let jpakeCharacteristic = CBUUID(string: "F8083536-849E-531C-C594-30F1F86A4EA5")
+
+        // EGV request opcode from G7SensorKit Messages/G7Opcode.swift.
+        static let egvRequestOpcode: UInt8 = 0x4E
+        static let scanWindow: TimeInterval = 12
+        static let reconnectDelay: TimeInterval = 4
+    }
+
+    private(set) var status: Status = .off
+    private(set) var lastDirectBLEEventAt: Date?
+
+    private var central: CBCentralManager?
+    private var peripheral: CBPeripheral?
+    private var authCharacteristic: CBCharacteristic?
+    private var controlCharacteristic: CBCharacteristic?
+    private var connectSource: String = "unknown"
+    private var scanTimeoutTask: Task<Void, Never>?
+    private var reconnectTask: Task<Void, Never>?
+
+    private var didObserveAuthTraffic = false
+    private var didPersistEGV = false
+
+    var onStatusChange: ((Status, Date?) -> Void)?
+    var onSnapshot: ((TrioComplicationSnapshot) -> Void)?
+
+    private override init() {
+        super.init()
+        central = CBCentralManager(delegate: self, queue: nil, options: [
+            CBCentralManagerOptionRestoreIdentifierKey: "com.trio.watch.g7observer"
+        ])
+    }
+
+    func start() {
+        if central == nil {
+            central = CBCentralManager(delegate: self, queue: nil, options: [
+                CBCentralManagerOptionRestoreIdentifierKey: "com.trio.watch.g7observer"
+            ])
+        }
+
+        log("event=g7_ble_lifecycle action=start")
+        driveStartIfReady()
+    }
+
+    func stop(reason: String = "manual") {
+        scanTimeoutTask?.cancel()
+        reconnectTask?.cancel()
+        scanTimeoutTask = nil
+        reconnectTask = nil
+
+        if let peripheral {
+            central?.cancelPeripheralConnection(peripheral)
+        }
+
+        peripheral = nil
+        authCharacteristic = nil
+        controlCharacteristic = nil
+        setStatus(.off)
+        log("event=g7_ble_lifecycle action=stop reason=\(reason)")
+    }
+
+    private func driveStartIfReady() {
+        guard let central else { return }
+        guard central.state == .poweredOn else {
+            setStatus(.unavailable)
+            log("event=g7_ble_blocked_central_not_ready state=\(central.state.rawValue)")
+            return
+        }
+
+        setStatus(.searching)
+        attemptRetrieveThenScan()
+    }
+
+    private func attemptRetrieveThenScan() {
+        guard let central else { return }
+
+        let connected = central.retrieveConnectedPeripherals(withServices: [Constants.dataService])
+        if let candidate = connected.first {
+            connect(to: candidate, source: "retrieved_data_service")
+            return
+        }
+
+        log("event=g7_ble_scan_start reason=no_retrieved_match")
+        central.scanForPeripherals(withServices: nil, options: [CBCentralManagerScanOptionAllowDuplicatesKey: true])
+
+        scanTimeoutTask?.cancel()
+        scanTimeoutTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(Constants.scanWindow * 1_000_000_000))
+            guard let self else { return }
+            self.central?.stopScan()
+            self.log("event=g7_ble_scan_stopped reason=timeout")
+            self.scheduleReconnect(reason: "scan_timeout")
+        }
+    }
+
+    private func connect(to candidate: CBPeripheral, source: String) {
+        guard let central else { return }
+        connectSource = source
+        peripheral = candidate
+        candidate.delegate = self
+        setStatus(.connecting)
+        log("event=g7_ble_connect_attempt source=\(source) identifier=\(candidate.identifier.uuidString) name=\(candidate.name ?? "nil")")
+        central.stopScan()
+        central.connect(candidate, options: [CBConnectPeripheralOptionNotifyOnDisconnectionKey: true])
+    }
+
+    private func scheduleReconnect(reason: String) {
+        reconnectTask?.cancel()
+        setStatus(.stalled)
+        reconnectTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            self.log("event=g7_ble_reconnect_scheduled reason=\(reason) delay_s=\(Constants.reconnectDelay)")
+            try? await Task.sleep(nanoseconds: UInt64(Constants.reconnectDelay * 1_000_000_000))
+            guard self.status != .off else { return }
+            self.attemptRetrieveThenScan()
+        }
+    }
+
+    private func setStatus(_ newStatus: Status) {
+        status = newStatus
+        onStatusChange?(status, lastDirectBLEEventAt)
+    }
+
+    private func markDirectBLEEvent() {
+        lastDirectBLEEventAt = Date()
+        onStatusChange?(status, lastDirectBLEEventAt)
+    }
+
+    private func requestEGV() {
+        guard let peripheral, let controlCharacteristic else {
+            log("event=g7_ble_blocked_control_not_ready")
+            return
+        }
+        let payload = Data([Constants.egvRequestOpcode])
+        peripheral.writeValue(payload, for: controlCharacteristic, type: .withResponse)
+        log("event=g7_ble_egv_request_sent bytes=\(payload.hexString)")
+    }
+
+    private func parseEGV(_ data: Data) -> TrioComplicationSnapshot? {
+        // Lightweight parse aligned with G7SensorKit G7GlucoseMessage structure.
+        guard data.count >= 4 else { return nil }
+
+        let messageType = data[0]
+        guard messageType == 0x4E || messageType == 0x4F else { return nil }
+
+        let glucoseValue = Int(data[2]) | (Int(data[3]) << 8)
+        guard glucoseValue > 20, glucoseValue < 500 else { return nil }
+
+        let trendCode = data.count > 4 ? Int8(bitPattern: data[4]) : 0
+        let trend = trendCodeToArrow(trendCode)
+
+        let now = Date()
+        return TrioComplicationSnapshot(
+            glucose: String(glucoseValue),
+            trend: trend,
+            delta: nil,
+            readingDate: now,
+            date: now,
+            source: .directBLE
+        )
+    }
+
+    private func trendCodeToArrow(_ rate: Int8) -> String {
+        switch rate {
+        case let x where x >= 3: return "DoubleUp"
+        case 2: return "SingleUp"
+        case 1: return "FortyFiveUp"
+        case 0: return "Flat"
+        case -1: return "FortyFiveDown"
+        case -2: return "SingleDown"
+        default: return "DoubleDown"
+        }
+    }
+
+    private func log(_ message: String, function: String = #function, file: String = #fileID, line: Int = #line) {
+        Task {
+            await WatchLogger.shared.log(message, function: function, file: file, line: line)
+        }
+    }
+}
+
+extension G7DirectBLEObserver: CBCentralManagerDelegate {
+    func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        log("event=g7_ble_lifecycle action=central_state state=\(central.state.rawValue)")
+        if central.state == .poweredOn {
+            driveStartIfReady()
+        } else {
+            setStatus(.unavailable)
+        }
+    }
+
+    func centralManager(_ central: CBCentralManager, willRestoreState dict: [String: Any]) {
+        let restored = (dict[CBCentralManagerRestoredStatePeripheralsKey] as? [CBPeripheral]) ?? []
+        log("event=g7_ble_lifecycle action=will_restore peripherals=\(restored.count)")
+        if let restoredPeripheral = restored.first {
+            connect(to: restoredPeripheral, source: "restored")
+        }
+    }
+
+    func centralManager(
+        _: CBCentralManager,
+        didDiscover peripheral: CBPeripheral,
+        advertisementData: [String: Any],
+        rssi RSSI: NSNumber
+    ) {
+        let localName = advertisementData[CBAdvertisementDataLocalNameKey] as? String
+        let name = peripheral.name ?? localName ?? ""
+        let isMatch = name.uppercased().contains("DXCM") || name.uppercased().contains("DEXCOM")
+
+        log("event=g7_ble_peripheral_discovered name=\(name) id=\(peripheral.identifier.uuidString) rssi=\(RSSI) adv=\(advertisementData)")
+
+        guard isMatch else {
+            log("event=g7_ble_peripheral_skipped reason=name_mismatch name=\(name)")
+            return
+        }
+
+        connect(to: peripheral, source: "scan")
+    }
+
+    func centralManager(_: CBCentralManager, didConnect peripheral: CBPeripheral) {
+        didObserveAuthTraffic = false
+        didPersistEGV = false
+        setStatus(.active)
+        log("event=g7_ble_did_connect source=\(connectSource) id=\(peripheral.identifier.uuidString)")
+        peripheral.discoverServices(nil)
+    }
+
+    func centralManager(_: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {
+        let nsError = error as NSError?
+        log("event=g7_ble_connect_failed source=\(connectSource) id=\(peripheral.identifier.uuidString) error_domain=\(nsError?.domain ?? "none") error_code=\(nsError?.code ?? -1) error_desc=\(nsError?.localizedDescription ?? "nil")")
+        scheduleReconnect(reason: "connect_failed")
+    }
+
+    func centralManager(_: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
+        let nsError = error as NSError?
+        log("event=g7_ble_session_outcome outcome=\(didPersistEGV ? "success" : "incomplete") final_stage=disconnect source=\(connectSource) error_domain=\(nsError?.domain ?? "none") error_code=\(nsError?.code ?? -1)")
+        scheduleReconnect(reason: "disconnected")
+    }
+}
+
+extension G7DirectBLEObserver: CBPeripheralDelegate {
+    func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
+        if let error {
+            log("event=g7_ble_services_discovered result=failure error=\(error.localizedDescription)")
+            scheduleReconnect(reason: "service_discovery_error")
+            return
+        }
+
+        log("event=g7_ble_services_discovered result=success services=\(peripheral.services?.map { $0.uuid.uuidString }.joined(separator: ",") ?? "none")")
+        peripheral.services?.forEach { peripheral.discoverCharacteristics(nil, for: $0) }
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
+        if let error {
+            log("event=g7_ble_characteristics_discovered result=failure service=\(service.uuid.uuidString) error=\(error.localizedDescription)")
+            return
+        }
+
+        let uuids = service.characteristics?.map { $0.uuid.uuidString }.joined(separator: ",") ?? "none"
+        log("event=g7_ble_characteristics_discovered result=success service=\(service.uuid.uuidString) chars=\(uuids)")
+
+        service.characteristics?.forEach { characteristic in
+            switch characteristic.uuid {
+            case Constants.authenticationCharacteristic:
+                authCharacteristic = characteristic
+                peripheral.setNotifyValue(true, for: characteristic)
+                log("event=g7_ble_auth_notify_enabled")
+            case Constants.controlCharacteristic:
+                controlCharacteristic = characteristic
+                peripheral.setNotifyValue(true, for: characteristic)
+                log("event=g7_ble_control_notify_enabled")
+            case Constants.jpakeCharacteristic:
+                log("event=g7_ble_jpake_skipped uuid=\(characteristic.uuid.uuidString)")
+            case Constants.backfillCharacteristic:
+                log("event=g7_ble_backfill_skipped uuid=\(characteristic.uuid.uuidString)")
+            default:
+                break
+            }
+        }
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didUpdateNotificationStateFor characteristic: CBCharacteristic, error: Error?) {
+        if let error {
+            log("event=g7_ble_notify_state_updated result=failure uuid=\(characteristic.uuid.uuidString) error=\(error.localizedDescription)")
+            return
+        }
+
+        log("event=g7_ble_notify_state_updated result=success uuid=\(characteristic.uuid.uuidString) enabled=\(characteristic.isNotifying)")
+
+        if characteristic.uuid == Constants.controlCharacteristic, characteristic.isNotifying {
+            requestEGV()
+        }
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
+        if let error {
+            log("event=g7_ble_value_update result=failure uuid=\(characteristic.uuid.uuidString) error=\(error.localizedDescription)")
+            return
+        }
+
+        guard let data = characteristic.value else {
+            log("event=g7_ble_value_update result=empty uuid=\(characteristic.uuid.uuidString)")
+            return
+        }
+
+        if characteristic.uuid == Constants.authenticationCharacteristic {
+            didObserveAuthTraffic = true
+            log("event=g7_ble_auth_payload_received bytes=\(data.hexString)")
+            if controlCharacteristic != nil {
+                requestEGV()
+            }
+            return
+        }
+
+        if characteristic.uuid == Constants.controlCharacteristic {
+            log("event=g7_ble_control_payload_received bytes=\(data.hexString)")
+            if let snapshot = parseEGV(data) {
+                didPersistEGV = true
+                markDirectBLEEvent()
+                onSnapshot?(snapshot)
+                log("event=g7_ble_egv_received glucose=\(snapshot.glucose) trend=\(snapshot.trend ?? "none")")
+            }
+            return
+        }
+
+        log("event=g7_ble_value_update uuid=\(characteristic.uuid.uuidString) bytes=\(data.hexString)")
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?) {
+        if let error {
+            log("event=g7_ble_control_write_failed uuid=\(characteristic.uuid.uuidString) error=\(error.localizedDescription)")
+            scheduleReconnect(reason: "control_write_failure")
+            return
+        }
+
+        log("event=g7_ble_control_write_ack uuid=\(characteristic.uuid.uuidString)")
+    }
+}
+
+private extension Data {
+    var hexString: String {
+        map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Trio Watch App Extension/TrioWatchApp.swift
+++ b/Trio Watch App Extension/TrioWatchApp.swift
@@ -11,9 +11,20 @@ import UserNotifications
     var body: some Scene {
         WindowGroup {
             TrioMainWatchView()
+                .task {
+                    if scenePhase == .active {
+                        G7DirectBLEObserver.shared.start()
+                    }
+                }
         }
         .onChange(of: scenePhase) { _, newScenePhase in
-            if newScenePhase == .background {
+            Task {
+                await WatchLogger.shared.log("event=g7_ble_lifecycle scene_phase=\(String(describing: newScenePhase))")
+            }
+
+            if newScenePhase == .active {
+                G7DirectBLEObserver.shared.start()
+            } else if newScenePhase == .background {
                 Task {
                     await WatchLogger.shared.flushPersistedLogs()
                 }

--- a/Trio Watch App Extension/Views/GlucoseTrendView.swift
+++ b/Trio Watch App Extension/Views/GlucoseTrendView.swift
@@ -148,17 +148,37 @@ struct GlucoseTrendView: View {
 
             Spacer()
 
-            Text(
-                isWatchStateDated ?
-                    String(localized: "STALE DATA", comment: "Information displayed when watch app data outdated or stale.") :
-                    state
-                    .lastLoopTime ?? "--"
-            )
+            Text(statusLineText)
             .font(.system(size: minutesAgoFontSize))
             .fontWidth(isWatchStateDated ? .expanded : .standard)
 
             Spacer()
 
         }.frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var statusLineText: String {
+        if isWatchStateDated {
+            return String(localized: "STALE DATA", comment: "Information displayed when watch app data outdated or stale.")
+        }
+
+        let recency = state.lastLoopTime ?? "--"
+        let source: String
+        switch state.currentReadingSource {
+        case .directBLE: source = "BLE"
+        case .phoneRelay: source = "Phone"
+        case .healthKit: source = "HK"
+        case .unknown: source = "?"
+        }
+
+        let bleRecency: String
+        if let lastBLE = state.lastDirectBLEEventAt {
+            let mins = max(0, Int(Date().timeIntervalSince(lastBLE) / 60))
+            bleRecency = "\(mins)m"
+        } else {
+            bleRecency = "--"
+        }
+
+        return "\(recency) · \(source) · BLE:\(state.directBLEStatus.rawValue) \(bleRecency)"
     }
 }

--- a/Trio Watch App Extension/WatchState.swift
+++ b/Trio Watch App Extension/WatchState.swift
@@ -19,6 +19,10 @@ import WatchConnectivity
     var currentGlucoseColorString: String = "#ffffff"
     var trend: String? = ""
     var delta: String? = "--"
+    var readingDate: Date?
+    var currentReadingSource: TrioReadingSource = .unknown
+    var directBLEStatus: G7DirectBLEObserver.Status = .off
+    var lastDirectBLEEventAt: Date?
     var glucoseValues: [(date: Date, glucose: Double, color: Color)] = []
     var minYAxisValue: Decimal = 39
     var maxYAxisValue: Decimal = 200
@@ -78,6 +82,7 @@ import WatchConnectivity
     override init() {
         super.init()
         setupSession()
+        setupDirectBLEObserver()
     }
 
     /// Configures the WatchConnectivity session if supported on the device
@@ -94,6 +99,20 @@ import WatchConnectivity
             Task {
                 await WatchLogger.shared.log("⌚️ WCSession is not supported on this device")
             }
+        }
+    }
+
+    private func setupDirectBLEObserver() {
+        G7DirectBLEObserver.shared.onStatusChange = { [weak self] status, lastEventAt in
+            guard let self else { return }
+            self.directBLEStatus = status
+            self.lastDirectBLEEventAt = lastEventAt
+        }
+
+        G7DirectBLEObserver.shared.onSnapshot = { [weak self] snapshot in
+            guard let self else { return }
+            TrioComplicationDataStore.shared.save(snapshot, triggerReload: true, minInterval: 5)
+            self.applyComplicationSnapshot(snapshot)
         }
     }
 
@@ -479,6 +498,16 @@ import WatchConnectivity
             self.delta = delta
         }
 
+        if let readingDate = message[WatchMessageKeys.readingDate] as? TimeInterval {
+            self.readingDate = Date(timeIntervalSince1970: readingDate)
+        }
+
+        if let readingSourceRaw = message[WatchMessageKeys.readingSource] as? String,
+           let readingSource = TrioReadingSource(rawValue: readingSourceRaw)
+        {
+            self.currentReadingSource = readingSource
+        }
+
         if let iob = message[WatchMessageKeys.iob] as? String {
             self.iob = iob
         }
@@ -573,5 +602,15 @@ import WatchConnectivity
                 self.confirmBolusFaster = booleanValue
             }
         }
+    }
+
+    private func applyComplicationSnapshot(_ snapshot: TrioComplicationSnapshot) {
+        currentGlucose = snapshot.glucose
+        trend = snapshot.trend
+        delta = snapshot.delta ?? delta
+        readingDate = snapshot.readingDate
+        currentReadingSource = snapshot.source
+        lastWatchStateUpdate = snapshot.date.timeIntervalSince1970
+        lastDirectBLEEventAt = snapshot.date
     }
 }

--- a/Trio Watch Shared/TrioComplicationDataStore.swift
+++ b/Trio Watch Shared/TrioComplicationDataStore.swift
@@ -1,0 +1,46 @@
+import Foundation
+import WidgetKit
+
+public final class TrioComplicationDataStore {
+    public static let shared = TrioComplicationDataStore()
+    public static let complicationKind = "TrioWatchComplication"
+
+    private let defaults: UserDefaults?
+    private let snapshotKey = "trio.complication.snapshot.v1"
+    private let lastWriteKey = "trio.complication.last.write.v1"
+
+    public var appGroupID: String? { "group.com.trio.watch" }
+
+    private init() {
+        if let appGroupID {
+            defaults = UserDefaults(suiteName: appGroupID)
+        } else {
+            defaults = UserDefaults.standard
+        }
+    }
+
+    @MainActor
+    public func save(_ snapshot: TrioComplicationSnapshot, triggerReload: Bool = true, minInterval: TimeInterval = 5) {
+        let now = Date()
+        let lastWrite = defaults?.object(forKey: lastWriteKey) as? Date
+        if let lastWrite, now.timeIntervalSince(lastWrite) < minInterval {
+            return
+        }
+
+        do {
+            let data = try JSONEncoder().encode(snapshot)
+            defaults?.set(data, forKey: snapshotKey)
+            defaults?.set(now, forKey: lastWriteKey)
+            if triggerReload {
+                WidgetCenter.shared.reloadTimelines(ofKind: Self.complicationKind)
+            }
+        } catch {
+            print("Failed to save TrioComplicationSnapshot: \(error)")
+        }
+    }
+
+    public func latestSnapshot() -> TrioComplicationSnapshot? {
+        guard let data = defaults?.data(forKey: snapshotKey) else { return nil }
+        return try? JSONDecoder().decode(TrioComplicationSnapshot.self, from: data)
+    }
+}

--- a/Trio Watch Shared/TrioComplicationSnapshot.swift
+++ b/Trio Watch Shared/TrioComplicationSnapshot.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public enum TrioReadingSource: String, Codable, Sendable {
+    case directBLE = "direct_ble"
+    case phoneRelay = "phone_relay"
+    case healthKit = "healthkit"
+    case unknown = "unknown"
+}
+
+public struct TrioComplicationSnapshot: Codable, Sendable {
+    public let glucose: String
+    public let trend: String?
+    public let delta: String?
+    public let readingDate: Date
+    public let date: Date
+    public let source: TrioReadingSource
+}

--- a/Trio/Sources/Models/WatchMessageKeys.swift
+++ b/Trio/Sources/Models/WatchMessageKeys.swift
@@ -35,6 +35,8 @@ enum WatchMessageKeys {
     static let currentGlucoseColorString = "currentGlucoseColorString"
     static let trend = "trend"
     static let delta = "delta"
+    static let readingDate = "readingDate"
+    static let readingSource = "readingSource"
     static let iob = "iob"
     static let cob = "cob"
     static let lastLoopTime = "lastLoopTime"

--- a/Trio/Sources/Services/WatchManager/AppleWatchManager.swift
+++ b/Trio/Sources/Services/WatchManager/AppleWatchManager.swift
@@ -439,6 +439,8 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
             WatchMessageKeys.currentGlucoseColorString: state.currentGlucoseColorString ?? "#ffffff",
             WatchMessageKeys.trend: state.trend ?? "",
             WatchMessageKeys.delta: state.delta ?? "",
+            WatchMessageKeys.readingDate: state.date.timeIntervalSince1970,
+            WatchMessageKeys.readingSource: "phone_relay",
             WatchMessageKeys.iob: state.iob ?? "",
             WatchMessageKeys.cob: state.cob ?? "",
             WatchMessageKeys.lastLoopTime: state.lastLoopTime ?? "",

--- a/docs/in-progress/watch-g7-direct-ble-observer/01-design.md
+++ b/docs/in-progress/watch-g7-direct-ble-observer/01-design.md
@@ -1,0 +1,117 @@
+# Trio Watch Dexcom G7 Direct BLE Observer — Design v1
+
+## Mission and premise
+
+Implement a watch-only observer path that attaches to the Dexcom G7 watch app's already-owned BLE session on the same watchOS device, requests EGV data over Trio's own GATT view, and writes snapshots into Trio's complication pipeline with explicit source attribution.
+
+This design assumes the Dexcom G7 watch app is installed and actively connected in direct-to-watch mode. Trio does not attempt to own auth or pair the sensor.
+
+## Protocol sequence
+
+1. Create long-lived `CBCentralManager` with restoration identifier.
+2. On foreground `.active`, attempt attach ladder:
+   - `retrieveConnectedPeripherals(withServices: [dataService])`
+   - then scan fallback.
+3. On connect, discover services/characteristics broadly (`nil`) and find auth/control/backfill/jpake by UUID.
+4. Enable auth notify and control notify.
+5. Observe auth payloads only (no auth writes, no J-PAKE participation).
+6. Send EGV request opcode on control (`withResponse`) once control notify is active and again when auth notifications are observed.
+7. Parse control notifications into glucose/trend, build `TrioComplicationSnapshot`, save via `TrioComplicationDataStore.shared.save(..., minInterval: 5)`.
+8. On disconnect/failure, auto-retry with simple backoff.
+
+## Filtering choice
+
+Chosen: DiaBLE-style standalone tolerant matching (name/advertisement heuristic) with no iPhone bridge in this pass. Rationale: minimize dependencies and maximize attach probability when phone/watch builds are mismatched.
+
+## Attach strategy
+
+Chosen order:
+1. `retrieveConnectedPeripherals(withServices:)`
+2. broad scan (`withServices: nil`, duplicates allowed) with tolerant name matching.
+
+Rationale: retrieval is fastest when OS already has active G7 link; scan fallback recovers when retrieval misses.
+
+## Auth advance condition and EGV cadence
+
+Advance condition: control characteristic notify enabled. Auth notifications are observed and used as positive signal; they are not a hard block because some session states may not expose stable `authenticated && bonded` semantics to observer clients.
+
+Cadence:
+- send once when control notify is enabled,
+- send again on observed auth payload,
+- resend after reconnect cycles.
+
+This balances reliability and avoids tight polling loops.
+
+## Reconnect / lifecycle
+
+- Start on scene `.active`.
+- Do not proactively tear down on `.inactive`/`.background`.
+- Explicit `stop()` exists and stays separate from scene phase.
+- Backoff is fixed simple retry (4s) with scan window timeout (12s).
+
+`WKExtendedRuntimeSession` is omitted in this pass to keep scope focused on core attach/eavesdrop reliability.
+
+## UI indicator design
+
+Existing recency text is augmented to:
+`<recency> · <source> · BLE:<status> <last-ble-recency>`.
+
+- Source badges: `BLE`, `Phone`, `HK`, `?`.
+- BLE status uses palette values (`off/searching/connecting/active/stalled/unavailable`).
+- Last-direct-BLE-event recency remains visible even if current reading is from a different source.
+
+## Source attribution model
+
+`TrioComplicationSnapshot` carries `source: TrioReadingSource` (`direct_ble`, `phone_relay`, `healthkit`, `unknown`).
+
+Phone relay messages include `readingSource=phone_relay`; direct BLE writes `direct_ble`.
+
+## Observability plan
+
+Structured logs with `event=g7_ble_*`, including:
+- lifecycle/scene phase
+- scan start/stop
+- peripheral discovered/skipped with raw name, advertisement dictionary, RSSI, identifier
+- connect attempt with `source=` attribution
+- connect failure with NSError domain/code/description
+- services/characteristics discovery
+- notify enable states
+- auth/control payload hex previews
+- EGV request send / write ack / write failure
+- session outcome on disconnect
+
+No auth-init writes or J-PAKE ownership writes are emitted; J-PAKE is explicitly logged as skipped.
+
+## Open design questions — decisions
+
+1. **Filtering:** standalone tolerant matching. Reduces cross-device dependency and keeps attach path local.
+2. **Attach strategy:** retrieval then scan. Fast path first, robust fallback second.
+3. **Discovery breadth:** broad discovery (`nil`) for services/chars. Matches high-fidelity guidance and avoids missing variants.
+4. **Timeout/backoff:** scan timeout 12s, reconnect 4s. Aggressive but bounded.
+5. **Central queue:** `queue: nil` (main runloop callbacks). Simpler and aligned with UI/MainActor handoff needs.
+6. **Restoration:** yes; restore peripherals and reconnect.
+7. **connect options:** enable `NotifyOnDisconnection`.
+8. **Auth advance:** control notify readiness + observed auth traffic when available; avoid strict bonded gate.
+9. **EGV cadence:** on control-ready + auth-traffic + reconnect.
+10. **Control write failure:** log + reconnect cycle.
+11. **Backfill:** discover + explicitly log skipped in this pass.
+12. **Stop scan after connect:** yes.
+13. **Multi-peripheral:** first matching candidate; log all discovered for diagnostics.
+14. **Identifier persistence:** not used in pass 1.
+15. **Delta on watch:** leave unset for direct BLE in pass 1.
+16. **Winner policy:** latest-write plus `minInterval: 5`; source attribution preserved for UI.
+17. **UI palette:** keep 6-state palette with compact inline text.
+18. **Active-name mid-session:** N/A (no iPhone-bridged filter in this pass).
+19. **Attach ladder cadence:** single sweep then retry loop on timeout/failure.
+
+## Deviations from references
+
+- Backfill parsing not enabled yet (only discovery + skip logging) to keep pass focused on repeated live EGV.
+- EGV parsing currently lightweight and intentionally conservative; full timestamp/activation math remains follow-up hardening.
+- No phone-bridged exact-name filter in pass 1.
+
+## Known risks / open test questions
+
+- UUID/opcode and payload field offsets must be device-validated against real watch session traffic.
+- Some watchOS sessions may require slightly different auth-observation gating before control writes are accepted.
+- Without target membership wiring/build, compilation-level issues remain for Xcode follow-up.

--- a/docs/in-progress/watch-g7-direct-ble-observer/02-implementation-plan.md
+++ b/docs/in-progress/watch-g7-direct-ble-observer/02-implementation-plan.md
@@ -1,0 +1,54 @@
+# Implementation Plan v1
+
+## New files
+
+1. `Trio Watch App Extension/G7DirectBLEObserver.swift`
+   - CoreBluetooth observer manager (attach, discovery, notify, request EGV, parse, reconnect, logs).
+2. `Trio Watch Shared/TrioComplicationSnapshot.swift`
+   - Shared snapshot schema and source attribution enum.
+3. `Trio Watch Shared/TrioComplicationDataStore.swift`
+   - Shared persistence/reload surface used by watch observer.
+
+## Existing files to modify
+
+1. `Trio Watch App Extension/WatchState.swift`
+   - Observer wiring and snapshot-to-UI application; source/status state.
+2. `Trio Watch App Extension/TrioWatchApp.swift`
+   - Scene-phase start trigger for observer lifecycle.
+3. `Trio Watch App Extension/Views/GlucoseTrendView.swift`
+   - Glanceable source + BLE status + last BLE event recency indicator.
+4. `Trio/Sources/Models/WatchMessageKeys.swift`
+   - Add source attribution keys (`readingDate`, `readingSource`).
+5. `Trio/Sources/Services/WatchManager/AppleWatchManager.swift`
+   - Send phone-relay source attribution fields in watch payload.
+
+## Phases
+
+1. **Scaffolding**
+   - Add shared snapshot/store schema.
+2. **Observer core**
+   - Add central allocation, retrieval+scan attach ladder, connect/discovery path.
+3. **Observer protocol path**
+   - Auth observe-only + control notify + EGV request + lightweight parse.
+4. **Persistence handoff**
+   - Save snapshot to complication store and publish callback to watch state.
+5. **UI status/source**
+   - Show source-of-reading and direct-BLE status/recency inline in main view.
+6. **Phone relay attribution**
+   - Mark legacy watch updates as `phone_relay`.
+7. **Docs and review**
+   - Write design/plan/log and static self-review.
+
+## Dependencies / sequencing rationale
+
+- Shared snapshot/store first to avoid temporary ad-hoc payload contracts.
+- Observer before UI so UI binds to concrete status/snapshot states.
+- Phone-side attribution added last and additive to avoid changing routing semantics.
+
+## Planned validation
+
+- Static review only (per constraints):
+  - Ensure no auth-init writes/J-PAKE ownership writes exist.
+  - Ensure `WatchState` and store interactions run on main actor paths.
+  - Ensure logs include `event=g7_ble_*` and connect source attribution.
+- No `xcodebuild`, no project sync.

--- a/docs/in-progress/watch-g7-direct-ble-observer/03-implementation-log.md
+++ b/docs/in-progress/watch-g7-direct-ble-observer/03-implementation-log.md
@@ -1,0 +1,62 @@
+# Implementation Log
+
+## Branch / base
+
+- Branch: `feature/watch-g7-direct-ble-observer-a`
+- Base commit: `1aa70ac077ef1492cddfce2bd39e0b2481f3d55c`
+
+## Phase entries
+
+### Phase 1 — scaffolding
+- Created `TrioComplicationSnapshot` and `TrioComplicationDataStore` under `Trio Watch Shared/`.
+- Added source attribution enum for downstream UI.
+
+### Phase 2 — observer core
+- Added `G7DirectBLEObserver` with:
+  - eager/restoration-backed central manager,
+  - retrieval + scan attach ladder,
+  - connect source tags,
+  - reconnect timers.
+
+### Phase 3 — protocol sequence
+- Implemented broad service/characteristic discovery.
+- Enabled auth/control notify.
+- Added observer-only auth handling and explicit J-PAKE skip logs.
+- Added control EGV request write (`withResponse`) and control payload parse path.
+
+### Phase 4 — watch state integration
+- Wired observer status and snapshots into `WatchState`.
+- Snapshot persistence path writes to `TrioComplicationDataStore`.
+
+### Phase 5 — UI indicator
+- Updated main glucose indicator line to include:
+  - source-of-reading marker,
+  - BLE observer status,
+  - last direct BLE event recency.
+
+### Phase 6 — additive phone relay attribution
+- Added `readingDate` + `readingSource` keys to watch payload schema.
+- Phone path now sets `readingSource=phone_relay`.
+
+## Plan deviations
+
+- Did not include optional WatchConnectivity active-name bridge.
+- Did not include backfill parsing in this pass (logged as skipped).
+- EGV parser is lightweight and intended for follow-up hardening after device captures.
+
+## Validation performed
+
+- Static review of modified files.
+- No build/test execution by design constraints.
+- Confirmed no Xcode project edits and no sync script invocation.
+
+## Final handoff state
+
+### Done
+- Docs set (`01-design.md`, `02-implementation-plan.md`, `03-implementation-log.md`).
+- Core watch observer implementation + UI/source attribution wiring.
+
+### Pending (human/device follow-up)
+- Xcode target membership wiring for new files.
+- Buildability/compile verification in Xcode.
+- On-device BLE validation and parser hardening with real payload traces.


### PR DESCRIPTION
### Motivation

- Provide a watch-only path to observe Dexcom G7 direct-to-watch BLE traffic, request EGVs, and publish those readings into the complication pipeline with explicit source attribution.
- Surface the observer status and last direct-BLE recency in the main watch UI so users can tell whether the displayed glucose came from BLE, phone relay, or HealthKit.

### Description

- Added `G7DirectBLEObserver` (`Trio Watch App Extension/G7DirectBLEObserver.swift`) which manages a restoration-backed `CBCentralManager`, attempts `retrieveConnectedPeripherals` then scanning, subscribes to auth/control notifications, sends an EGV request opcode, parses lightweight EGV payloads, and exposes `onStatusChange` and `onSnapshot` callbacks while logging `event=g7_ble_*` traces.
- Introduced shared snapshot types and persistence via `TrioComplicationSnapshot` and `TrioComplicationDataStore` under `Trio Watch Shared/` to encode/save snapshots and trigger complication reloads with a `minInterval` guard.
- Wired the observer into watch lifecycle and state by starting the observer on scene `.active` (`TrioWatchApp.swift`) and hooking callbacks into `WatchState` (`WatchState.swift`) to apply `TrioComplicationSnapshot` updates and expose `directBLEStatus`, `lastDirectBLEEventAt`, `currentReadingSource`, and `readingDate` to the UI.
- Updated UI in `GlucoseTrendView.swift` to display a compact status line with recency, source badge, BLE status, and BLE recency, and added phone-side attribution keys in `WatchMessageKeys.swift` and `AppleWatchManager.swift` to mark phone-relay messages as `readingSource=phone_relay`.
- Added design and implementation docs under `docs/in-progress/watch-g7-direct-ble-observer/` describing protocol, decisions, and implementation notes.

### Testing

- No automated build or unit tests were executed as part of this change (static review only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eb78de8b04832496862079fb16fda2)