### PR TITLE
Watch: G7 direct BLE observer (dev + patches 01–10, shared store)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,7 +15,7 @@
 	url = https://github.com/loopandlearn/OmniBLE.git
 [submodule "G7SensorKit"]
 	path = G7SensorKit
-	url = https://github.com/loopandlearn/G7SensorKit.git
+	url = https://github.com/cachrisman/G7SensorKit.git
 [submodule "OmniKit"]
 	path = OmniKit
 	url = https://github.com/loopandlearn/OmniKit.git

--- a/Trio Watch App Extension/ExtensionDelegate.swift
+++ b/Trio Watch App Extension/ExtensionDelegate.swift
@@ -1,0 +1,53 @@
+import WatchKit
+
+final class ExtensionDelegate: NSObject, WKApplicationDelegate {
+    func applicationDidFinishLaunching() {
+        // Only set in Watch App Extension; complication extension has no WatchLogger so forwarder stays nil.
+        TrioComplicationDataStore.setLogForwarder { msg in Task { await WatchLogger.shared.log(msg) } }
+        WatchState.shared.scheduleBackgroundLaunchDisarmIfNeeded()
+        Task {
+            await WatchLogger.shared.log(
+                "event=watch_extension_launched source=wk_application_delegate "
+                    + "method=applicationDidFinishLaunching",
+                force: false
+            )
+            // Emit App Group diagnostics early, before any snapshot reads/writes.
+            let diagnostics = TrioComplicationDataStore.shared.diagnosticsSummary(context: "applicationDidFinishLaunching")
+            await WatchLogger.shared.log(diagnostics, force: false)
+        }
+        WatchState.shared.scheduleBackgroundRefresh()
+    }
+
+    func applicationDidBecomeActive() {
+        WatchState.shared.handleForegroundActiveEntry()
+        Task {
+            await WatchLogger.shared.log(
+                "event=watch_app_became_active source=wk_application_delegate "
+                    + "method=applicationDidBecomeActive context=foreground",
+                force: false
+            )
+        }
+        // Note: forceComplicationUpdate() is now called in finalizePendingData() after fresh data arrives
+        // This prevents the race condition where stale data was saved before fresh data arrived
+    }
+
+    func applicationWillResignActive() {
+        WatchState.shared.handleForegroundInactiveOrBackground()
+        Task {
+            await WatchLogger.shared.log(
+                "event=watch_app_resigning_active source=wk_application_delegate "
+                    + "method=applicationWillResignActive",
+                force: false
+            )
+        }
+    }
+
+    func handle(_ backgroundTasks: Set<WKRefreshBackgroundTask>) {
+        Task {
+            await WatchLogger.shared.log(
+                "event=complication_bgtask_forwarding source=wk_application_delegate count=\(backgroundTasks.count)"
+            )
+        }
+        WatchState.shared.handleBackgroundTasks(backgroundTasks)
+    }
+}

--- a/Trio Watch App Extension/G7/G7AlgorithmState.swift
+++ b/Trio Watch App Extension/G7/G7AlgorithmState.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+// Mirrors G7SensorKit `AlgorithmState.swift` (G7SensorKit/AlgorithmState.swift) for parsing only.
+
+enum G7AlgorithmState: RawRepresentable, Equatable {
+    typealias RawValue = UInt8
+
+    enum State: UInt8 {
+        case stopped = 1
+        case warmup = 2
+        case excessNoise = 3
+        case firstOfTwoBGsNeeded = 4
+        case secondOfTwoBGsNeeded = 5
+        case ok = 6
+        case needsCalibration = 7
+        case calibrationError1 = 8
+        case calibrationError2 = 9
+        case calibrationLinearityFitFailure = 10
+        case sensorFailedDuetoCountsAberration = 11
+        case sensorFailedDuetoResidualAberration = 12
+        case outOfCalibrationDueToOutlier = 13
+        case outlierCalibrationRequest = 14
+        case sessionExpired = 15
+        case sessionFailedDueToUnrecoverableError = 16
+        case sessionFailedDueToTransmitterError = 17
+        case temporarySensorIssue = 18
+        case sensorFailedDueToProgressiveSensorDecline = 19
+        case sensorFailedDuetoHighCountsAberration = 20
+        case sensorFailedDuetoLowCountsAberration = 21
+        case sensorFailedDuetoRestart = 22
+        case expired = 24
+        case sensorFailed = 25
+        case sessionEnded = 26
+    }
+
+    case known(State)
+    case unknown(RawValue)
+
+    init(rawValue: RawValue) {
+        if let s = State(rawValue: rawValue) {
+            self = .known(s)
+        } else {
+            self = .unknown(rawValue)
+        }
+    }
+
+    var rawValue: RawValue {
+        switch self {
+        case .known(let s):
+            s.rawValue
+        case .unknown(let v):
+            v
+        }
+    }
+
+    var hasReliableGlucose: Bool {
+        guard case .known(.ok) = self else { return false }
+        return true
+    }
+}
+
+enum G7GlucoseLimits {
+    static let minimum: UInt16 = 40
+    static let maximum: UInt16 = 400
+}

--- a/Trio Watch App Extension/G7/G7AuthChallengeRxMessage.swift
+++ b/Trio Watch App Extension/G7/G7AuthChallengeRxMessage.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+// G7SensorKit `AuthChallengeRxMessage.swift` (G7SensorKit/Messages/AuthChallengeRxMessage.swift).
+
+struct G7AuthChallengeRxMessage: Equatable {
+    let isAuthenticated: Bool
+    let isBonded: Bool
+
+    init?(data: Data) {
+        guard data.count >= 3 else { return nil }
+        guard data[0] == G7Opcode.authChallengeRx.rawValue else { return nil }
+        isAuthenticated = data[1] == 0x01
+        isBonded = data[2] == 0x01
+    }
+}

--- a/Trio Watch App Extension/G7/G7BLEConstants.swift
+++ b/Trio Watch App Extension/G7/G7BLEConstants.swift
@@ -1,0 +1,32 @@
+import CoreBluetooth
+import Foundation
+
+// UUIDs match G7SensorKit `BluetoothServices.swift` (G7SensorKit/BluetoothServices.swift).
+
+enum G7BLEAdvertisement {
+    static let febc = CBUUID(string: "FEBC")
+}
+
+enum G7BLEService {
+    static let cgm = CBUUID(string: "F8083532-849E-531C-C594-30F1F86A4EA5")
+    static let serviceB = CBUUID(string: "F8084532-849E-531C-C594-30F1F86A4EA5")
+}
+
+enum G7BLECharacteristic {
+    static let communication = CBUUID(string: "F8083533-849E-531C-C594-30F1F86A4EA5")
+    static let control = CBUUID(string: "F8083534-849E-531C-C594-30F1F86A4EA5")
+    static let authentication = CBUUID(string: "F8083535-849E-531C-C594-30F1F86A4EA5")
+    static let backfill = CBUUID(string: "F8083536-849E-531C-C594-30F1F86A4EA5")
+    // Service B (J-PAKE path) — G7SensorKit `ServiceBCharacteristicUUID`
+    static let serviceB_E = CBUUID(string: "F8084533-849E-531C-C594-30F1F86A4EA5")
+    static let serviceB_F = CBUUID(string: "F8084534-849E-531C-C594-30F1F86A4EA5")
+}
+
+enum G7Opcode: UInt8 {
+    case authChallengeRx = 0x05
+    case glucoseTx = 0x4E
+    case backfillFinished = 0x59
+}
+
+/// Restoration identifier for same-device eavesdrop session (DiaBLE-style eager CBCentral; G7SensorKit also uses a stable ID).
+let kG7DirectBLERestoreIdentifier = "com.trio.watchapp.g7directble.observer"

--- a/Trio Watch App Extension/G7/G7BLELog.swift
+++ b/Trio Watch App Extension/G7/G7BLELog.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Structured logging for the G7 direct BLE observer. Forwards call-site context to `WatchLogger` so
+/// BetterStack shows the syntactic caller, not this helper. See `docs/in-progress/watch-g7-direct-ble-observer/01-design.md`.
+enum G7BLELog {
+    static func log(
+        _ message: String,
+        file: String = #fileID,
+        line: Int = #line,
+        function: String = #function
+    ) {
+        Task {
+            await WatchLogger.shared.log(
+                message,
+                function: function,
+                file: file,
+                line: line
+            )
+        }
+    }
+}

--- a/Trio Watch App Extension/G7/G7Data+G7Bytes.swift
+++ b/Trio Watch App Extension/G7/G7Data+G7Bytes.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+// Byte helpers following G7SensorKit `Common/Data.swift` patterns (G7SensorKit/Common/Data.swift).
+
+extension Data {
+    fileprivate func g7_toDefaultEndian<T: FixedWidthInteger>(_: T.Type) -> T {
+        withUnsafeBytes { raw in
+            guard raw.count >= MemoryLayout<T>.size, let base = raw.baseAddress else { return 0 }
+            return base.loadUnaligned(as: T.self)
+        }
+    }
+
+    func g7To<T: FixedWidthInteger>(_ type: T.Type) -> T {
+        T(littleEndian: g7_toDefaultEndian(T.self))
+    }
+
+    /// Four-byte little-endian value (e.g. message timestamp).
+    func g7ToUInt32() -> UInt32 {
+        g7To(UInt32.self)
+    }
+
+    func g7ToUInt16() -> UInt16 {
+        g7To(UInt16.self)
+    }
+}

--- a/Trio Watch App Extension/G7/G7DirectBLEManager.swift
+++ b/Trio Watch App Extension/G7/G7DirectBLEManager.swift
@@ -1,0 +1,507 @@
+import CoreBluetooth
+import Foundation
+
+/// Watch-only G7 eavesdrop observer. Dexcom G7 watch app owns the session; Trio attaches via same-device CoreBluetooth
+/// (G7SensorKit `G7BluetoothManager.swift`, DiaBLE `BluetoothDelegate.swift`).
+final class G7DirectBLEManager: NSObject {
+    static let shared = G7DirectBLEManager()
+
+    private let queue = DispatchQueue(label: "com.trio.g7directble", qos: .userInitiated)
+    private var central: CBCentralManager!
+    private weak var watchState: WatchState?
+
+    // BLE thread (queue) state
+    private var shouldRun = false
+    private var connectBackoff: TimeInterval = 0.5
+    private var sessionStart: Date?
+    private var receivedEGVThisSession = false
+    private var egvRequestTimer: DispatchSourceTimer?
+    private var authWatchdog: DispatchSourceTimer?
+    private var isScanning = false
+
+    private var targetPeripheral: CBPeripheral?
+    private var connectSourceTag = ""
+    private var authCharacteristic: CBCharacteristic?
+    private var controlCharacteristic: CBCharacteristic?
+    private var backfillCharacteristic: CBCharacteristic?
+    private var activationDate: Date?
+    private var authReady = false
+    private var controlNotifying = false
+    private var lastConnectAttempt: Date?
+    private let connectAttemptTimeout: TimeInterval = 25
+    private let authWatchdogTimeout: TimeInterval = 90
+
+    private let userDefaults = UserDefaults.standard
+    private let kLastPeripheralUUIDKey = "g7directble.lastPeripheralUUID"
+
+    private override init() {
+        super.init()
+        queue.sync { [self] in
+            self.central = CBCentralManager(
+                delegate: self,
+                queue: self.queue,
+                options: [
+                    CBCentralManagerOptionShowPowerAlertKey: true,
+                    CBCentralManagerOptionRestoreIdentifierKey: kG7DirectBLERestoreIdentifier
+                ]
+            )
+        }
+    }
+
+    func bind(watchState: WatchState) {
+        self.watchState = watchState
+    }
+
+    /// Call from `MainActor` / SwiftUI when the watch scene is active.
+    func start() {
+        queue.async { [self] in
+            self.shouldRun = true
+            self.sessionStart = Date()
+            self.receivedEGVThisSession = false
+            self.connectBackoff = 0.5
+            G7BLELog.log("event=g7_ble_lifecycle phase=start shouldRun=true")
+            self.performWorkAfterAttach(reason: "scene_active")
+        }
+    }
+
+    /// Hard off (tests / product), not from `ScenePhase` baseline.
+    func stop() {
+        queue.async { [self] in
+            if self.receivedEGVThisSession {
+                if let s = self.sessionStart {
+                    let duration = Int(Date().timeIntervalSince(s) * 1000)
+                    G7BLELog.log("event=g7_ble_session_outcome outcome=success final_stage=egv duration_ms=\(duration) g7_session=watch_observer")
+                }
+            } else {
+                if let s = self.sessionStart {
+                    let duration = Int(Date().timeIntervalSince(s) * 1000)
+                    G7BLELog.log("event=g7_ble_session_outcome outcome=incomplete final_stage=stop duration_ms=\(duration) g7_session=watch_observer")
+                }
+            }
+            self.shouldRun = false
+            self.cancelTimers()
+            self.central?.stopScan()
+            self.isScanning = false
+            if let p = self.targetPeripheral { self.central?.cancelPeripheralConnection(p) }
+        }
+        G7BLELog.log("event=g7_ble_lifecycle phase=stop")
+        Task { @MainActor in
+            self.watchState?.g7DirectBLEStatus = .off
+            self.watchState?.g7DirectBLEStatusLabel = "off"
+        }
+    }
+
+    // MARK: - Work loop
+
+    private func performWorkAfterAttach(reason: String) {
+        dispatchPrecondition(condition: .onQueue(queue))
+        guard shouldRun, let c = central else { return }
+        if c.state != .poweredOn {
+            G7BLELog.log("event=g7_ble_blocked_unavailable reason=cb_state_\(c.state.rawValue) detail=\(reason)")
+            return
+        }
+
+        if let p = targetPeripheral, p.state == .connecting, let start = lastConnectAttempt,
+           Date().timeIntervalSince(start) > connectAttemptTimeout
+        {
+            G7BLELog.log("event=g7_ble_connect_failed source=\(connectSourceTag) error_desc=connect_attempt_timeout_s=\(Int(connectAttemptTimeout))")
+            c.cancelPeripheralConnection(p)
+        }
+
+        if let p = targetPeripheral, p.state == .connected { return }
+        if let p = targetPeripheral, p.state == .connecting { return }
+
+        if let idStr = userDefaults.string(forKey: kLastPeripheralUUIDKey), let u = UUID(uuidString: idStr) {
+            let list = c.retrievePeripherals(withIdentifiers: [u])
+            if let p = list.first, self.nameMatchesG7(p.name) {
+                connectSourceTag = "retrieved_identifier"
+                beginConnect(p)
+                return
+            }
+        }
+
+        for p in c.retrieveConnectedPeripherals(withServices: [G7BLEAdvertisement.febc]) {
+            if nameMatchesG7(p.name) {
+                connectSourceTag = "retrieved_febc"
+                beginConnect(p)
+                return
+            }
+        }
+        for p in c.retrieveConnectedPeripherals(withServices: [G7BLEService.cgm]) {
+            if nameMatchesG7(p.name) {
+                connectSourceTag = "retrieved_data_service"
+                beginConnect(p)
+                return
+            }
+        }
+
+        startScanIfNeeded()
+    }
+
+    private func startScanIfNeeded() {
+        guard let c = central, !c.isScanning, targetPeripheral == nil else { return }
+        c.registerForConnectionEvents(
+            options: [CBConnectionEventMatchingOption.serviceUUIDs: [G7BLEAdvertisement.febc, G7BLEService.cgm]]
+        )
+        c.scanForPeripherals(withServices: [G7BLEAdvertisement.febc], options: [CBCentralManagerOptionAllowDuplicatesKey: true])
+        isScanning = true
+        connectSourceTag = "scan"
+        G7BLELog.log("event=g7_ble_scan_start allow_duplicates=true service=FEBC")
+        Task { @MainActor in
+            self.watchState?.g7DirectBLEStatus = .searching
+            self.watchState?.g7DirectBLEStatusLabel = "searching"
+        }
+    }
+
+    private func stopScanIfConnected() {
+        central?.stopScan()
+        isScanning = false
+        G7BLELog.log("event=g7_ble_scan_stopped")
+    }
+
+    // MARK: - Name filter (DiaBLE-style, tolerant)
+
+    private func nameMatchesG7(_ name: String?) -> Bool {
+        guard let n = name, !n.isEmpty else { return true }
+        let u = n.uppercased()
+        if u.hasPrefix("DXCM") { return n.count >= 2 }
+        if u.hasPrefix("DX02") { return n.count >= 2 }
+        if u.hasPrefix("DX01") { return n.count >= 2 }
+        if u.hasPrefix("DEXCOM") { return n.count >= 2 }
+        return true
+    }
+
+    // MARK: - Connect
+
+    private func beginConnect(_ peripheral: CBPeripheral) {
+        lastConnectAttempt = Date()
+        targetPeripheral = peripheral
+        peripheral.delegate = self
+        G7BLELog.log(
+            "event=g7_ble_connect_attempt source=\(connectSourceTag) peripheral_id=\(peripheral.identifier) name=\(peripheral.name ?? "nil")"
+        )
+        Task { @MainActor in
+            self.watchState?.g7DirectBLEStatus = .connecting
+            self.watchState?.g7DirectBLEStatusLabel = "connecting"
+        }
+        let opts: [String: Any] = [
+            CBConnectPeripheralOptionNotifyOnConnectionKey: true,
+            CBConnectPeripheralOptionNotifyOnDisconnectionKey: true
+        ]
+        central?.connect(peripheral, options: opts)
+    }
+
+    private func increaseBackoff() {
+        connectBackoff = min(30, connectBackoff * 1.5)
+    }
+
+    private func resetBackoff() {
+        connectBackoff = 0.5
+    }
+
+    private func scheduleReconnect() {
+        let delay = min(8, connectBackoff)
+        G7BLELog.log("event=g7_ble_lifecycle schedule_reconnect after_s=\(String(format: "%.1f", delay))")
+        increaseBackoff()
+        queue.asyncAfter(deadline: .now() + delay) { [weak self] in
+            self?.performWorkAfterAttach(reason: "reconnect")
+        }
+    }
+
+    // MARK: - GATT
+
+    private func onConnected() {
+        dispatchPrecondition(condition: .onQueue(queue))
+        receivedEGVThisSession = false
+        authReady = false
+        controlNotifying = false
+        authCharacteristic = nil
+        controlCharacteristic = nil
+        backfillCharacteristic = nil
+        if let p = targetPeripheral {
+            G7BLELog.log("event=g7_ble_did_connect peripheral_id=\(p.identifier) name=\(p.name ?? "nil") source=\(connectSourceTag)")
+            resetBackoff()
+            p.discoverServices([G7BLEService.cgm, G7BLEService.serviceB])
+        }
+    }
+
+    private func startAuthWatchdog() {
+        authWatchdog?.cancel()
+        let t = DispatchSource.makeTimer(queue: queue)
+        t.schedule(deadline: .now() + authWatchdogTimeout)
+        t.setEventHandler { [weak self] in
+            guard let self, !self.authReady, self.shouldRun else { return }
+            G7BLELog.log("event=g7_ble_blocked_auth_incomplete reason=watchdog_s=\(Int(self.authWatchdogTimeout))")
+            Task { @MainActor in
+                self.watchState?.g7DirectBLEStatus = .stalled
+                self.watchState?.g7DirectBLEStatusLabel = "stalled"
+            }
+        }
+        t.resume()
+        authWatchdog = t
+    }
+
+    private func subscribeAuth() {
+        guard let a = authCharacteristic, let p = targetPeripheral else { return }
+        p.setNotifyValue(true, for: a)
+        G7BLELog.log("event=g7_ble_auth_notify_enabling char=\(a.uuid)")
+        startAuthWatchdog()
+    }
+
+    private func onAuthPayload(_ data: Data) {
+        guard !data.isEmpty else { return }
+        G7BLELog.log(
+            "event=g7_ble_auth_payload_received opcode=0x\(String(format: "%02x", data[0])) len=\(data.count) hex_preview=\(data.prefix(32).map { String(format: "%02x", $0) }.joined())"
+        )
+        if let m = G7AuthChallengeRxMessage(data: data), m.isBonded, m.isAuthenticated {
+            if !authReady {
+                G7BLELog.log("event=g7_ble_auth_ready bonded=true auth=true")
+                authReady = true
+                authWatchdog?.cancel()
+            }
+            enableControlNotifyIfReady()
+            sendEGVRequest(reason: "auth_0x05")
+            scheduleEGVRequestTimer()
+        }
+    }
+
+    private func enableControlNotifyIfReady() {
+        guard let c = controlCharacteristic, let p = targetPeripheral, authReady, !c.isNotifying else { return }
+        p.setNotifyValue(true, for: c)
+        G7BLELog.log("event=g7_ble_control_notify_enabling char=\(c.uuid)")
+    }
+
+    private func sendEGVRequest(reason: String) {
+        guard let ctrl = controlCharacteristic, let p = targetPeripheral, authReady else {
+            G7BLELog.log("event=g7_ble_blocked_control_write reason=not_ready")
+            return
+        }
+        p.writeValue(Data([G7Opcode.glucoseTx.rawValue]), for: ctrl, type: .withResponse)
+        G7BLELog.log("event=g7_ble_egv_request_sent reason=\(reason) write_type=withResponse opcode=0x4e")
+    }
+
+    private func scheduleEGVRequestTimer() {
+        egvRequestTimer?.cancel()
+        let t = DispatchSource.makeTimer(queue: queue)
+        t.schedule(deadline: .now() + 4 * 60 + 50, repeating: 4 * 60 + 50)
+        t.setEventHandler { [weak self] in
+            self?.sendEGVRequest(reason: "timer_4m50s")
+        }
+        t.resume()
+        egvRequestTimer = t
+    }
+
+    private func handleControlData(_ data: Data) {
+        guard !data.isEmpty, data[0] == G7Opcode.glucoseTx.rawValue else { return }
+        if let m = G7GlucoseMessage(data: data) {
+            receivedEGVThisSession = true
+            G7BLELog.log(
+                "event=g7_ble_egv_received seq=\(m.sequence) glucose=\(m.glucose.map { String($0) } ?? "nil") alg=\(m.algorithmState.rawValue) ts=\(m.messageTimestamp) age_s=\(m.age)"
+            )
+            applyGlucose(m)
+        } else {
+            G7BLELog.log("event=g7_ble_egv_parse_fail len=\(data.count)")
+        }
+    }
+
+    private func applyGlucose(_ m: G7GlucoseMessage) {
+        if activationDate == nil, let p = targetPeripheral {
+            activationDate = Date().addingTimeInterval(-TimeInterval(m.messageTimestamp))
+            userDefaults.set(p.identifier.uuidString, forKey: kLastPeripheralUUIDKey)
+        }
+        guard let act = activationDate, let g = m.glucose, m.hasReliableGlucose else {
+            G7BLELog.log("event=g7_ble_egv_skipped reason=no_value_or_warmup alg=\(m.algorithmState.rawValue)")
+            return
+        }
+        let reading = act.addingTimeInterval(TimeInterval(m.glucoseTimestamp))
+        let s = min(max(g, G7GlucoseLimits.minimum), G7GlucoseLimits.maximum)
+        let tStr = m.trendString
+        let colorHex = colorHexForGlucose(mgPerDl: Int(s))
+        Task { @MainActor in
+            G7ComplicationDeltaState.previousGlucose = nil
+            self.watchState?.lastG7DirectBLEEventDate = reading
+            self.watchState?.applyG7DirectFromObserver(
+                glucoseMgDl: Int(s),
+                trend: tStr,
+                readingDate: reading,
+                glucoseColorHex: colorHex
+            )
+            G7BLELog.log("event=g7_ble_snapshot_saved source=g7DirectBLE reading_date=\(reading) glucose=\(s)")
+        }
+    }
+
+    private func colorHexForGlucose(mgPerDl: Int) -> String {
+        if mgPerDl < 80 { return "#ff8c00" }
+        if mgPerDl < 200 { return "#4cd964" }
+        if mgPerDl < 250 { return "#ffcc00" }
+        return "#ff3b30"
+    }
+
+    private func cancelTimers() {
+        egvRequestTimer?.cancel()
+        egvRequestTimer = nil
+        authWatchdog?.cancel()
+        authWatchdog = nil
+    }
+
+}
+
+// MARK: - CBCentral
+
+extension G7DirectBLEManager: CBCentralManagerDelegate {
+    func centralManager(_: CBCentralManager, willRestoreState dict: [String: Any]) {
+        if let pList = dict[CBCentralManagerRestoredStatePeripheralsKey] as? [CBPeripheral], let p = pList.first {
+            G7BLELog.log("event=g7_ble_lifecycle will_restore_state peripherals=\(pList.count) first_id=\(p.identifier)")
+            targetPeripheral = p
+            p.delegate = self
+        }
+    }
+
+    func centralManagerDidUpdateState(_ c: CBCentralManager) {
+        if c.state == .poweredOn {
+            G7BLELog.log("event=g7_ble_lifecycle cb=powered_on")
+            performWorkAfterAttach(reason: "powered_on")
+        } else {
+            G7BLELog.log("event=g7_ble_blocked_unavailable state=\(c.state.rawValue)")
+            Task { @MainActor in
+                self.watchState?.g7DirectBLEStatus = .unavailable
+                self.watchState?.g7DirectBLEStatusLabel = "unavailable"
+            }
+        }
+    }
+
+    func centralManager(
+        _ central: CBCentralManager,
+        didDiscover peripheral: CBPeripheral,
+        advertisementData: [String: Any],
+        rssi RSSI: NSNumber
+    ) {
+        let mfg = (advertisementData[CBAdvertisementDataManufacturerDataKey] as? Data)?.prefix(4).map { String(format: "%02x", $0) }
+            .joined() ?? "nil"
+        G7BLELog.log(
+            "event=g7_ble_peripheral_discovered name=\(peripheral.name ?? "nil") id=\(peripheral.identifier) rssi=\(RSSI) mfg=\(mfg) adv_keys=\(advertisementData.keys.sorted().joined(separator: ","))"
+        )
+        if !nameMatchesG7(peripheral.name) {
+            G7BLELog.log("event=g7_ble_peripheral_skipped name=\(peripheral.name ?? "nil") reason=name_pattern")
+            return
+        }
+        if targetPeripheral == nil {
+            connectSourceTag = "scan"
+            beginConnect(peripheral)
+        }
+    }
+
+    func centralManager(_: CBCentralManager, didConnect peripheral: CBPeripheral) {
+        stopScanIfConnected()
+        targetPeripheral = peripheral
+        onConnected()
+    }
+
+    func centralManager(_: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: (any Error)?) {
+        let n = error as NSError?
+        G7BLELog.log(
+            "event=g7_ble_connect_failed source=\(connectSourceTag) error_domain=\(n?.domain ?? "nil") error_code=\(n?.code ?? -1) error_desc=\(n?.localizedDescription ?? "unknown")"
+        )
+        targetPeripheral = nil
+        scheduleReconnect()
+        Task { @MainActor in
+            self.watchState?.g7DirectBLEStatus = .stalled
+            self.watchState?.g7DirectBLEStatusLabel = "stalled"
+        }
+    }
+
+    func centralManager(_: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: (any Error)?) {
+        G7BLELog.log("event=g7_ble_did_disconnect peripheral=\(peripheral.identifier) err=\(error.map { $0.localizedDescription } ?? "none")")
+        let run = shouldRun
+        cancelTimers()
+        authReady = false
+        controlNotifying = false
+        targetPeripheral = nil
+        if run { scheduleReconnect() }
+        Task { @MainActor in
+            if run {
+                self.watchState?.g7DirectBLEStatus = .stalled
+                self.watchState?.g7DirectBLEStatusLabel = "disconnect"
+            }
+        }
+    }
+}
+
+// MARK: - Peripheral
+
+extension G7DirectBLEManager: CBPeripheralDelegate {
+    func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: (any Error)?) {
+        if let e = error {
+            G7BLELog.log("event=g7_ble_services_discovered error=\(e.localizedDescription)")
+            return
+        }
+        for s in peripheral.services ?? [] {
+            if s.uuid == G7BLEService.cgm {
+                G7BLELog.log("event=g7_ble_services_discovered uuid=\(s.uuid) label=cgm")
+                peripheral.discoverCharacteristics(nil, for: s)
+            } else if s.uuid == G7BLEService.serviceB {
+                G7BLELog.log("event=g7_ble_services_discovered uuid=\(s.uuid) label=serviceB_jpake")
+                peripheral.discoverCharacteristics([G7BLECharacteristic.serviceB_E, G7BLECharacteristic.serviceB_F], for: s)
+            }
+        }
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: (any Error)?) {
+        if let e = error {
+            G7BLELog.log("event=g7_ble_characteristics_discovered err=\(e.localizedDescription)")
+            return
+        }
+        for ch in service.characteristics ?? [] {
+            G7BLELog.log("event=g7_ble_characteristics_discovered uuid=\(ch.uuid) props=\(ch.properties.rawValue)")
+            switch ch.uuid {
+            case G7BLECharacteristic.authentication: authCharacteristic = ch
+            case G7BLECharacteristic.control: controlCharacteristic = ch
+            case G7BLECharacteristic.backfill: backfillCharacteristic = ch
+            case G7BLECharacteristic.serviceB_E, G7BLECharacteristic.serviceB_F:
+                G7BLELog.log("event=g7_ble_jpake_discovered char=\(ch.uuid) (no_notify_safety)")
+            default: break
+            }
+        }
+        if service.uuid == G7BLEService.cgm, let a = authCharacteristic, let c = controlCharacteristic {
+            G7BLELog.log("event=g7_ble_services_ready auth=\(a.uuid) control=\(c.uuid) backfill=\(backfillCharacteristic != nil)")
+            subscribeAuth()
+        } else if service.uuid == G7BLEService.cgm, authCharacteristic == nil || controlCharacteristic == nil {
+            G7BLELog.log("event=g7_ble_blocked_missing_chars auth=\(authCharacteristic != nil) control=\(controlCharacteristic != nil)")
+        }
+    }
+
+    func peripheral(_: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: (any Error)?) {
+        if let e = error {
+            G7BLELog.log("event=g7_ble_error char=\(characteristic.uuid) \(e.localizedDescription)")
+        }
+        guard let v = characteristic.value, !v.isEmpty else { return }
+        if characteristic.uuid == G7BLECharacteristic.authentication {
+            onAuthPayload(v)
+        } else if characteristic.uuid == G7BLECharacteristic.control {
+            handleControlData(v)
+        } else if characteristic.uuid == G7BLECharacteristic.backfill {
+            G7BLELog.log("event=g7_ble_backfill_ignored len=\(v.count)")
+        }
+    }
+
+    func peripheral(_: CBPeripheral, didUpdateNotificationStateFor characteristic: CBCharacteristic, error: (any Error)?) {
+        if characteristic.uuid == G7BLECharacteristic.authentication {
+            G7BLELog.log("event=g7_ble_auth_notify_enabled success=\(error == nil) notifying=\(characteristic.isNotifying)")
+        }
+        if characteristic.uuid == G7BLECharacteristic.control, characteristic.isNotifying {
+            controlNotifying = true
+            G7BLELog.log("event=g7_ble_control_notify_enabled success=\(error == nil)")
+            Task { @MainActor in
+                self.watchState?.g7DirectBLEStatus = .active
+                self.watchState?.g7DirectBLEStatusLabel = "active"
+                self.watchState?.lastG7DirectBLEEventDate = Date()
+            }
+        }
+    }
+
+    func peripheral(_: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: (any Error)?) {
+        if characteristic.uuid == G7BLECharacteristic.control, let e = error {
+            G7BLELog.log("event=g7_ble_connect_failed source=control_write error_desc=\(e.localizedDescription)")
+        }
+    }
+}

--- a/Trio Watch App Extension/G7/G7DirectBLEStatus.swift
+++ b/Trio Watch App Extension/G7/G7DirectBLEStatus.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Glanceable observer state for the main watch face (see `01-design.md` § UI).
+enum G7DirectBLEStatus: String, Sendable, Equatable {
+    case off
+    case searching
+    case connecting
+    case active
+    case stalled
+    case unavailable
+}

--- a/Trio Watch App Extension/G7/G7GlucoseMessage.swift
+++ b/Trio Watch App Extension/G7/G7GlucoseMessage.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+// Layout from G7SensorKit `G7GlucoseMessage.swift` (G7SensorKit/Messages/G7GlucoseMessage.swift).
+
+struct G7GlucoseMessage: Equatable {
+    let glucose: UInt16?
+    let predicted: UInt16?
+    let glucoseIsDisplayOnly: Bool
+    let messageTimestamp: UInt32
+    let algorithmState: G7AlgorithmState
+    let sequence: UInt16
+    let trend: Double?
+    let data: Data
+    let age: UInt16
+
+    var hasReliableGlucose: Bool { algorithmState.hasReliableGlucose }
+
+    var glucoseTimestamp: UInt32 { messageTimestamp - UInt32(age) }
+
+    /// Nightscout / Trio watch trend string (same naming as `WatchState.trend` from the phone).
+    var trendString: String? {
+        guard let t = trend else { return nil }
+        switch t {
+        case let x where x <= -3.0: "DoubleDown"
+        case let x where x <= -2.0: "SingleDown"
+        case let x where x <= -1.0: "FortyFiveDown"
+        case let x where x < 1.0: "Flat"
+        case let x where x < 2.0: "FortyFiveUp"
+        case let x where x < 3.0: "SingleUp"
+        default: "DoubleUp"
+        }
+    }
+
+    init?(data: Data) {
+        guard data.count >= 19 else { return nil }
+        guard data[1] == 0 else { return nil }
+
+        messageTimestamp = data.subdata(in: 2 ..< 6).g7ToUInt32()
+        sequence = data.subdata(in: 6 ..< 8).g7ToUInt16()
+        age = data.subdata(in: 10 ..< 12).g7ToUInt16()
+        let glucoseData = data.subdata(in: 12 ..< 14).g7ToUInt16()
+        if glucoseData != 0xFFFF {
+            glucose = glucoseData & 0x0FFF
+            glucoseIsDisplayOnly = (data[18] & 0x10) > 0
+        } else {
+            glucose = nil
+            glucoseIsDisplayOnly = false
+        }
+        let predictionData = data.subdata(in: 16 ..< 18).g7ToUInt16()
+        if predictionData != 0xFFFF {
+            predicted = predictionData & 0x0FFF
+        } else {
+            predicted = nil
+        }
+        algorithmState = G7AlgorithmState(rawValue: data[14])
+        if data[15] == 0x7F {
+            trend = nil
+        } else {
+            trend = Double(Int8(bitPattern: data[15])) / 10
+        }
+        self.data = data
+    }
+}

--- a/Trio Watch App Extension/Helper/WatchResidentTelemetry.swift
+++ b/Trio Watch App Extension/Helper/WatchResidentTelemetry.swift
@@ -1,0 +1,139 @@
+import Darwin
+import Foundation
+
+// MARK: - Field resident memory telemetry (watch)
+
+/// Rollout gate for resident memory samples. Policy: **04** / plan **02** (resident sample §).
+enum WatchResidentTelemetryGate {
+    /// Opt-in for **production App Store** builds when the receipt is not sandbox (see `hasSandboxAppStoreReceipt`).
+    private static let userDefaultsKey = "com.trio.watch.residentTelemetryEnabled"
+
+    /// `true` when `Bundle.main.appStoreReceiptURL` ends with **`sandboxReceipt`** — includes **TestFlight** and other sandbox-distributed builds. Production App Store builds use the **`receipt`** filename instead.
+    private static var hasSandboxAppStoreReceipt: Bool {
+        Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
+    }
+
+    static var isEnabled: Bool {
+        #if DEBUG
+        return true
+        #else
+        if hasSandboxAppStoreReceipt {
+            return true
+        }
+        return UserDefaults.standard.bool(forKey: userDefaultsKey)
+        #endif
+    }
+}
+
+/// Reads **`TASK_VM_INFO.phys_footprint`** (bytes) → **MiB** only (design **04**).
+enum WatchResidentMemory {
+    static func physFootprintMebibytes() -> Double? {
+        var info = task_vm_info_data_t()
+        var count = mach_msg_type_number_t(MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<integer_t>.size)
+        let kr: kern_return_t = withUnsafeMutablePointer(to: &info) { ptr in
+            ptr.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { rebound in
+                task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), rebound, &count)
+            }
+        }
+        guard kr == KERN_SUCCESS else { return nil }
+        return Double(info.phys_footprint) / (1024.0 * 1024.0)
+    }
+}
+
+// MARK: - Budget
+
+/// Per-activation sample cap + **`hk_batch`** once per process (plan **02**).
+struct WatchResidentTelemetryBudget {
+    /// Matches the **six** activation-scoped checkpoint tokens; **`hk_batch`** with **`activationSequence == nil`** is process-scoped and does not use this counter.
+    private static let maxSamplesPerActivation = 6
+
+    private static let checkpointTokens: Set<String> = [
+        "first_main_view",
+        "deferred_watch_state_fired",
+        "first_watch_state_apply",
+        "hk_batch",
+        "post_startup_flush",
+        "chart_visible"
+    ]
+
+    private var budgetActivationSeq: Int?
+    private var firedCheckpoints: Set<String> = []
+    private var totalThisActivation: Int = 0
+    private var hkBatchEmittedThisProcess = false
+
+    mutating func resetForNewActivation(_ seq: Int) {
+        budgetActivationSeq = seq
+        firedCheckpoints.removeAll()
+        totalThisActivation = 0
+    }
+
+    /// Returns `true` if this checkpoint should emit (caller logs after).
+    /// **`hk_batch`** may use **`activationSequence == nil`** for the process-scoped first batch when no foreground activation sequence exists yet (omit `activation_seq` on the log line — design **04**).
+    mutating func consumeIfAllowed(checkpoint: String, activationSequence: Int?) -> Bool {
+        guard Self.checkpointTokens.contains(checkpoint) else { return false }
+
+        if checkpoint == "hk_batch", hkBatchEmittedThisProcess {
+            return false
+        }
+
+        if activationSequence == nil {
+            guard checkpoint == "hk_batch" else { return false }
+            hkBatchEmittedThisProcess = true
+            return true
+        }
+
+        guard let seq = activationSequence else { return false }
+
+        guard budgetActivationSeq == seq else { return false }
+        guard totalThisActivation < Self.maxSamplesPerActivation else { return false }
+        guard !firedCheckpoints.contains(checkpoint) else { return false }
+
+        firedCheckpoints.insert(checkpoint)
+        totalThisActivation += 1
+        if checkpoint == "hk_batch" {
+            hkBatchEmittedThisProcess = true
+        }
+        return true
+    }
+
+    /// Undo `consumeIfAllowed` when `task_info` fails after the budget slot was reserved.
+    mutating func rollbackConsume(checkpoint: String, activationSequence: Int?) {
+        if checkpoint == "hk_batch", activationSequence == nil {
+            hkBatchEmittedThisProcess = false
+            return
+        }
+        guard let seq = activationSequence, budgetActivationSeq == seq else { return }
+        guard firedCheckpoints.remove(checkpoint) != nil else { return }
+        totalThisActivation = max(0, totalThisActivation - 1)
+        if checkpoint == "hk_batch" {
+            hkBatchEmittedThisProcess = false
+        }
+    }
+}
+
+// MARK: - WatchState emission
+
+extension WatchState {
+    /// **Main thread only.** Structured **`event=watch_resident_sample`** line (plan **02**).
+    func emitResidentMemorySample(checkpoint: String, activationSequence: Int?) {
+        assert(Thread.isMainThread, "emitResidentMemorySample must run on main")
+        guard WatchResidentTelemetryGate.isEnabled else { return }
+        guard residentTelemetryBudget.consumeIfAllowed(checkpoint: checkpoint, activationSequence: activationSequence)
+        else { return }
+        guard let mib = WatchResidentMemory.physFootprintMebibytes() else {
+            residentTelemetryBudget.rollbackConsume(checkpoint: checkpoint, activationSequence: activationSequence)
+            return
+        }
+
+        let mibStr = String(format: "%.3f", mib)
+        var line =
+            "event=watch_resident_sample checkpoint=\(checkpoint) phys_footprint_mib=\(mibStr)"
+        if let seq = activationSequence {
+            line += " activation_seq=\(seq)"
+        }
+
+        Task {
+            await WatchLogger.shared.log(line)
+        }
+    }
+}

--- a/Trio Watch App Extension/TrioWatchApp.swift
+++ b/Trio Watch App Extension/TrioWatchApp.swift
@@ -1,31 +1,49 @@
 import SwiftUI
 import UserNotifications
+import WatchKit
 
 @main struct TrioWatchApp: App {
+    @WKApplicationDelegateAdaptor(ExtensionDelegate.self) var appDelegate
     @Environment(\.scenePhase) private var scenePhase
 
     init() {
         WatchNotificationHandler.shared.configure()
+        Task {
+            let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown"
+            await WatchLogger.shared.log("[DEPLOY] event=watch_app_launch platform=watchos build=\(build)")
+        }
     }
 
     var body: some Scene {
         WindowGroup {
             TrioMainWatchView()
         }
-        .onChange(of: scenePhase) { _, newScenePhase in
-            if newScenePhase == .active {
-                Task {
-                    // Check for crashes and mark as active
-                    await WatchErrorReporter.shared.startup()
-                    await WatchErrorReporter.shared.markBecameActive()
-                    // Flush persisted logs (will query ACKs first, then resend pending payloads)
-                    await WatchLogger.shared.flushPersistedLogs()
-                }
-            } else if newScenePhase == .background || newScenePhase == .inactive {
-                Task {
-                    await WatchErrorReporter.shared.markEnteredBackgroundOrInactive()
-                }
+        .onChange(of: scenePhase) { oldPhase, newPhase in
+            let oldToken = watchScenePhaseToken(oldPhase)
+            let newToken = watchScenePhaseToken(newPhase)
+
+            if newPhase == .active {
+                WatchState.shared.handleForegroundActiveEntry()
+            } else if newPhase == .background || newPhase == .inactive {
+                WatchState.shared.handleForegroundInactiveOrBackground()
+            }
+
+            let forceFlush = newPhase != .active
+            Task {
+                await WatchLogger.shared.log(
+                    "event=watch_scene_phase_transition old=\(oldToken) new=\(newToken) source=swiftui_environment",
+                    force: forceFlush
+                )
             }
         }
+    }
+}
+
+private func watchScenePhaseToken(_ phase: ScenePhase) -> String {
+    switch phase {
+    case .active: "active"
+    case .inactive: "inactive"
+    case .background: "background"
+    @unknown default: "unknown"
     }
 }

--- a/Trio Watch App Extension/TrioWatchApp.swift
+++ b/Trio Watch App Extension/TrioWatchApp.swift
@@ -13,9 +13,17 @@ import UserNotifications
             TrioMainWatchView()
         }
         .onChange(of: scenePhase) { _, newScenePhase in
-            if newScenePhase == .background {
+            if newScenePhase == .active {
                 Task {
+                    // Check for crashes and mark as active
+                    await WatchErrorReporter.shared.startup()
+                    await WatchErrorReporter.shared.markBecameActive()
+                    // Flush persisted logs (will query ACKs first, then resend pending payloads)
                     await WatchLogger.shared.flushPersistedLogs()
+                }
+            } else if newScenePhase == .background || newScenePhase == .inactive {
+                Task {
+                    await WatchErrorReporter.shared.markEnteredBackgroundOrInactive()
                 }
             }
         }

--- a/Trio Watch App Extension/Views/ComplicationDebugView.swift
+++ b/Trio Watch App Extension/Views/ComplicationDebugView.swift
@@ -1,0 +1,511 @@
+import SwiftUI
+import WatchKit
+
+struct ComplicationDebugView: View {
+    @State private var snapshot: TrioComplicationSnapshot?
+    @State private var showConfirmation = false
+    @State private var confirmationMessage = ""
+    @State private var refreshTrigger = UUID()
+
+    @State private var watchLogCount: Int = 0
+    @State private var watchLogBytes: UInt64 = 0
+    @State private var drainCount: Int = 0
+    @State private var drainBytes: UInt64 = 0
+    @State private var pendingCount: Int = 0
+    @State private var isLoadingLogFiles: Bool = false
+
+    private let dataStore = TrioComplicationDataStore.shared
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 8) {
+                // SECTION 1: Data Store State
+                sectionHeader("DATA STORE")
+                dataStoreStateView
+
+                Divider().padding(.vertical, 4)
+
+                // SECTION 2: Log Files
+                sectionHeader("LOG FILES")
+                logFilesView
+
+                Divider().padding(.vertical, 4)
+
+                // SECTION 3: Reload Status
+                sectionHeader("RELOAD STATUS")
+                reloadStatusView
+
+                Divider().padding(.vertical, 4)
+
+                // SECTION 4: Actions
+                sectionHeader("ACTIONS")
+                actionsView
+            }
+            .padding(.horizontal, 8)
+        }
+        .navigationTitle("Debug")
+        .onAppear {
+            loadSnapshot()
+            loadLogFileStats()
+        }
+        .overlay(confirmationOverlay)
+        .id(refreshTrigger)
+    }
+
+    // MARK: - Data Store State Section
+
+    private var dataStoreStateView: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if let s = snapshot {
+                HStack {
+                    Text("Glucose:")
+                    Spacer()
+                    Text(s.glucose)
+                        .foregroundColor(glucoseColor(for: s.glucose))
+                        .fontWeight(.bold)
+                }
+
+                HStack {
+                    Text("Trend:")
+                    Spacer()
+                    Text(s.trend.isEmpty ? "--" : s.trend)
+                }
+
+                HStack {
+                    Text("Delta:")
+                    Spacer()
+                    Text(s.delta)
+                }
+
+                HStack {
+                    Text("Reading:")
+                    Spacer()
+                    VStack(alignment: .trailing, spacing: 2) {
+                        Text(formatTime(s.readingDate))
+                        Text("(\(formatAge(s.readingDate)))")
+                            .font(.caption2)
+                            .foregroundColor(ageColor(s.readingDate))
+                    }
+                }
+
+                HStack {
+                    Text("Saved:")
+                    Spacer()
+                    Text(formatTime(s.date))
+                }
+
+                if let state = s.state, !state.isEmpty {
+                    HStack {
+                        Text("State:")
+                        Spacer()
+                        Text(state)
+                            .foregroundColor(.orange)
+                    }
+                }
+            } else {
+                Text("No snapshot available")
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+            }
+
+            HStack {
+                Text("Path:")
+                Spacer()
+                Text(truncatePath(dataStore.appGroupContainerPath))
+                    .font(.system(size: 9))
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+            }
+
+            Divider().padding(.vertical, 2)
+
+            // App Group ID Debug Section
+            sectionHeader("APP GROUP")
+
+            HStack {
+                Text("AppGroupID:")
+                Spacer()
+                if let appGroupID = dataStore.appGroupID {
+                    Text(appGroupID)
+                        .font(.system(size: 9))
+                        .foregroundColor(.green)
+                        .lineLimit(1)
+                } else {
+                    Text("Not Found")
+                        .font(.system(size: 9))
+                        .foregroundColor(.red)
+                }
+            }
+
+            HStack {
+                Text("Container:")
+                Spacer()
+                if dataStore.appGroupContainerURL != nil {
+                    Text(dataStore.appGroupContainerAccessible ? "✓ Accessible" : "✗ Not Accessible")
+                        .font(.system(size: 9))
+                        .foregroundColor(dataStore.appGroupContainerAccessible ? .green : .red)
+                } else {
+                    Text("✗ No URL")
+                        .font(.system(size: 9))
+                        .foregroundColor(.red)
+                }
+            }
+
+            if let containerURL = dataStore.appGroupContainerURL {
+                HStack {
+                    Text("Container Path:")
+                    Spacer()
+                    Text(truncatePath(containerURL.path))
+                        .font(.system(size: 8))
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                }
+
+                HStack {
+                    Text("Snapshot File:")
+                    Spacer()
+                    if dataStore.snapshotFileExists {
+                        VStack(alignment: .trailing, spacing: 2) {
+                            Text("✓ Exists")
+                                .font(.system(size: 9))
+                                .foregroundColor(.green)
+                            if let size = dataStore.snapshotFileSize {
+                                Text("\(size) bytes")
+                                    .font(.system(size: 7))
+                                    .foregroundColor(.secondary)
+                            }
+                            if let age = dataStore.snapshotFileAge {
+                                Text("\(Int(age))s old")
+                                    .font(.system(size: 7))
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                    } else {
+                        Text("✗ Missing")
+                            .font(.system(size: 9))
+                            .foregroundColor(.red)
+                    }
+                }
+
+                if let files = try? FileManager.default.contentsOfDirectory(atPath: containerURL.path), !files.isEmpty {
+                    HStack {
+                        Text("Container Files:")
+                        Spacer()
+                        Text("\(files.count)")
+                            .font(.system(size: 8))
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+        }
+        .font(.caption)
+    }
+
+    // MARK: - Reload Status Section
+
+    private var reloadStatusView: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text("Last reload:")
+                Spacer()
+                Text(formatTime(dataStore.lastReloadTimestamp))
+            }
+
+            HStack {
+                Text("Elapsed:")
+                Spacer()
+                Text("\(Int(dataStore.secondsSinceLastReload))s ago")
+            }
+
+            HStack {
+                Text("Debounce:")
+                Spacer()
+                if dataStore.isDebounceActive {
+                    HStack(spacing: 4) {
+                        Circle()
+                            .fill(Color.red)
+                            .frame(width: 8, height: 8)
+                        Text("\(Int(dataStore.secondsUntilNextReloadAllowed))s")
+                    }
+                    .foregroundColor(.red)
+                } else {
+                    HStack(spacing: 4) {
+                        Circle()
+                            .fill(Color.green)
+                            .frame(width: 8, height: 8)
+                        Text("Ready")
+                    }
+                    .foregroundColor(.green)
+                }
+            }
+        }
+        .font(.caption)
+    }
+
+    // MARK: - Log Files Section
+
+    private var logFilesView: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text("Watch Logs:")
+                Spacer()
+                Text("\(watchLogCount) files, \(formatBytes(watchLogBytes))")
+                    .foregroundColor(.secondary)
+            }
+            HStack {
+                Text("Drain Files:")
+                Spacer()
+                Text("\(drainCount) files, \(formatBytes(drainBytes))")
+                    .foregroundColor(.secondary)
+            }
+            HStack {
+                Text("Pending:")
+                Spacer()
+                Text("\(pendingCount)")
+                    .foregroundColor(pendingCount > 0 ? .yellow : .secondary)
+            }
+        }
+        .font(.caption)
+    }
+
+    private func loadLogFileStats() {
+        guard !isLoadingLogFiles else { return }
+        isLoadingLogFiles = true
+        Task {
+            let fileManager = FileManager.default
+            var wlCount = 0
+            var wlBytes: UInt64 = 0
+            var dcCount = 0
+            var dcBytes: UInt64 = 0
+
+            let logDir = fileManager.urls(
+                for: .documentDirectory, in: .userDomainMask
+            ).first?.appendingPathComponent("logs", isDirectory: true)
+
+            if let logDir, let files = try? fileManager.contentsOfDirectory(
+                at: logDir, includingPropertiesForKeys: [.fileSizeKey]
+            ) {
+                for file in files
+                    where file.lastPathComponent.hasPrefix("watch_log_")
+                    && file.lastPathComponent.hasSuffix(".txt")
+                    && file.lastPathComponent != "watch_log_daily.txt" {
+                    wlCount += 1
+                    if let attrs = try? fileManager.attributesOfItem(
+                        atPath: file.path
+                    ), let size = attrs[.size] as? UInt64 {
+                        wlBytes += size
+                    }
+                }
+            }
+
+            if let containerURL = ComplicationLogBuffer
+                .sharedContainerURL() {
+                let drainsDir = containerURL.appendingPathComponent(
+                    "logs", isDirectory: true
+                )
+                if let files = try? fileManager.contentsOfDirectory(
+                    at: drainsDir, includingPropertiesForKeys: [.fileSizeKey]
+                ) {
+                    for file in files
+                        where file.lastPathComponent
+                        .hasPrefix("complication_log.drain.")
+                        && file.lastPathComponent.hasSuffix(".txt") {
+                        dcCount += 1
+                        if let attrs = try? fileManager.attributesOfItem(
+                            atPath: file.path
+                        ), let size = attrs[.size] as? UInt64 {
+                            dcBytes += size
+                        }
+                    }
+                }
+            }
+
+            let pCount = await WatchLogger.shared
+                .getPendingPayloads().count
+
+            await MainActor.run {
+                watchLogCount = wlCount
+                watchLogBytes = wlBytes
+                drainCount = dcCount
+                drainBytes = dcBytes
+                pendingCount = pCount
+                isLoadingLogFiles = false
+            }
+        }
+    }
+
+    private func formatBytes(_ bytes: UInt64) -> String {
+        if bytes < 1024 { return "\(bytes) B" }
+        return "\(bytes / 1024) KB"
+    }
+
+    // MARK: - Actions Section
+
+    private var actionsView: some View {
+        VStack(spacing: 8) {
+            Button {
+                Task {
+                    await WatchLogger.shared.log("🔧 Debug: Force Reload tapped")
+                }
+                // scheduleRetry: false — debug view one-shot; no retry needed (Phase 1.3).
+                dataStore.forceReload(scheduleRetry: false)
+                showConfirmation(message: "✅ Reload triggered!")
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    loadSnapshot()
+                }
+            } label: {
+                HStack {
+                    Image(systemName: "arrow.clockwise")
+                    Text("Force Reload")
+                }
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+            .tint(.blue)
+
+            Button {
+                Task {
+                    await WatchLogger.shared.log("🔧 Debug: Request Fresh Data tapped")
+                }
+                WatchState.shared.requestWatchStateUpdate()
+                showConfirmation(message: "📡 Requesting...")
+            } label: {
+                HStack {
+                    Image(systemName: "iphone.radiowaves.left.and.right")
+                    Text("Request Data")
+                }
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+            .tint(.orange)
+
+            Button {
+                loadSnapshot()
+                loadLogFileStats()
+                refreshTrigger = UUID()
+                showConfirmation(message: "🔄 Refreshed")
+            } label: {
+                HStack {
+                    Image(systemName: "arrow.triangle.2.circlepath")
+                    Text("Refresh View")
+                }
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+            .tint(.gray)
+            .disabled(isLoadingLogFiles)
+
+            Button {
+                flushWatchLogs()
+            } label: {
+                HStack {
+                    Image(systemName: "square.and.arrow.up")
+                    Text("Flush Logs")
+                }
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+            .tint(.purple)
+        }
+    }
+
+    private func flushWatchLogs() {
+        Task {
+            await WatchLogger.shared.log("⌚️ DEBUG manual flush requested", force: true)
+            await WatchLogger.shared.flushIfNeeded(force: true)
+            await WatchLogger.shared.flushPersistedLogs()
+            await MainActor.run {
+                showConfirmation(message: "📤 Logs flushed")
+            }
+        }
+    }
+
+    // MARK: - Confirmation Overlay
+
+    private var confirmationOverlay: some View {
+        Group {
+            if showConfirmation {
+                VStack {
+                    Spacer()
+                    Text(confirmationMessage)
+                        .font(.caption)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .background(.ultraThinMaterial)
+                        .cornerRadius(8)
+                        .padding(.bottom, 20)
+                }
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+        }
+        .animation(.easeInOut(duration: 0.3), value: showConfirmation)
+    }
+
+    // MARK: - Helpers
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(.caption2)
+            .fontWeight(.semibold)
+            .foregroundColor(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.top, 4)
+    }
+
+    private func loadSnapshot() {
+        snapshot = dataStore.latestSnapshot()
+    }
+
+    private func showConfirmation(message: String) {
+        confirmationMessage = message
+        showConfirmation = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            showConfirmation = false
+        }
+    }
+
+    private func formatTime(_ date: Date) -> String {
+        if date == .distantPast { return "--" }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+        return formatter.string(from: date)
+    }
+
+    private func formatAge(_ date: Date) -> String {
+        if date == .distantPast { return "--" }
+        let seconds = Int(Date().timeIntervalSince(date))
+        if seconds < 60 { return "\(seconds)s ago" }
+        if seconds < 3600 { return "\(seconds / 60)m ago" }
+        return "\(seconds / 3600)h ago"
+    }
+
+    private func ageColor(_ date: Date) -> Color {
+        if date == .distantPast { return .secondary }
+        let age = Date().timeIntervalSince(date)
+        if age < 300 { return .green }
+        if age < 900 { return .yellow }
+        return .red
+    }
+
+    private func glucoseColor(for value: String) -> Color {
+        guard let glucose = Double(value) else { return .secondary }
+        if glucose < 70 { return .red }
+        if glucose > 180 { return .orange }
+        return .green
+    }
+
+    private func truncatePath(_ path: String?) -> String {
+        guard let path = path else { return "Unknown" }
+        let components = path.components(separatedBy: "/")
+        if components.count > 3 {
+            return ".../" + components.suffix(2).joined(separator: "/")
+        }
+        return path
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ComplicationDebugView()
+    }
+}

--- a/Trio Watch App Extension/Views/GlucoseTrendView.swift
+++ b/Trio Watch App Extension/Views/GlucoseTrendView.swift
@@ -114,6 +114,45 @@ struct GlucoseTrendView: View {
         }
     }
 
+    private var sourceAbbrev: String {
+        switch state.displayedComplicationDataSource {
+        case .g7DirectBLE: "BLE"
+        case .watchConnectivityPhone: "Phone"
+        case .healthKit: "HK"
+        case .unknown: "…"
+        }
+    }
+
+    private var bleStateAbbrev: String {
+        switch state.g7DirectBLEStatus {
+        case .off: "off"
+        case .searching: "scan"
+        case .connecting: "conn"
+        case .active: "ok"
+        case .stalled: "stall"
+        case .unavailable: "noBT"
+        }
+    }
+
+    private var lastBleRecency: String? {
+        guard let d = state.lastG7DirectBLEEventDate else { return nil }
+        let s = max(0, Int(Date().timeIntervalSince(d)))
+        if s < 60 { return "<1m" }
+        let m = s / 60
+        if m < 120 { return "\(m)m" }
+        return "\(m/60)h+"
+    }
+
+    private var recencyLine: String {
+        if isWatchStateDated {
+            return String(localized: "STALE DATA", comment: "Information displayed when watch app data outdated or stale.")
+        }
+        let base = state.lastLoopTime ?? "--"
+        let path = "· src:\(sourceAbbrev)"
+        let ble = " · G7:\(bleStateAbbrev)\(lastBleRecency.map { "[\($0)]" } ?? "")"
+        return "\(base)\(path)\(ble)"
+    }
+
     var body: some View {
         VStack {
             ZStack {
@@ -148,13 +187,10 @@ struct GlucoseTrendView: View {
 
             Spacer()
 
-            Text(
-                isWatchStateDated ?
-                    String(localized: "STALE DATA", comment: "Information displayed when watch app data outdated or stale.") :
-                    state
-                    .lastLoopTime ?? "--"
-            )
-            .font(.system(size: minutesAgoFontSize))
+            Text(recencyLine)
+            .font(.system(size: minutesAgoFontSize - 1))
+            .lineLimit(2)
+            .minimumScaleFactor(0.55)
             .fontWidth(isWatchStateDated ? .expanded : .standard)
 
             Spacer()

--- a/Trio Watch App Extension/Views/TrioMainWatchView.swift
+++ b/Trio Watch App Extension/Views/TrioMainWatchView.swift
@@ -4,6 +4,7 @@ import WatchKit
 
 struct TrioMainWatchView: View {
     @State private var state = WatchState.shared
+    @Environment(\.scenePhase) private var scenePhase
 
     // misc
     @State private var currentPage: Int = 0
@@ -132,6 +133,7 @@ struct TrioMainWatchView: View {
                         state.currentGlucoseColorString = glucoseColor
                     }
                     state.lastWatchStateUpdate = snapshot.readingDate
+                    if let s = snapshot.dataSource { state.displayedComplicationDataSource = s }
                     state.showSyncingAnimation = true
                 } else if let snapshot = cachedSnapshot,
                           let lastUpdate = state.lastWatchStateUpdate,
@@ -144,13 +146,24 @@ struct TrioMainWatchView: View {
                         state.currentGlucoseColorString = glucoseColor
                     }
                     state.lastWatchStateUpdate = snapshot.readingDate
+                    if let s = snapshot.dataSource { state.displayedComplicationDataSource = s }
                     state.showSyncingAnimation = false
                 }
 
                 state.bolusAmount = 0
                 state.recommendedBolus = 0
 
+                G7DirectBLEManager.shared.bind(watchState: state)
+                if scenePhase == .active {
+                    G7DirectBLEManager.shared.start()
+                }
+
                 state.noteMainWatchRootViewAppearedForResidentTelemetry()
+            }
+            .onChange(of: scenePhase) { _, newPhase in
+                if newPhase == .active {
+                    G7DirectBLEManager.shared.start()
+                }
             }
             .onChange(of: currentPage) { _, newPage in
                 if newPage == 1 {

--- a/Trio Watch App Extension/Views/TrioMainWatchView.swift
+++ b/Trio Watch App Extension/Views/TrioMainWatchView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 import WatchKit
 
 struct TrioMainWatchView: View {
-    @State private var state = WatchState()
+    @State private var state = WatchState.shared
 
     // misc
     @State private var currentPage: Int = 0
@@ -25,8 +25,8 @@ struct TrioMainWatchView: View {
         guard let lastUpdateTimestamp = state.lastWatchStateUpdate else {
             return true
         }
-        let now = Date().timeIntervalSince1970
-        let secondsSinceUpdate = now - lastUpdateTimestamp
+        let now = Date()
+        let secondsSinceUpdate = now.timeIntervalSince(lastUpdateTimestamp)
         // Return true if last update older than 5 min, so 1 loop cycle
         return secondsSinceUpdate > 5 * 60
     }
@@ -69,6 +69,12 @@ struct TrioMainWatchView: View {
                         rotationDegrees: rotationDegrees,
                         isWatchStateDated: isWatchStateDated || isSessionUnreachable
                     )
+                    .onLongPressGesture(minimumDuration: 1.0) {
+                        // Long press to quickly access debug view
+                        withAnimation {
+                            currentPage = 2
+                        }
+                    }
 
                     if state.showSyncingAnimation {
                         Image(systemName: "iphone.radiowaves.left.and.right")
@@ -88,22 +94,72 @@ struct TrioMainWatchView: View {
                 }.tag(0)
 
                 // Page 2: Glucose chart
-                GlucoseChartView(
-                    glucoseValues: state.glucoseValues,
-                    minYAxisValue: state.minYAxisValue,
-                    maxYAxisValue: state.maxYAxisValue
-                )
+                Group {
+                    if currentPage == 1 {
+                        GlucoseChartView(
+                            glucoseValues: state.glucoseValues,
+                            minYAxisValue: state.minYAxisValue,
+                            maxYAxisValue: state.maxYAxisValue
+                        )
+                    } else {
+                        Color.clear
+                    }
+                }
                 .tag(1)
+
+                // Page 3: Complication Debug View (only constructed when visible)
+                Group {
+                    if currentPage == 2 {
+                        ComplicationDebugView()
+                    } else {
+                        Color.clear
+                    }
+                }
+                .tag(2)
             }
             .onAppear {
-                /// Hard reset variables when main view appears
-                /// Reset `bolusAmount` and `recommendedBolus` to ensure no stale / old value is set when user opens bolus input or meal combo the next time.
+                Task {
+                    await WatchLogger.shared.log("Watch main view appeared")
+                }
+
+                let cachedSnapshot = TrioComplicationDataStore.shared.latestSnapshot()
+                let hasValidWatchData = state.currentGlucose != "--" && !state.currentGlucose.isEmpty
+                if !hasValidWatchData, let snapshot = cachedSnapshot {
+                    state.currentGlucose = snapshot.glucose
+                    state.trend = snapshot.trend
+                    state.delta = snapshot.delta
+                    if let glucoseColor = snapshot.glucoseColor {
+                        state.currentGlucoseColorString = glucoseColor
+                    }
+                    state.lastWatchStateUpdate = snapshot.readingDate
+                    state.showSyncingAnimation = true
+                } else if let snapshot = cachedSnapshot,
+                          let lastUpdate = state.lastWatchStateUpdate,
+                          snapshot.readingDate > lastUpdate
+                {
+                    state.currentGlucose = snapshot.glucose
+                    state.trend = snapshot.trend
+                    state.delta = snapshot.delta
+                    if let glucoseColor = snapshot.glucoseColor {
+                        state.currentGlucoseColorString = glucoseColor
+                    }
+                    state.lastWatchStateUpdate = snapshot.readingDate
+                    state.showSyncingAnimation = false
+                }
+
                 state.bolusAmount = 0
                 state.recommendedBolus = 0
+
+                state.noteMainWatchRootViewAppearedForResidentTelemetry()
+            }
+            .onChange(of: currentPage) { _, newPage in
+                if newPage == 1 {
+                    state.noteChartTabBecameVisibleForResidentTelemetry()
+                }
             }
             .background(trioBackgroundColor)
             .tabViewStyle(.verticalPage)
-            .digitalCrownRotation($currentPage.doubleBinding(), from: 0, through: 1, by: 1)
+            .digitalCrownRotation($currentPage.doubleBinding(), from: 0, through: 2, by: 1)
             .onChange(of: state.trend) { _, newTrend in
                 withAnimation {
                     updateRotation(for: newTrend)

--- a/Trio Watch App Extension/WatchConnectivityPayloadIds.swift
+++ b/Trio Watch App Extension/WatchConnectivityPayloadIds.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Normalizes watch ↔ phone payload identifiers from `WCSession` dictionaries.
+/// Accepts `String`, `NSString`, `UUID`, and `NSUUID` only (rejects `NSNumber` and other types).
+enum WatchConnectivityPayloadIds {
+    private static func debugLogUnexpected(_ value: Any?) {
+        #if DEBUG
+        if let value {
+            let typeName = String(describing: type(of: value))
+            debugPrint("WatchConnectivityPayloadIds: unexpected payload id type \(typeName)")
+        }
+        #endif
+    }
+
+    /// Returns a canonical UUID string, or `nil` if the value is not a supported type.
+    static func payloadIdString(_ value: Any?) -> String? {
+        switch value {
+        case let s as String:
+            return s
+        case let s as NSString:
+            return s as String
+        case let u as UUID:
+            return u.uuidString
+        case let u as NSUUID:
+            return u.uuidString
+        case is NSNumber:
+            debugLogUnexpected(value)
+            return nil
+        default:
+            if value != nil {
+                debugLogUnexpected(value)
+            }
+            return nil
+        }
+    }
+
+    /// Extracts payload id strings from an array or `NSArray` value (e.g. `ackIds`, `payloadIds`).
+    static func payloadIdStrings(from value: Any?) -> [String] {
+        guard let value else { return [] }
+
+        if let anyArray = value as? [Any] {
+            return anyArray.compactMap { payloadIdString($0) }
+        }
+
+        if let nsArray = value as? NSArray {
+            var out: [String] = []
+            out.reserveCapacity(nsArray.count)
+            for i in 0 ..< nsArray.count {
+                if let s = payloadIdString(nsArray[i]) {
+                    out.append(s)
+                }
+            }
+            return out
+        }
+
+        debugLogUnexpected(value)
+        return []
+    }
+}

--- a/Trio Watch App Extension/WatchErrorReporter.swift
+++ b/Trio Watch App Extension/WatchErrorReporter.swift
@@ -1,0 +1,363 @@
+import Foundation
+import WatchConnectivity
+
+/// Forwards errors from watchOS to iOS via WatchConnectivity for logging to Crashlytics.
+/// This is the recommended approach since Crashlytics isn't fully supported on watchOS.
+actor WatchErrorReporter {
+    static let shared = WatchErrorReporter()
+
+    private let session = WCSession.default
+    private let watchLastRunWasForegroundKey = "watchLastRunWasForeground"
+    private let crashContextKey = "watchAppCrashContext"
+    private let firstLaunchKey = "watchAppHasLaunchedBefore"
+    private let pendingPayloadsKey = "watchPendingPayloads"
+
+    // TTL and caps
+    private let savedContextMaxEntries = 5
+    private let savedContextMaxAge: TimeInterval = 7 * 24 * 60 * 60 // 7 days
+    private let valueLengthCap = 512
+    private let recentLogsSizeCap = 16 * 1024 // 16 KB
+
+    private var hasCheckedForCrash = false
+    private static let dateFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    private init() {
+        // No automatic crash check - must call startup() explicitly
+    }
+
+    /// Startup method - safe to call multiple times (idempotent).
+    /// Checks for previous crash and marks the session as checked.
+    func startup() async {
+        guard !hasCheckedForCrash else { return }
+        hasCheckedForCrash = true
+        await checkForPreviousCrash()
+    }
+
+    /// Checks if the app crashed on the previous launch and reports it.
+    private func checkForPreviousCrash() async {
+        let userDefaults = UserDefaults.standard
+        let hasLaunchedBefore = userDefaults.bool(forKey: firstLaunchKey)
+
+        // First launch
+        if !hasLaunchedBefore {
+            userDefaults.set(true, forKey: firstLaunchKey)
+            userDefaults.set(false, forKey: watchLastRunWasForegroundKey)
+            return
+        }
+
+        // Subsequent launches - check if previous run was foreground
+        let lastRunWasForeground = userDefaults.bool(forKey: watchLastRunWasForegroundKey)
+
+        if lastRunWasForeground {
+            // Previous run was foreground and didn't transition to background - likely crashed
+            await reportPotentialCrash()
+            // Clear the marker to prevent repeated reporting in the same session
+            userDefaults.set(false, forKey: watchLastRunWasForegroundKey)
+        }
+    }
+
+    /// Reports a potential crash from the previous session.
+    private func reportPotentialCrash() async {
+        var crashInfo: [String: Any] = [
+            "type": "potentialCrash",
+            "platform": "watchOS",
+            "detectedAt": Self.dateFormatter.string(from: Date())
+        ]
+
+        // Add version info
+        if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
+           let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String {
+            crashInfo["appVersion"] = "\(version) (\(build))"
+        }
+
+        // Try to read persisted logs for context (with size cap)
+        if let logContext = await readRecentLogs() {
+            crashInfo["recentLogs"] = logContext
+        }
+
+        // Read any saved crash context from UserDefaults (with TTL/cap enforcement)
+        if let savedContext = await getSavedCrashContext() {
+            crashInfo["savedContext"] = savedContext
+        }
+
+        await sendErrorToPhone(crashInfo)
+
+        await WatchLogger.shared.log("⌚️ Detected potential crash from previous session, reported to iOS")
+    }
+
+    /// Gets saved crash context with TTL and cap enforcement.
+    private func getSavedCrashContext() async -> [String: String]? {
+        guard let contextDict = UserDefaults.standard.dictionary(forKey: crashContextKey) as? [String: String] else {
+            return nil
+        }
+
+        // Apply TTL - remove entries older than maxAge
+        let now = Date()
+        var validContext: [String: String] = [:]
+        var contextMetadata: [String: TimeInterval] = [:]
+
+        // Try to get metadata if it exists
+        if let metadata = UserDefaults.standard.dictionary(forKey: "\(crashContextKey)_metadata") as? [String: TimeInterval] {
+            contextMetadata = metadata
+        }
+
+        for (key, value) in contextDict {
+            // Check TTL
+            if let createdAt = contextMetadata[key] {
+                let age = now.timeIntervalSince1970 - createdAt
+                if age > savedContextMaxAge {
+                    continue // Skip expired entries
+                }
+            }
+
+            // Apply value length cap
+            let cappedValue = String(value.prefix(valueLengthCap))
+            validContext[key] = cappedValue
+        }
+
+        // Enforce max entries (keep most recent)
+        if validContext.count > savedContextMaxEntries {
+            // Sort by creation time and keep most recent
+            let sortedKeys = validContext.keys.sorted { key1, key2 in
+                let time1 = contextMetadata[key1] ?? 0
+                let time2 = contextMetadata[key2] ?? 0
+                return time1 > time2
+            }
+            let keysToKeep = Array(sortedKeys.prefix(savedContextMaxEntries))
+            validContext = Dictionary(uniqueKeysWithValues: keysToKeep.compactMap { key in
+                guard let value = validContext[key] else { return nil }
+                return (key, value)
+            })
+        }
+
+        return validContext.isEmpty ? nil : validContext
+    }
+
+    /// Reads recent log entries from persisted logs for crash context (with size cap).
+    private func readRecentLogs() async -> String? {
+        let logDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+            .appendingPathComponent("logs", isDirectory: true)
+
+        // Try to read from daily log file
+        let dailyLogFile = logDir.appendingPathComponent("watch_log_daily.txt")
+
+        guard let data = try? Data(contentsOf: dailyLogFile),
+              let logString = String(data: data, encoding: .utf8),
+              !logString.isEmpty
+        else { return nil }
+
+        // Apply size cap
+        let cappedString: String
+        if logString.utf8.count > recentLogsSizeCap {
+            // Take last N bytes that fit within cap
+            let cappedData = data.suffix(recentLogsSizeCap)
+            cappedString = String(data: cappedData, encoding: .utf8) ?? String(logString.suffix(recentLogsSizeCap))
+        } else {
+            cappedString = logString
+        }
+
+        // Return last 50 lines for context
+        let lines = cappedString.components(separatedBy: .newlines)
+        let recentLines = Array(lines.suffix(50))
+        return recentLines.joined(separator: "\n")
+    }
+
+    /// Marks the app as having become active (foreground).
+    func markBecameActive() async {
+        UserDefaults.standard.set(true, forKey: watchLastRunWasForegroundKey)
+    }
+
+    /// Marks the app as having entered background or inactive state.
+    func markEnteredBackgroundOrInactive() async {
+        UserDefaults.standard.set(false, forKey: watchLastRunWasForegroundKey)
+    }
+
+    /// Saves context that should be included if the app crashes.
+    /// Useful for saving state before operations that might crash.
+    func saveCrashContext(_ context: [String: String]) async {
+        // Apply value length cap
+        var cappedContext: [String: String] = [:]
+        var metadata: [String: TimeInterval] = [:]
+        let now = Date().timeIntervalSince1970
+
+        for (key, value) in context.prefix(savedContextMaxEntries) {
+            let cappedValue = String(value.prefix(valueLengthCap))
+            cappedContext[key] = cappedValue
+            metadata[key] = now
+        }
+
+        UserDefaults.standard.set(cappedContext, forKey: crashContextKey)
+        UserDefaults.standard.set(metadata, forKey: "\(crashContextKey)_metadata")
+    }
+
+    /// Clears saved context for a specific payloadId after ACK.
+    func clearSavedContextForPayload(_ payloadId: String) async {
+        // Context is cleared when payload is acknowledged
+        // This is called from ACK handler
+        UserDefaults.standard.removeObject(forKey: crashContextKey)
+        UserDefaults.standard.removeObject(forKey: "\(crashContextKey)_metadata")
+    }
+
+    /// Reports a non-fatal error from the watch app to iOS for Crashlytics logging.
+    /// - Parameters:
+    ///   - error: The error to report
+    ///   - context: Optional context information (e.g., function name, file name)
+    func reportError(_ error: Error, context: [String: String]? = nil) async {
+        var errorInfo: [String: Any] = [
+            "errorDomain": (error as NSError).domain,
+            "errorCode": (error as NSError).code,
+            "errorDescription": error.localizedDescription,
+            "platform": "watchOS"
+        ]
+
+        // Add version info
+        if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
+           let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String {
+            errorInfo["appVersion"] = "\(version) (\(build))"
+        }
+
+        // Add context if provided (with caps)
+        if let context = context {
+            var cappedContext: [String: String] = [:]
+            for (key, value) in context.prefix(10) {
+                cappedContext[key] = String(value.prefix(valueLengthCap))
+            }
+            errorInfo["context"] = cappedContext
+        }
+
+        // Add stack trace info if available (renamed to reportingStackTrace)
+        let stackSymbols = Thread.callStackSymbols
+        if !stackSymbols.isEmpty {
+            errorInfo["reportingStackTrace"] = Array(stackSymbols.prefix(10)) // Limit to first 10 frames
+        }
+
+        await sendErrorToPhone(errorInfo)
+    }
+
+    /// Reports a non-fatal issue with a custom message.
+    /// - Parameters:
+    ///   - message: Description of the issue
+    ///   - context: Optional context information
+    func reportNonFatalIssue(_ message: String, context: [String: String]? = nil) async {
+        var errorInfo: [String: Any] = [
+            "message": message,
+            "platform": "watchOS",
+            "type": "nonFatalIssue"
+        ]
+
+        // Add version info
+        if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
+           let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String {
+            errorInfo["appVersion"] = "\(version) (\(build))"
+        }
+
+        // Add context if provided (with caps)
+        if let context = context {
+            var cappedContext: [String: String] = [:]
+            for (key, value) in context.prefix(10) {
+                cappedContext[key] = String(value.prefix(valueLengthCap))
+            }
+            errorInfo["context"] = cappedContext
+        }
+
+        await sendErrorToPhone(errorInfo)
+    }
+
+    /// Stores a pending payload record for later ACK matching.
+    func storePendingPayload(payloadId: String, type: String, filePath: String?) async {
+        var pendingPayloads = UserDefaults.standard.array(forKey: pendingPayloadsKey) as? [[String: Any]] ?? []
+
+        let record: [String: Any] = [
+            "payloadId": payloadId,
+            "type": type,
+            "filePath": filePath as Any,
+            "createdAtEpoch": Date().timeIntervalSince1970
+        ]
+
+        pendingPayloads.append(record)
+
+        // Clean up old records (older than 7 days)
+        let now = Date().timeIntervalSince1970
+        pendingPayloads = pendingPayloads.filter { record in
+            if let createdAt = record["createdAtEpoch"] as? TimeInterval {
+                return (now - createdAt) < (7 * 24 * 60 * 60)
+            }
+            return true
+        }
+
+        UserDefaults.standard.set(pendingPayloads, forKey: pendingPayloadsKey)
+    }
+
+    /// Removes a pending payload record after ACK.
+    func removePendingPayload(_ payloadId: String) async {
+        var pendingPayloads = UserDefaults.standard.array(forKey: pendingPayloadsKey) as? [[String: Any]] ?? []
+        pendingPayloads.removeAll { record in
+            record["payloadId"] as? String == payloadId
+        }
+        UserDefaults.standard.set(pendingPayloads, forKey: pendingPayloadsKey)
+    }
+
+    /// Gets all pending payload records.
+    func getPendingPayloads() async -> [[String: Any]] {
+        return UserDefaults.standard.array(forKey: pendingPayloadsKey) as? [[String: Any]] ?? []
+    }
+
+    private func sendErrorToPhone(_ errorInfo: [String: Any]) async {
+        // Don't block if WatchConnectivity isn't supported (shouldn't happen on watchOS, but be safe)
+        guard WCSession.isSupported() else {
+            await WatchLogger.shared.log("⌚️ WatchConnectivity not supported, cannot send error to phone")
+            return
+        }
+
+        // Generate payloadId
+        let payloadId = UUID().uuidString
+
+        // Wrap in envelope structure
+        let envelope: [String: Any] = [
+            "type": "watchError",
+            "payloadId": payloadId,
+            "data": errorInfo
+        ]
+
+        // Do NOT activate session - WatchState owns activation
+        // If session is not activated or reachable, use transferUserInfo or persist locally
+
+        if session.isReachable && session.activationState == .activated {
+            // Use sendMessage with replyHandler for immediate ACK
+            session.sendMessage(
+                envelope,
+                replyHandler: { reply in
+                    Task {
+                        // Check if ACK received
+                        if let ackType = reply["type"] as? String,
+                           ackType == "ack",
+                           let ackPayloadId = reply["payloadId"] as? String,
+                           ackPayloadId == payloadId {
+                            // ACK received - clear saved context for this payloadId
+                            await WatchErrorReporter.shared.clearSavedContextForPayload(payloadId)
+                            await WatchErrorReporter.shared.removePendingPayload(payloadId)
+                            await WatchLogger.shared.log("⌚️ Error ACK received from phone for payloadId: \(payloadId)")
+                        }
+                    }
+                },
+                errorHandler: { error in
+                    Task {
+                        await WatchLogger.shared.log("⌚️ Failed to send error to phone: \(error.localizedDescription)")
+                        // Store as pending for retry
+                        await WatchErrorReporter.shared.storePendingPayload(payloadId: payloadId, type: "watchError", filePath: nil)
+                    }
+                }
+            )
+        } else {
+            // Fallback to transferUserInfo for background delivery
+            _ = session.transferUserInfo(envelope)
+            // Store as pending - will need ACK later
+            await storePendingPayload(payloadId: payloadId, type: "watchError", filePath: nil)
+            await WatchLogger.shared.log("⌚️ Error queued for background delivery to phone (payloadId: \(payloadId))")
+        }
+    }
+}

--- a/Trio Watch App Extension/WatchErrorReporter.swift
+++ b/Trio Watch App Extension/WatchErrorReporter.swift
@@ -7,7 +7,7 @@ actor WatchErrorReporter {
     static let shared = WatchErrorReporter()
 
     private let session = WCSession.default
-    private let watchLastRunWasForegroundKey = "watchLastRunWasForeground"
+    private static let watchLastRunWasForegroundKey = "watchLastRunWasForeground"
     private let crashContextKey = "watchAppCrashContext"
     private let firstLaunchKey = "watchAppHasLaunchedBefore"
     private let pendingPayloadsKey = "watchPendingPayloads"
@@ -45,18 +45,18 @@ actor WatchErrorReporter {
         // First launch
         if !hasLaunchedBefore {
             userDefaults.set(true, forKey: firstLaunchKey)
-            userDefaults.set(false, forKey: watchLastRunWasForegroundKey)
+            userDefaults.set(false, forKey: Self.watchLastRunWasForegroundKey)
             return
         }
 
         // Subsequent launches - check if previous run was foreground
-        let lastRunWasForeground = userDefaults.bool(forKey: watchLastRunWasForegroundKey)
+        let lastRunWasForeground = userDefaults.bool(forKey: Self.watchLastRunWasForegroundKey)
 
         if lastRunWasForeground {
             // Previous run was foreground and didn't transition to background - likely crashed
             await reportPotentialCrash()
             // Clear the marker to prevent repeated reporting in the same session
-            userDefaults.set(false, forKey: watchLastRunWasForegroundKey)
+            userDefaults.set(false, forKey: Self.watchLastRunWasForegroundKey)
         }
     }
 
@@ -167,13 +167,21 @@ actor WatchErrorReporter {
     }
 
     /// Marks the app as having become active (foreground).
+    static func markBecameActiveImmediately() {
+        UserDefaults.standard.set(true, forKey: Self.watchLastRunWasForegroundKey)
+    }
+
     func markBecameActive() async {
-        UserDefaults.standard.set(true, forKey: watchLastRunWasForegroundKey)
+        Self.markBecameActiveImmediately()
     }
 
     /// Marks the app as having entered background or inactive state.
+    static func markEnteredBackgroundOrInactiveImmediately() {
+        UserDefaults.standard.set(false, forKey: Self.watchLastRunWasForegroundKey)
+    }
+
     func markEnteredBackgroundOrInactive() async {
-        UserDefaults.standard.set(false, forKey: watchLastRunWasForegroundKey)
+        Self.markEnteredBackgroundOrInactiveImmediately()
     }
 
     /// Saves context that should be included if the app crashes.
@@ -271,12 +279,12 @@ actor WatchErrorReporter {
     func storePendingPayload(payloadId: String, type: String, filePath: String?) async {
         var pendingPayloads = UserDefaults.standard.array(forKey: pendingPayloadsKey) as? [[String: Any]] ?? []
 
-        let record: [String: Any] = [
+        var record: [String: Any] = [
             "payloadId": payloadId,
             "type": type,
-            "filePath": filePath as Any,
             "createdAtEpoch": Date().timeIntervalSince1970
         ]
+        if let filePath { record["filePath"] = filePath }
 
         pendingPayloads.append(record)
 
@@ -288,6 +296,10 @@ actor WatchErrorReporter {
             }
             return true
         }
+        guard JSONSerialization.isValidJSONObject(pendingPayloads) else {
+            UserDefaults.standard.removeObject(forKey: pendingPayloadsKey)
+            return
+        }
 
         UserDefaults.standard.set(pendingPayloads, forKey: pendingPayloadsKey)
     }
@@ -297,6 +309,10 @@ actor WatchErrorReporter {
         var pendingPayloads = UserDefaults.standard.array(forKey: pendingPayloadsKey) as? [[String: Any]] ?? []
         pendingPayloads.removeAll { record in
             record["payloadId"] as? String == payloadId
+        }
+        guard JSONSerialization.isValidJSONObject(pendingPayloads) else {
+            UserDefaults.standard.removeObject(forKey: pendingPayloadsKey)
+            return
         }
         UserDefaults.standard.set(pendingPayloads, forKey: pendingPayloadsKey)
     }

--- a/Trio Watch App Extension/WatchLogger.swift
+++ b/Trio Watch App Extension/WatchLogger.swift
@@ -10,8 +10,15 @@ actor WatchLogger {
     private let flushSizeThreshold = 100
     private var lastFlush = Date()
 
+    // Size caps
+    private let logSizeCap = 16 * 1024 // 16 KB
+    private let maxPerPayloadFiles = 20
+    private let maxFileAge: TimeInterval = 7 * 24 * 60 * 60 // 7 days
+
     private let session = WCSession.default
     private var timerTask: Task<Void, Never>?
+
+    private let pendingPayloadsKey = "watchLoggerPendingPayloads"
 
     private init() {
         Task {
@@ -51,7 +58,32 @@ actor WatchLogger {
         }
 
         print(entry)
+
+        // Also append to daily log for local debugging
+        await appendToDailyLog(entry)
+
         await flushIfNeeded(force: force)
+    }
+
+    /// Appends text to the daily local debug log (never sent to phone).
+    func appendToDailyLog(_ text: String) async {
+        let logDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+            .appendingPathComponent("logs", isDirectory: true)
+
+        try? FileManager.default.createDirectory(at: logDir, withIntermediateDirectories: true)
+
+        let dailyLogFile = logDir.appendingPathComponent("watch_log_daily.txt")
+        let logEntry = text + "\n"
+
+        if let data = logEntry.data(using: .utf8) {
+            if let handle = try? FileHandle(forWritingTo: dailyLogFile) {
+                _ = try? handle.seekToEnd()
+                handle.write(data)
+                try? handle.close()
+            } else {
+                try? data.write(to: dailyLogFile)
+            }
+        }
     }
 
     func flushIfNeeded(force: Bool = false) async {
@@ -68,83 +100,276 @@ actor WatchLogger {
             return
         }
 
-        let payload: [String: Any] = ["watchLogs": logs.joined(separator: "\n")]
+        // Capture logsToSend BEFORE sending
+        var logsToSend = logs.joined(separator: "\n")
 
-        if session.activationState != .activated {
-            session.activate()
+        // Truncate to size cap
+        if logsToSend.utf8.count > logSizeCap {
+            let cappedData = logsToSend.data(using: .utf8)?.prefix(logSizeCap) ?? Data()
+            logsToSend = String(data: cappedData, encoding: .utf8) ?? String(logsToSend.prefix(logSizeCap))
         }
 
-        if session.isReachable {
-            session.sendMessage(payload, replyHandler: nil) { _ in
-                Task {
-                    await self.persistLogsLocally()
-                }
-            }
-        } else {
-            await persistLogsLocally()
-        }
+        // Generate payloadId
+        let payloadId = UUID().uuidString
 
-        lastFlush = Date()
-        logs.removeAll()
-    }
-
-    func persistLogsLocally() async {
+        // Write to per-payload file BEFORE sending
         let logDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
             .appendingPathComponent("logs", isDirectory: true)
-
         try? FileManager.default.createDirectory(at: logDir, withIntermediateDirectories: true)
 
-        let logFile = logDir.appendingPathComponent("watch_log.txt")
-        let previousLogFile = logDir.appendingPathComponent("watch_log_prev.txt")
-        let startOfDay = Calendar.current.startOfDay(for: Date())
-
-        if let attributes = try? FileManager.default.attributesOfItem(atPath: logFile.path),
-           let creationDate = attributes[.creationDate] as? Date,
-           creationDate < startOfDay
-        {
-            try? FileManager.default.removeItem(at: previousLogFile)
-            try? FileManager.default.moveItem(at: logFile, to: previousLogFile)
-            FileManager.default.createFile(atPath: logFile.path, contents: nil, attributes: [.creationDate: startOfDay])
+        let perPayloadFile = logDir.appendingPathComponent("watch_log_\(payloadId).txt")
+        if let data = logsToSend.data(using: .utf8) {
+            try? data.write(to: perPayloadFile)
         }
 
-        let fullLog = logs.joined(separator: "\n") + "\n"
-        if let data = fullLog.data(using: .utf8) {
-            if let handle = try? FileHandle(forWritingTo: logFile) {
-                try? handle.seekToEnd()
-                handle.write(data)
-                try? handle.close()
-            } else {
-                try? data.write(to: logFile)
-            }
+        // Clear in-memory logs ONLY after file write
+        logs.removeAll()
+        lastFlush = Date()
+
+        // Create envelope
+        let envelope: [String: Any] = [
+            "type": "watchLogs",
+            "payloadId": payloadId,
+            "data": logsToSend
+        ]
+
+        // Do NOT activate session - WatchState owns activation
+        if session.isReachable && session.activationState == .activated {
+            // Use sendMessage with replyHandler for immediate ACK
+            let filePath = perPayloadFile.path
+            session.sendMessage(
+                envelope,
+                replyHandler: { reply in
+                    Task {
+                        // Check if ACK received
+                        if let ackType = reply["type"] as? String,
+                           ackType == "ack",
+                           let ackPayloadId = reply["payloadId"] as? String,
+                           ackPayloadId == payloadId {
+                            // ACK received - delete file
+                            try? FileManager.default.removeItem(at: perPayloadFile)
+                            await WatchLogger.shared.removePendingPayload(payloadId)
+                            await WatchLogger.shared.log("⌚️ Logs ACK received from phone for payloadId: \(payloadId)")
+                        }
+                    }
+                },
+                errorHandler: { error in
+                    Task {
+                        await WatchLogger.shared.log("⌚️ Failed to send logs to phone: \(error.localizedDescription)")
+                        // Keep file, mark as pending for retry
+                        await WatchLogger.shared.storePendingPayload(payloadId: payloadId, type: "watchLogs", filePath: filePath)
+                    }
+                }
+            )
+        } else {
+            // Not reachable - persist locally and mark as pending
+            await storePendingPayload(payloadId: payloadId, type: "watchLogs", filePath: perPayloadFile.path)
+            // Optionally use transferUserInfo for background delivery
+            _ = session.transferUserInfo(envelope)
+            await log("⌚️ Logs queued for background delivery to phone (payloadId: \(payloadId))")
         }
     }
 
     func flushPersistedLogs() async {
         let logDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
             .appendingPathComponent("logs", isDirectory: true)
-        let logFile = logDir.appendingPathComponent("watch_log.txt")
 
-        guard let data = try? Data(contentsOf: logFile),
-              let logString = String(data: data, encoding: .utf8),
-              !logString.isEmpty
-        else { return }
-
-        let payload: [String: Any] = ["watchLogs": logString]
-
-        if session.activationState != .activated {
-            session.activate()
+        // Scan for per-payload log files
+        guard let files = try? FileManager.default.contentsOfDirectory(at: logDir, includingPropertiesForKeys: [.creationDateKey, .fileSizeKey]) else {
+            return
         }
 
-        if session.isReachable {
-            session.sendMessage(payload, replyHandler: nil) { _ in
-                Task {
-                    await self.persistLogsLocally()
+        let perPayloadFiles = files.filter { file in
+            file.lastPathComponent.hasPrefix("watch_log_") &&
+            file.lastPathComponent.hasSuffix(".txt") &&
+            file.lastPathComponent != "watch_log_daily.txt"
+        }
+
+        // Apply retention caps
+        let now = Date()
+        var validFiles: [URL] = []
+        var filesToDelete: [URL] = []
+
+        for file in perPayloadFiles {
+            // Check age
+            if let attributes = try? FileManager.default.attributesOfItem(atPath: file.path),
+               let creationDate = attributes[.creationDate] as? Date {
+                let age = now.timeIntervalSince(creationDate)
+                if age > maxFileAge {
+                    filesToDelete.append(file)
+                    continue
                 }
             }
-            try? FileManager.default.removeItem(at: logFile)
-        } else {
-            _ = session.transferUserInfo(payload)
-            try? FileManager.default.removeItem(at: logFile)
+            validFiles.append(file)
         }
+
+        // Delete old files
+        for file in filesToDelete {
+            try? FileManager.default.removeItem(at: file)
+        }
+
+        // Enforce max files (keep most recent)
+        if validFiles.count > maxPerPayloadFiles {
+            // Sort by creation date, keep most recent
+            let sortedFiles = validFiles.sorted { file1, file2 in
+                let date1 = ((try? FileManager.default.attributesOfItem(atPath: file1.path))?[.creationDate] as? Date) ?? Date.distantPast
+                let date2 = ((try? FileManager.default.attributesOfItem(atPath: file2.path))?[.creationDate] as? Date) ?? Date.distantPast
+                return date1 > date2
+            }
+            let filesToRemove = sortedFiles.suffix(validFiles.count - maxPerPayloadFiles)
+            for file in filesToRemove {
+                try? FileManager.default.removeItem(at: file)
+            }
+            validFiles = Array(sortedFiles.prefix(maxPerPayloadFiles))
+        }
+
+        // If reachable, query ACKs first, then resend remaining files
+        if session.isReachable && session.activationState == .activated {
+            // 1. Query ACKs for pending payloads
+            let pendingPayloads = await getPendingPayloads()
+            let pendingIds = pendingPayloads.compactMap { $0["payloadId"] as? String }
+
+            if !pendingIds.isEmpty {
+                let queryEnvelope: [String: Any] = [
+                    "type": "queryAcks",
+                    "pendingIds": pendingIds
+                ]
+
+                session.sendMessage(
+                    queryEnvelope,
+                    replyHandler: { reply in
+                        Task {
+                            // Handle batchAck response
+                            if let batchAckType = reply["type"] as? String,
+                               batchAckType == "batchAck",
+                               let ackIds = reply["ackIds"] as? [String] {
+                                // Delete acknowledged files
+                                for ackId in ackIds {
+                                    let filePath = logDir.appendingPathComponent("watch_log_\(ackId).txt")
+                                    try? FileManager.default.removeItem(at: filePath)
+                                    await WatchLogger.shared.removePendingPayload(ackId)
+                                }
+                                // Resend remaining files
+                                await WatchLogger.shared.resendPendingPayloads()
+                            }
+                        }
+                    },
+                    errorHandler: { error in
+                        Task {
+                            await WatchLogger.shared.log("⌚️ Failed to query ACKs: \(error.localizedDescription)")
+                            // Still try to resend
+                            await WatchLogger.shared.resendPendingPayloads()
+                        }
+                    }
+                )
+            } else {
+                // No pending payloads, just resend any remaining files
+                await resendPendingPayloads()
+            }
+        } else {
+            // Not reachable - do NOT delete files, optionally use transferUserInfo
+            // Files will be resent when reachable
+        }
+    }
+
+    /// Resends pending payload files using sendMessage (not transferUserInfo) when reachable.
+    func resendPendingPayloads() async {
+        guard session.isReachable && session.activationState == .activated else {
+            return
+        }
+
+        // Get pending payloads
+        let pendingPayloads = await getPendingPayloads()
+
+        for pendingRecord in pendingPayloads {
+            guard let payloadId = pendingRecord["payloadId"] as? String,
+                  let type = pendingRecord["type"] as? String,
+                  type == "watchLogs",
+                  let filePath = pendingRecord["filePath"] as? String else {
+                continue
+            }
+
+            let fileURL = URL(fileURLWithPath: filePath)
+
+            // Read file
+            guard let data = try? Data(contentsOf: fileURL),
+                  let logString = String(data: data, encoding: .utf8),
+                  !logString.isEmpty else {
+                // File doesn't exist or is empty - remove from pending
+                await removePendingPayload(payloadId)
+                continue
+            }
+
+            // Create envelope
+            let envelope: [String: Any] = [
+                "type": "watchLogs",
+                "payloadId": payloadId,
+                "data": logString
+            ]
+
+            // Resend using sendMessage (not transferUserInfo) to get immediate ACK
+            session.sendMessage(
+                envelope,
+                replyHandler: { reply in
+                    Task {
+                        // Check if ACK received
+                        if let ackType = reply["type"] as? String,
+                           ackType == "ack",
+                           let ackPayloadId = reply["payloadId"] as? String,
+                           ackPayloadId == payloadId {
+                            // ACK received - delete file
+                            try? FileManager.default.removeItem(at: fileURL)
+                            await WatchLogger.shared.removePendingPayload(payloadId)
+                            await WatchLogger.shared.log("⌚️ Resent logs ACK received for payloadId: \(payloadId)")
+                        }
+                    }
+                },
+                errorHandler: { error in
+                    Task {
+                        await WatchLogger.shared.log("⌚️ Failed to resend logs for payloadId \(payloadId): \(error.localizedDescription)")
+                        // Keep file for next retry
+                    }
+                }
+            )
+        }
+    }
+
+    /// Stores a pending payload record for later ACK matching.
+    func storePendingPayload(payloadId: String, type: String, filePath: String) async {
+        var pendingPayloads = UserDefaults.standard.array(forKey: pendingPayloadsKey) as? [[String: Any]] ?? []
+
+        let record: [String: Any] = [
+            "payloadId": payloadId,
+            "type": type,
+            "filePath": filePath,
+            "createdAtEpoch": Date().timeIntervalSince1970
+        ]
+
+        pendingPayloads.append(record)
+
+        // Clean up old records (older than 7 days)
+        let now = Date().timeIntervalSince1970
+        pendingPayloads = pendingPayloads.filter { record in
+            if let createdAt = record["createdAtEpoch"] as? TimeInterval {
+                return (now - createdAt) < (7 * 24 * 60 * 60)
+            }
+            return true
+        }
+
+        UserDefaults.standard.set(pendingPayloads, forKey: pendingPayloadsKey)
+    }
+
+    /// Removes a pending payload record after ACK.
+    func removePendingPayload(_ payloadId: String) async {
+        var pendingPayloads = UserDefaults.standard.array(forKey: pendingPayloadsKey) as? [[String: Any]] ?? []
+        pendingPayloads.removeAll { record in
+            record["payloadId"] as? String == payloadId
+        }
+        UserDefaults.standard.set(pendingPayloads, forKey: pendingPayloadsKey)
+    }
+
+    /// Gets all pending payload records.
+    func getPendingPayloads() async -> [[String: Any]] {
+        return UserDefaults.standard.array(forKey: pendingPayloadsKey) as? [[String: Any]] ?? []
     }
 }

--- a/Trio Watch App Extension/WatchLogger.swift
+++ b/Trio Watch App Extension/WatchLogger.swift
@@ -1,9 +1,26 @@
 import Foundation
 import WatchConnectivity
 
+// MARK: - WCSession send completion (single resume for reply vs error)
+
+/// Ensures `CheckedContinuation.resume` runs at most once when either `replyHandler` or `errorHandler` fires.
+private final class WCSessionReplyGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var finished = false
+
+    func complete(_ continuation: CheckedContinuation<Void, Never>) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !finished else { return }
+        finished = true
+        continuation.resume()
+    }
+}
+
 actor WatchLogger {
     static let shared = WatchLogger()
 
+    private let build: String = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown"
     private var logs: [String] = []
     private let maxEntries = 500
     private let flushInterval: TimeInterval = 3 * 60
@@ -11,14 +28,27 @@ actor WatchLogger {
     private var lastFlush = Date()
 
     // Size caps
-    private let logSizeCap = 16 * 1024 // 16 KB
-    private let maxPerPayloadFiles = 20
-    private let maxFileAge: TimeInterval = 7 * 24 * 60 * 60 // 7 days
+    private let logSizeCap = 64 * 1024 // 64 KB
+    private let maxPerPayloadFiles = 10
+    private let maxFileAge: TimeInterval = 48 * 60 * 60 // 48 hours
 
     private let session = WCSession.default
     private var timerTask: Task<Void, Never>?
 
     private let pendingPayloadsKey = "watchLoggerPendingPayloads"
+    private let lastKnownBuildKey = "watchLogger.lastKnownBuild"
+    private let lastInventoryKey = "WatchLogger.lastInventoryTimestamp"
+
+    // E3: Inline metrics cache (10s TTL)
+    private var cachedWatchLogFiles: Int = 0
+    private var cachedDrainFiles: Int = 0
+    private var cachedCountsTimestamp: Date = .distantPast
+
+    /// Wall-clock cap for how long **this actor** waits on `sendMessage`’s reply/error callbacks.
+    /// This does **not** cancel in-flight `WCSession` delivery; a late `replyHandler` may still run.
+    /// Keep conservative on watchOS: long waits serialize the actor behind other lifecycle/flush work.
+    /// Raise only if telemetry shows healthy ACKs routinely exceed this under real devices.
+    private static let wcSessionSendTimeoutNs: UInt64 = 5 * 1_000_000_000
 
     private init() {
         Task {
@@ -26,11 +56,128 @@ actor WatchLogger {
         }
     }
 
-    private var dateFormatter: DateFormatter {
+    private static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
         return formatter
+    }()
+
+    // MARK: - File-removal helpers
+
+    struct RemoveResult {
+        let outcome: String // "deleted" | "missing" | "error"
+        let error: String? // nil → result=ok
+        var succeeded: Bool { error == nil }
     }
+
+    static func removeFileTracked(at url: URL) -> RemoveResult {
+        do {
+            try FileManager.default.removeItem(at: url)
+            return RemoveResult(outcome: "deleted", error: nil)
+        } catch {
+            let nsErr = error as NSError
+            if nsErr.domain == NSCocoaErrorDomain && nsErr.code == 4 {
+                return RemoveResult(outcome: "missing", error: nil)
+            }
+            return RemoveResult(
+                outcome: "error",
+                error: sanitizeError(error)
+            )
+        }
+    }
+
+    static func removeFileTracked(atPath path: String) -> RemoveResult {
+        do {
+            try FileManager.default.removeItem(atPath: path)
+            return RemoveResult(outcome: "deleted", error: nil)
+        } catch {
+            let nsErr = error as NSError
+            if nsErr.domain == NSCocoaErrorDomain && nsErr.code == 4 {
+                return RemoveResult(outcome: "missing", error: nil)
+            }
+            return RemoveResult(
+                outcome: "error",
+                error: sanitizeError(error)
+            )
+        }
+    }
+
+    /// Best-effort removal: true = gone (deleted or already absent),
+    /// false = unexpected error.
+    static func removeFileQuietly(at url: URL) -> Bool {
+        do {
+            try FileManager.default.removeItem(at: url)
+            return true
+        } catch {
+            let nsErr = error as NSError
+            return nsErr.domain == NSCocoaErrorDomain && nsErr.code == 4
+        }
+    }
+
+    static func sanitizeError(_ error: Error) -> String {
+        let nsErr = error as NSError
+        let raw = "\(nsErr.domain)_\(nsErr.code)"
+        let sanitized = raw
+            .replacingOccurrences(of: " ", with: "_")
+            .filter { $0.isLetter || $0.isNumber || $0 == "_" || $0 == "." }
+        return String(sanitized.prefix(50))
+    }
+
+    /// Non-blocking: nudges `activate()` and reports whether the session is already `.activated`
+    /// for an immediate `sendMessage`. Avoids multi-second polling on hot paths.
+    private func prepareSessionForImmediateSend() -> Bool {
+        if session.activationState == .activated { return true }
+        session.activate()
+        return session.activationState == .activated
+    }
+
+    /// Awaits `sendMessage` until reply, error, or **actor-side** timeout.
+    ///
+    /// **Semantics:** The timeout only bounds how long `WatchLogger` suspends; it does not cancel the
+    /// underlying session send. If the phone ACKs later, `replyHandler` may still run; `WCSessionReplyGate`
+    /// ensures the continuation resumes at most once, while `onReply` cleanup stays idempotent
+    /// (`removeFileTracked` / `removePendingPayload` tolerate missing files).
+    ///
+    /// **Pending:** Call sites that need recovery must `storePendingPayload` *before* awaiting here.
+    /// On timeout we **do not** enqueue `transferUserInfo` automatically (avoids duplicate delivery);
+    /// the payload row + on-disk file remain for `resendPendingPayloads` / a later ACK.
+    private func sendMessageAwaitingReply(
+        _ envelope: [String: Any],
+        context: String,
+        onReply: @escaping ([String: Any]) async -> Void,
+        onError: @escaping (Error) async -> Void
+    ) async {
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            let gate = WCSessionReplyGate()
+            let timeoutTask = Task {
+                try? await Task.sleep(nanoseconds: Self.wcSessionSendTimeoutNs)
+                await WatchLogger.shared.log(
+                    "⌚️ WCSession sendMessage timed out context=\(context)"
+                        + " note=payload_still_pending no_auto_transferUserInfo"
+                )
+                gate.complete(cont)
+            }
+            session.sendMessage(
+                envelope,
+                replyHandler: { reply in
+                    Task {
+                        timeoutTask.cancel()
+                        defer { gate.complete(cont) }
+                        await onReply(reply)
+                    }
+                },
+                errorHandler: { error in
+                    Task {
+                        timeoutTask.cancel()
+                        defer { gate.complete(cont) }
+                        await onError(error)
+                    }
+                }
+            )
+        }
+    }
+
+    // MARK: - Timer
 
     private func startFlushTimer() async {
         timerTask = Task {
@@ -41,6 +188,8 @@ actor WatchLogger {
         }
     }
 
+    // MARK: - Logging
+
     func log(
         _ message: String,
         force: Bool = false,
@@ -49,8 +198,8 @@ actor WatchLogger {
         line: Int = #line
     ) async {
         let shortFile = (file as NSString).lastPathComponent
-        let timestamp = dateFormatter.string(from: Date())
-        let entry = "[\(timestamp)] [\(shortFile):\(line)] \(function) → \(message)"
+        let timestamp = Self.dateFormatter.string(from: Date())
+        let entry = "[\(timestamp)] [b:\(build)] [\(shortFile):\(line)] \(function) → \(message)"
 
         logs.append(entry)
         if logs.count > maxEntries {
@@ -59,7 +208,6 @@ actor WatchLogger {
 
         print(entry)
 
-        // Also append to daily log for local debugging
         await appendToDailyLog(entry)
 
         await flushIfNeeded(force: force)
@@ -67,10 +215,13 @@ actor WatchLogger {
 
     /// Appends text to the daily local debug log (never sent to phone).
     func appendToDailyLog(_ text: String) async {
-        let logDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-            .appendingPathComponent("logs", isDirectory: true)
+        let logDir = FileManager.default.urls(
+            for: .documentDirectory, in: .userDomainMask
+        ).first!.appendingPathComponent("logs", isDirectory: true)
 
-        try? FileManager.default.createDirectory(at: logDir, withIntermediateDirectories: true)
+        try? FileManager.default.createDirectory(
+            at: logDir, withIntermediateDirectories: true
+        )
 
         let dailyLogFile = logDir.appendingPathComponent("watch_log_daily.txt")
         let logEntry = text + "\n"
@@ -86,9 +237,13 @@ actor WatchLogger {
         }
     }
 
+    // MARK: - Flush
+
     func flushIfNeeded(force: Bool = false) async {
         let now = Date()
-        let shouldFlush = force || now.timeIntervalSince(lastFlush) >= flushInterval || logs.count >= flushSizeThreshold
+        let shouldFlush = force
+            || now.timeIntervalSince(lastFlush) >= flushInterval
+            || logs.count >= flushSizeThreshold
 
         if shouldFlush {
             await flushToPhone()
@@ -96,247 +251,481 @@ actor WatchLogger {
     }
 
     private func flushToPhone() async {
-        guard !logs.isEmpty else {
-            return
-        }
+        guard !logs.isEmpty else { return }
 
-        // Capture logsToSend BEFORE sending
-        var logsToSend = logs.joined(separator: "\n")
+        updateCachedCountsIfStale()
+        await logFileInventory()
 
-        // Truncate to size cap
-        if logsToSend.utf8.count > logSizeCap {
-            let cappedData = logsToSend.data(using: .utf8)?.prefix(logSizeCap) ?? Data()
-            logsToSend = String(data: cappedData, encoding: .utf8) ?? String(logsToSend.prefix(logSizeCap))
-        }
+        let allContent = logs.joined(separator: "\n")
+        let originalUTF8Count = allContent.utf8.count
+        let totalLineCount = logs.count
+        let originalLines = logs
 
-        // Generate payloadId
-        let payloadId = UUID().uuidString
-
-        // Write to per-payload file BEFORE sending
-        let logDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-            .appendingPathComponent("logs", isDirectory: true)
-        try? FileManager.default.createDirectory(at: logDir, withIntermediateDirectories: true)
-
-        let perPayloadFile = logDir.appendingPathComponent("watch_log_\(payloadId).txt")
-        if let data = logsToSend.data(using: .utf8) {
-            try? data.write(to: perPayloadFile)
-        }
-
-        // Clear in-memory logs ONLY after file write
         logs.removeAll()
         lastFlush = Date()
 
-        // Create envelope
-        let envelope: [String: Any] = [
-            "type": "watchLogs",
-            "payloadId": payloadId,
-            "data": logsToSend
-        ]
-
-        // Do NOT activate session - WatchState owns activation
-        if session.isReachable && session.activationState == .activated {
-            // Use sendMessage with replyHandler for immediate ACK
-            let filePath = perPayloadFile.path
-            session.sendMessage(
-                envelope,
-                replyHandler: { reply in
-                    Task {
-                        // Check if ACK received
-                        if let ackType = reply["type"] as? String,
-                           ackType == "ack",
-                           let ackPayloadId = reply["payloadId"] as? String,
-                           ackPayloadId == payloadId {
-                            // ACK received - delete file
-                            try? FileManager.default.removeItem(at: perPayloadFile)
-                            await WatchLogger.shared.removePendingPayload(payloadId)
-                            await WatchLogger.shared.log("⌚️ Logs ACK received from phone for payloadId: \(payloadId)")
-                        }
-                    }
-                },
-                errorHandler: { error in
-                    Task {
-                        await WatchLogger.shared.log("⌚️ Failed to send logs to phone: \(error.localizedDescription)")
-                        // Keep file, mark as pending for retry
-                        await WatchLogger.shared.storePendingPayload(payloadId: payloadId, type: "watchLogs", filePath: filePath)
-                    }
-                }
-            )
-        } else {
-            // Not reachable - persist locally and mark as pending
-            await storePendingPayload(payloadId: payloadId, type: "watchLogs", filePath: perPayloadFile.path)
-            // Optionally use transferUserInfo for background delivery
-            _ = session.transferUserInfo(envelope)
-            await log("⌚️ Logs queued for background delivery to phone (payloadId: \(payloadId))")
-        }
-    }
-
-    func flushPersistedLogs() async {
-        let logDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-            .appendingPathComponent("logs", isDirectory: true)
-
-        // Scan for per-payload log files
-        guard let files = try? FileManager.default.contentsOfDirectory(at: logDir, includingPropertiesForKeys: [.creationDateKey, .fileSizeKey]) else {
+        // Single payload fits within cap — send directly
+        if originalUTF8Count <= logSizeCap {
+            await sendLogPayload(allContent)
             return
         }
 
-        let perPayloadFiles = files.filter { file in
-            file.lastPathComponent.hasPrefix("watch_log_") &&
-            file.lastPathComponent.hasSuffix(".txt") &&
-            file.lastPathComponent != "watch_log_daily.txt"
+        // 4E: Split oversized payloads into sequential chunks (max 4 × logSizeCap)
+        let maxChunks = 4
+        let groupId = UUID().uuidString
+
+        // Content budget per chunk: logSizeCap minus worst-case chunk marker overhead.
+        // Marker byte cost is subtracted so the total chunk payload stays within logSizeCap.
+        let worstCaseMarker = "📦 log_flush_chunk chunk=\(maxChunks)/\(maxChunks) payload_id=\(groupId) lines_in_chunk=\(totalLineCount)"
+        let markerOverhead = worstCaseMarker.utf8.count + 1
+        let contentBudget = max(1, logSizeCap - markerOverhead)
+
+        // Pack lines greedily into chunks (line-boundary-aware)
+        var chunks: [(content: String, lineCount: Int)] = []
+        var currentLines: [String] = []
+        var currentBytes = 0
+        var lineIndex = 0
+
+        while lineIndex < originalLines.count {
+            let line = originalLines[lineIndex]
+            let addedBytes = (currentLines.isEmpty ? 0 : 1) + line.utf8.count
+
+            if currentBytes + addedBytes > contentBudget && !currentLines.isEmpty {
+                chunks.append((
+                    content: currentLines.joined(separator: "\n"),
+                    lineCount: currentLines.count
+                ))
+                currentLines = []
+                currentBytes = 0
+
+                if chunks.count >= maxChunks - 1 {
+                    // Last allowed chunk — pack all remaining lines
+                    let remaining = Array(originalLines[lineIndex...])
+                    let remainingContent = remaining.joined(separator: "\n")
+
+                    if remainingContent.utf8.count <= contentBudget {
+                        chunks.append((content: remainingContent, lineCount: remaining.count))
+                    } else {
+                        // 4A truncation on the last chunk
+                        let truncMarker = "⚠️ log_flush_truncated cap_bytes=\(logSizeCap) original_bytes=\(originalUTF8Count) lines_total=\(totalLineCount)"
+                        let truncMarkerBytes = truncMarker.utf8.count + 1
+                        let truncBudget = max(0, contentBudget - truncMarkerBytes)
+
+                        var truncLines: [String] = []
+                        var truncBytes = 0
+                        for rl in remaining {
+                            let added = (truncLines.isEmpty ? 0 : 1) + rl.utf8.count
+                            if truncBytes + added > truncBudget { break }
+                            truncLines.append(rl)
+                            truncBytes += added
+                        }
+
+                        let truncContent = truncMarker + "\n" + truncLines.joined(separator: "\n")
+                        chunks.append((content: truncContent, lineCount: truncLines.count))
+                    }
+                    lineIndex = originalLines.count
+                    break
+                }
+                continue
+            }
+
+            currentLines.append(line)
+            currentBytes += addedBytes
+            lineIndex += 1
         }
 
-        // Apply retention caps
+        if !currentLines.isEmpty {
+            chunks.append((
+                content: currentLines.joined(separator: "\n"),
+                lineCount: currentLines.count
+            ))
+        }
+
+        let totalChunks = chunks.count
+
+        for (index, chunk) in chunks.enumerated() {
+            let chunkNumber = index + 1
+            let chunkMarker = "📦 log_flush_chunk chunk=\(chunkNumber)/\(totalChunks) payload_id=\(groupId) lines_in_chunk=\(chunk.lineCount)"
+            let finalContent = chunkMarker + "\n" + chunk.content
+            await sendLogPayload(finalContent)
+        }
+    }
+
+    /// Sends a single log payload (or chunk) to the phone via WCSession.
+    private func sendLogPayload(_ content: String) async {
+        let payloadId = UUID().uuidString
+
+        let logDir = FileManager.default.urls(
+            for: .documentDirectory, in: .userDomainMask
+        ).first!.appendingPathComponent("logs", isDirectory: true)
+        try? FileManager.default.createDirectory(
+            at: logDir, withIntermediateDirectories: true
+        )
+
+        let perPayloadFile = logDir.appendingPathComponent(
+            "watch_log_\(payloadId).txt"
+        )
+        if let data = content.data(using: .utf8) {
+            try? data.write(to: perPayloadFile)
+        }
+
+        let envelope: [String: Any] = [
+            "type": "watchLogs",
+            "payloadId": payloadId,
+            "data": content
+        ]
+
+        if session.isReachable {
+            guard prepareSessionForImmediateSend() else {
+                await storePendingPayload(
+                    payloadId: payloadId,
+                    type: "watchLogs",
+                    filePath: perPayloadFile.path
+                )
+                _ = session.transferUserInfo(envelope)
+                await log(
+                    "⌚️ Logs queued for background delivery"
+                        + " (payloadId: \(payloadId))"
+                        + " watch_log_files=\(cachedWatchLogFiles)"
+                        + " drain_files=\(cachedDrainFiles)"
+                        + " note=activation_timeout"
+                )
+                return
+            }
+
+            let filePath = perPayloadFile.path
+            await storePendingPayload(
+                payloadId: payloadId,
+                type: "watchLogs",
+                filePath: filePath
+            )
+            await sendMessageAwaitingReply(
+                envelope,
+                context: "flush payloadId=\(payloadId)"
+            ) { reply in
+                if let ackType = reply["type"] as? String,
+                   ackType == "ack",
+                   let ackId = WatchConnectivityPayloadIds.payloadIdString(
+                       reply["payloadId"]
+                   ),
+                   ackId == payloadId {
+                    let res = WatchLogger.removeFileTracked(
+                        at: perPayloadFile
+                    )
+                    if res.succeeded {
+                        await WatchLogger.shared
+                            .removePendingPayload(payloadId)
+                    }
+                    await WatchLogger.shared
+                        .logCleanup(
+                            path: "ack_reply", flow: "flush",
+                            artifact: "watch_log",
+                            payloadId: payloadId,
+                            result: res
+                        )
+                }
+            } onError: { error in
+                await WatchLogger.shared.log(
+                    "⌚️ Failed to send logs: "
+                        + error.localizedDescription
+                )
+            }
+        } else {
+            await storePendingPayload(
+                payloadId: payloadId,
+                type: "watchLogs",
+                filePath: perPayloadFile.path
+            )
+            _ = session.transferUserInfo(envelope)
+            await log(
+                "⌚️ Logs queued for background delivery"
+                    + " (payloadId: \(payloadId))"
+                    + " watch_log_files=\(cachedWatchLogFiles)"
+                    + " drain_files=\(cachedDrainFiles)"
+            )
+        }
+    }
+
+    // MARK: - Persisted log flush + retention
+
+    func flushPersistedLogs() async {
+        let lastKnownBuild = UserDefaults.standard.string(
+            forKey: lastKnownBuildKey
+        )
+        if lastKnownBuild != build {
+            UserDefaults.standard.set(build, forKey: lastKnownBuildKey)
+            await log(
+                "[UPGRADE] build changed"
+                    + " from \(lastKnownBuild ?? "nil") to \(build)",
+                force: true
+            )
+        }
+
+        updateCachedCountsIfStale()
+        await logFileInventory()
+
+        await drainComplicationLogs()
+
+        let logDir = FileManager.default.urls(
+            for: .documentDirectory, in: .userDomainMask
+        ).first!.appendingPathComponent("logs", isDirectory: true)
+
+        guard let files = try? FileManager.default.contentsOfDirectory(
+            at: logDir,
+            includingPropertiesForKeys: [.creationDateKey, .fileSizeKey]
+        ) else { return }
+
+        let perPayloadFiles = files.filter { file in
+            file.lastPathComponent.hasPrefix("watch_log_")
+                && file.lastPathComponent.hasSuffix(".txt")
+                && file.lastPathComponent != "watch_log_daily.txt"
+        }
+
+        _ = await applyWatchLogRetention(
+            perPayloadFiles: perPayloadFiles
+        )
+
+        guard session.isReachable else { return }
+
+        if !prepareSessionForImmediateSend() {
+            await log(
+                "⌚️ flush_persisted_logs skipping_query_acks"
+                    + " note=session_not_activated"
+            )
+            return
+        }
+
+        let pendingPayloads = await getPendingPayloads()
+        let pendingIds = pendingPayloads.compactMap {
+            WatchConnectivityPayloadIds.payloadIdString($0["payloadId"])
+        }
+
+        if !pendingIds.isEmpty {
+            let queryEnvelope: [String: Any] = [
+                "type": "queryAcks",
+                "pendingIds": pendingIds
+            ]
+            await sendMessageAwaitingReply(
+                queryEnvelope,
+                context: "query_acks"
+            ) { reply in
+                guard let ackType = reply["type"] as? String,
+                      ackType == "batchAck"
+                else {
+                    await WatchLogger.shared.resendPendingPayloads()
+                    return
+                }
+
+                let ackIds = WatchConnectivityPayloadIds.payloadIdStrings(
+                    from: reply["ackIds"]
+                )
+
+                if ackIds.isEmpty {
+                    await WatchLogger.shared.resendPendingPayloads()
+                    return
+                }
+
+                var errCount = 0
+                for ackId in ackIds {
+                    let path = logDir.appendingPathComponent(
+                        "watch_log_\(ackId).txt"
+                    )
+                    if WatchLogger.removeFileQuietly(at: path) {
+                        await WatchLogger.shared
+                            .removePendingPayload(ackId)
+                    } else {
+                        errCount += 1
+                    }
+                }
+                let result = errCount > 0 ? "err" : "ok"
+                await WatchLogger.shared.log(
+                    "⌚️ [CLEANUP] path=query_acks"
+                        + " artifact=watch_log"
+                        + " count=\(ackIds.count)"
+                        + " result=\(result)"
+                )
+                await WatchLogger.shared
+                    .resendPendingPayloads()
+            } onError: { error in
+                await WatchLogger.shared.log(
+                    "⌚️ Failed to query ACKs: "
+                        + error.localizedDescription
+                )
+                await WatchLogger.shared.resendPendingPayloads()
+            }
+        } else {
+            await resendPendingPayloads()
+        }
+    }
+
+    /// Deletes age-expired and excess watch_log files, emits a
+    /// [CLEANUP] retention summary when any files are removed.
+    /// Returns the surviving file list.
+    private func applyWatchLogRetention(
+        perPayloadFiles: [URL]
+    ) async -> [URL] {
         let now = Date()
         var validFiles: [URL] = []
-        var filesToDelete: [URL] = []
+        var expiredFiles: [URL] = []
+        var oldestDeletedAge: TimeInterval = 0
 
         for file in perPayloadFiles {
-            // Check age
-            if let attributes = try? FileManager.default.attributesOfItem(atPath: file.path),
-               let creationDate = attributes[.creationDate] as? Date {
-                let age = now.timeIntervalSince(creationDate)
+            if let attrs = try? FileManager.default.attributesOfItem(
+                atPath: file.path
+            ),
+                let created = attrs[.creationDate] as? Date {
+                let age = now.timeIntervalSince(created)
                 if age > maxFileAge {
-                    filesToDelete.append(file)
+                    expiredFiles.append(file)
+                    oldestDeletedAge = max(oldestDeletedAge, age)
                     continue
                 }
             }
             validFiles.append(file)
         }
 
-        // Delete old files
-        for file in filesToDelete {
-            try? FileManager.default.removeItem(at: file)
-        }
+        var deletedCount = 0
+        var errCount = 0
 
-        // Enforce max files (keep most recent)
-        if validFiles.count > maxPerPayloadFiles {
-            // Sort by creation date, keep most recent
-            let sortedFiles = validFiles.sorted { file1, file2 in
-                let date1 = ((try? FileManager.default.attributesOfItem(atPath: file1.path))?[.creationDate] as? Date) ?? Date.distantPast
-                let date2 = ((try? FileManager.default.attributesOfItem(atPath: file2.path))?[.creationDate] as? Date) ?? Date.distantPast
-                return date1 > date2
-            }
-            let filesToRemove = sortedFiles.suffix(validFiles.count - maxPerPayloadFiles)
-            for file in filesToRemove {
-                try? FileManager.default.removeItem(at: file)
-            }
-            validFiles = Array(sortedFiles.prefix(maxPerPayloadFiles))
-        }
-
-        // If reachable, query ACKs first, then resend remaining files
-        if session.isReachable && session.activationState == .activated {
-            // 1. Query ACKs for pending payloads
-            let pendingPayloads = await getPendingPayloads()
-            let pendingIds = pendingPayloads.compactMap { $0["payloadId"] as? String }
-
-            if !pendingIds.isEmpty {
-                let queryEnvelope: [String: Any] = [
-                    "type": "queryAcks",
-                    "pendingIds": pendingIds
-                ]
-
-                session.sendMessage(
-                    queryEnvelope,
-                    replyHandler: { reply in
-                        Task {
-                            // Handle batchAck response
-                            if let batchAckType = reply["type"] as? String,
-                               batchAckType == "batchAck",
-                               let ackIds = reply["ackIds"] as? [String] {
-                                // Delete acknowledged files
-                                for ackId in ackIds {
-                                    let filePath = logDir.appendingPathComponent("watch_log_\(ackId).txt")
-                                    try? FileManager.default.removeItem(at: filePath)
-                                    await WatchLogger.shared.removePendingPayload(ackId)
-                                }
-                                // Resend remaining files
-                                await WatchLogger.shared.resendPendingPayloads()
-                            }
-                        }
-                    },
-                    errorHandler: { error in
-                        Task {
-                            await WatchLogger.shared.log("⌚️ Failed to query ACKs: \(error.localizedDescription)")
-                            // Still try to resend
-                            await WatchLogger.shared.resendPendingPayloads()
-                        }
-                    }
-                )
+        for file in expiredFiles {
+            if Self.removeFileQuietly(at: file) {
+                deletedCount += 1
             } else {
-                // No pending payloads, just resend any remaining files
-                await resendPendingPayloads()
+                errCount += 1
             }
-        } else {
-            // Not reachable - do NOT delete files, optionally use transferUserInfo
-            // Files will be resent when reachable
         }
+
+        if validFiles.count > maxPerPayloadFiles {
+            let sorted = validFiles.sorted { f1, f2 in
+                let d1 = ((try? FileManager.default.attributesOfItem(
+                    atPath: f1.path
+                ))?[.creationDate] as? Date) ?? .distantPast
+                let d2 = ((try? FileManager.default.attributesOfItem(
+                    atPath: f2.path
+                ))?[.creationDate] as? Date) ?? .distantPast
+                return d1 > d2
+            }
+            let excess = sorted.suffix(
+                validFiles.count - maxPerPayloadFiles
+            )
+            for file in excess {
+                if let attrs = try? FileManager.default.attributesOfItem(
+                    atPath: file.path
+                ),
+                    let created = attrs[.creationDate] as? Date {
+                    oldestDeletedAge = max(
+                        oldestDeletedAge, now.timeIntervalSince(created)
+                    )
+                }
+                if Self.removeFileQuietly(at: file) {
+                    deletedCount += 1
+                } else {
+                    errCount += 1
+                }
+            }
+            validFiles = Array(sorted.prefix(maxPerPayloadFiles))
+        }
+
+        if deletedCount > 0 || errCount > 0 {
+            let hours = Int(oldestDeletedAge / 3600)
+            let result = errCount > 0 ? "err" : "ok"
+            await log(
+                "⌚️ [CLEANUP] path=retention artifact=watch_log"
+                    + " deleted=\(deletedCount)"
+                    + " remaining=\(validFiles.count)"
+                    + " oldest_age_hours=\(hours)"
+                    + " result=\(result)"
+            )
+        }
+
+        return validFiles
     }
 
-    /// Resends pending payload files using sendMessage (not transferUserInfo) when reachable.
+    // MARK: - Resend pending payloads
+
     func resendPendingPayloads() async {
-        guard session.isReachable && session.activationState == .activated else {
+        guard session.isReachable else { return }
+        guard prepareSessionForImmediateSend() else {
+            await log(
+                "⌚️ resend_pending_payloads skipped"
+                    + " note=session_not_activated"
+            )
             return
         }
 
-        // Get pending payloads
         let pendingPayloads = await getPendingPayloads()
 
-        for pendingRecord in pendingPayloads {
-            guard let payloadId = pendingRecord["payloadId"] as? String,
-                  let type = pendingRecord["type"] as? String,
+        for record in pendingPayloads {
+            guard let payloadId = WatchConnectivityPayloadIds.payloadIdString(
+                      record["payloadId"]
+                  ),
+                  let type = record["type"] as? String,
                   type == "watchLogs",
-                  let filePath = pendingRecord["filePath"] as? String else {
-                continue
-            }
+                  let filePath = record["filePath"] as? String
+            else { continue }
 
             let fileURL = URL(fileURLWithPath: filePath)
 
-            // Read file
             guard let data = try? Data(contentsOf: fileURL),
                   let logString = String(data: data, encoding: .utf8),
-                  !logString.isEmpty else {
-                // File doesn't exist or is empty - remove from pending
+                  !logString.isEmpty
+            else {
                 await removePendingPayload(payloadId)
                 continue
             }
 
-            // Create envelope
             let envelope: [String: Any] = [
                 "type": "watchLogs",
                 "payloadId": payloadId,
                 "data": logString
             ]
 
-            // Resend using sendMessage (not transferUserInfo) to get immediate ACK
-            session.sendMessage(
+            await sendMessageAwaitingReply(
                 envelope,
-                replyHandler: { reply in
-                    Task {
-                        // Check if ACK received
-                        if let ackType = reply["type"] as? String,
-                           ackType == "ack",
-                           let ackPayloadId = reply["payloadId"] as? String,
-                           ackPayloadId == payloadId {
-                            // ACK received - delete file
-                            try? FileManager.default.removeItem(at: fileURL)
-                            await WatchLogger.shared.removePendingPayload(payloadId)
-                            await WatchLogger.shared.log("⌚️ Resent logs ACK received for payloadId: \(payloadId)")
-                        }
+                context: "resend payloadId=\(payloadId)"
+            ) { reply in
+                if let ackType = reply["type"] as? String,
+                   ackType == "ack",
+                   let ackId = WatchConnectivityPayloadIds.payloadIdString(
+                       reply["payloadId"]
+                   ),
+                   ackId == payloadId {
+                    let res = WatchLogger.removeFileTracked(
+                        at: fileURL
+                    )
+                    if res.succeeded {
+                        await WatchLogger.shared
+                            .removePendingPayload(payloadId)
                     }
-                },
-                errorHandler: { error in
-                    Task {
-                        await WatchLogger.shared.log("⌚️ Failed to resend logs for payloadId \(payloadId): \(error.localizedDescription)")
-                        // Keep file for next retry
-                    }
+                    await WatchLogger.shared
+                        .logCleanup(
+                            path: "ack_reply", flow: "resend",
+                            artifact: "watch_log",
+                            payloadId: payloadId,
+                            result: res
+                        )
                 }
-            )
+            } onError: { error in
+                await WatchLogger.shared.log(
+                    "⌚️ Failed to resend for \(payloadId): "
+                        + error.localizedDescription
+                )
+            }
         }
     }
 
-    /// Stores a pending payload record for later ACK matching.
-    func storePendingPayload(payloadId: String, type: String, filePath: String) async {
-        var pendingPayloads = UserDefaults.standard.array(forKey: pendingPayloadsKey) as? [[String: Any]] ?? []
+    // MARK: - Pending payload storage
+
+    /// Replaces any existing pending row with the same `payloadId` before append, so repeated
+    /// failures for one payload cannot multiply list entries (only `createdAtEpoch` refreshes).
+    func storePendingPayload(
+        payloadId: String, type: String, filePath: String
+    ) async {
+        var pending = UserDefaults.standard.array(
+            forKey: pendingPayloadsKey
+        ) as? [[String: Any]] ?? []
+
+        pending.removeAll { $0["payloadId"] as? String == payloadId }
 
         let record: [String: Any] = [
             "payloadId": payloadId,
@@ -344,32 +733,477 @@ actor WatchLogger {
             "filePath": filePath,
             "createdAtEpoch": Date().timeIntervalSince1970
         ]
+        pending.append(record)
 
-        pendingPayloads.append(record)
-
-        // Clean up old records (older than 7 days)
         let now = Date().timeIntervalSince1970
-        pendingPayloads = pendingPayloads.filter { record in
-            if let createdAt = record["createdAtEpoch"] as? TimeInterval {
-                return (now - createdAt) < (7 * 24 * 60 * 60)
+        pending = pending.filter { rec in
+            if let t = rec["createdAtEpoch"] as? TimeInterval {
+                return (now - t) < maxFileAge
             }
             return true
         }
 
-        UserDefaults.standard.set(pendingPayloads, forKey: pendingPayloadsKey)
+        UserDefaults.standard.set(pending, forKey: pendingPayloadsKey)
     }
 
-    /// Removes a pending payload record after ACK.
     func removePendingPayload(_ payloadId: String) async {
-        var pendingPayloads = UserDefaults.standard.array(forKey: pendingPayloadsKey) as? [[String: Any]] ?? []
-        pendingPayloads.removeAll { record in
-            record["payloadId"] as? String == payloadId
-        }
-        UserDefaults.standard.set(pendingPayloads, forKey: pendingPayloadsKey)
+        var pending = UserDefaults.standard.array(
+            forKey: pendingPayloadsKey
+        ) as? [[String: Any]] ?? []
+        pending.removeAll { $0["payloadId"] as? String == payloadId }
+        UserDefaults.standard.set(pending, forKey: pendingPayloadsKey)
     }
 
-    /// Gets all pending payload records.
     func getPendingPayloads() async -> [[String: Any]] {
-        return UserDefaults.standard.array(forKey: pendingPayloadsKey) as? [[String: Any]] ?? []
+        UserDefaults.standard.array(
+            forKey: pendingPayloadsKey
+        ) as? [[String: Any]] ?? []
+    }
+
+    // MARK: - Drain File Cleanup
+
+    /// Deletes drain files and pending payload records for the given
+    /// payloadIds. Idempotent: tolerates missing files, duplicate calls,
+    /// and overlap between batchAck and watchLogConfirm.
+    /// Emits per-artifact-type [CLEANUP] events.
+    func deleteFilesForPayloadIds(_ ids: [String]) async {
+        let pendingPayloads = await getPendingPayloads()
+        let pendingByPayloadId = Dictionary(
+            pendingPayloads.compactMap { rec -> (String, String)? in
+                guard let pid = WatchConnectivityPayloadIds.payloadIdString(
+                          rec["payloadId"]
+                      ),
+                      let path = rec["filePath"] as? String
+                else { return nil }
+                return (pid, path)
+            },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let logsDir = ComplicationLogBuffer.sharedContainerURL()?
+            .appendingPathComponent("logs", isDirectory: true)
+
+        var watchLogOk = 0, watchLogErr = 0
+        var pendingRecordCount = 0
+        var drainOk = 0, drainErr = 0
+
+        for id in ids {
+            var watchLogFailed = false
+            if let filePath = pendingByPayloadId[id] {
+                let res = Self.removeFileTracked(atPath: filePath)
+                if res.succeeded {
+                    watchLogOk += 1
+                } else {
+                    watchLogErr += 1
+                    watchLogFailed = true
+                }
+            }
+
+            if !watchLogFailed {
+                await removePendingPayload(id)
+                pendingRecordCount += 1
+            }
+
+            if let logsDir {
+                let drainFile = logsDir.appendingPathComponent(
+                    "complication_log.drain.\(id).txt"
+                )
+                let res = Self.removeFileTracked(at: drainFile)
+                if res.succeeded { drainOk += 1 }
+                else { drainErr += 1 }
+            }
+        }
+
+        let sampleIds = ids.prefix(3).joined(separator: "|")
+        if watchLogOk + watchLogErr > 0 {
+            let result = watchLogErr > 0 ? "err" : "ok"
+            await log(
+                "⌚️ [CLEANUP] path=confirm artifact=watch_log"
+                    + " count=\(watchLogOk + watchLogErr)"
+                    + " sample_ids=\(sampleIds)"
+                    + " result=\(result)"
+            )
+        }
+        if pendingRecordCount > 0 {
+            await log(
+                "⌚️ [CLEANUP] path=confirm"
+                    + " artifact=pending_record"
+                    + " count=\(pendingRecordCount) result=ok"
+            )
+        }
+        if drainOk + drainErr > 0 {
+            let result = drainErr > 0 ? "err" : "ok"
+            await log(
+                "⌚️ [CLEANUP] path=confirm artifact=drain"
+                    + " count=\(drainOk + drainErr)"
+                    + " result=\(result)"
+            )
+        }
+    }
+
+    // MARK: - Complication Log Drain
+
+    private func drainComplicationLogs() async {
+        guard let containerURL = ComplicationLogBuffer
+            .sharedContainerURL() else { return }
+
+        let logsDir = containerURL.appendingPathComponent(
+            "logs", isDirectory: true
+        )
+        let fileManager = FileManager.default
+
+        guard let allFiles = try? fileManager.contentsOfDirectory(
+            at: logsDir, includingPropertiesForKeys: [.creationDateKey]
+        ) else { return }
+
+        var drainFiles = allFiles
+            .filter {
+                $0.lastPathComponent.hasPrefix("complication_log.drain.")
+                    && $0.lastPathComponent.hasSuffix(".txt")
+            }
+            .sorted { url1, url2 in
+                let d1 = (try? url1.resourceValues(
+                    forKeys: [.creationDateKey]
+                ).creationDate) ?? .distantPast
+                let d2 = (try? url2.resourceValues(
+                    forKeys: [.creationDateKey]
+                ).creationDate) ?? .distantPast
+                return d1 < d2
+            }
+
+        drainFiles = await applyDrainRetention(
+            drainFiles: drainFiles
+        )
+
+        for drainFile in drainFiles {
+            await sendLogContentFromFile(fileURL: drainFile)
+        }
+
+        let logFile = logsDir.appendingPathComponent("complication_log.txt")
+        guard fileManager.fileExists(atPath: logFile.path) else { return }
+
+        let drainURL = logsDir.appendingPathComponent(
+            "complication_log.drain.\(UUID().uuidString).txt"
+        )
+        do {
+            try fileManager.moveItem(at: logFile, to: drainURL)
+        } catch {
+            return
+        }
+
+        await sendLogContentFromFile(fileURL: drainURL)
+    }
+
+    /// Deletes drain files exceeding maxFileAge or maxPerPayloadFiles,
+    /// emits [CLEANUP] retention summary. Returns surviving files.
+    private func applyDrainRetention(
+        drainFiles: [URL]
+    ) async -> [URL] {
+        let now = Date()
+        var deletedCount = 0
+        var errCount = 0
+        var oldestDeletedAge: TimeInterval = 0
+
+        var remaining = drainFiles.filter { file in
+            guard let created = (try? file.resourceValues(
+                forKeys: [.creationDateKey]
+            ).creationDate),
+                now.timeIntervalSince(created) > maxFileAge
+            else { return true }
+
+            let age = now.timeIntervalSince(created)
+            oldestDeletedAge = max(oldestDeletedAge, age)
+            if Self.removeFileQuietly(at: file) {
+                deletedCount += 1
+            } else {
+                errCount += 1
+            }
+            return false
+        }
+
+        if remaining.count > maxPerPayloadFiles {
+            let excess = remaining.prefix(
+                remaining.count - maxPerPayloadFiles
+            )
+            for file in excess {
+                if let created = (try? file.resourceValues(
+                    forKeys: [.creationDateKey]
+                ).creationDate) {
+                    oldestDeletedAge = max(
+                        oldestDeletedAge, now.timeIntervalSince(created)
+                    )
+                }
+                if Self.removeFileQuietly(at: file) {
+                    deletedCount += 1
+                } else {
+                    errCount += 1
+                }
+            }
+            remaining = Array(remaining.suffix(maxPerPayloadFiles))
+        }
+
+        if deletedCount > 0 || errCount > 0 {
+            let hours = Int(oldestDeletedAge / 3600)
+            let result = errCount > 0 ? "err" : "ok"
+            await log(
+                "⌚️ [CLEANUP] path=retention artifact=drain"
+                    + " deleted=\(deletedCount)"
+                    + " remaining=\(remaining.count)"
+                    + " oldest_age_hours=\(hours)"
+                    + " result=\(result)"
+            )
+        }
+
+        return remaining
+    }
+
+    private static func payloadIdFromDrainFile(_ fileURL: URL) -> String {
+        let name = fileURL.deletingPathExtension().lastPathComponent
+        let prefix = "complication_log.drain."
+        if let range = name.range(of: prefix) {
+            let candidate = String(name[range.upperBound...])
+            if !candidate.isEmpty { return candidate }
+        }
+        return UUID().uuidString
+    }
+
+    private static let drainSizeCap = 64 * 1024
+
+    private func sendLogContentFromFile(fileURL: URL) async {
+        guard let data = try? Data(contentsOf: fileURL),
+              var content = String(data: data, encoding: .utf8),
+              !content.trimmingCharacters(in: .whitespacesAndNewlines)
+                  .isEmpty
+        else {
+            try? FileManager.default.removeItem(at: fileURL)
+            return
+        }
+
+        if content.utf8.count > Self.drainSizeCap {
+            let rawData = Data(content.utf8)
+            let truncData = rawData.prefix(Self.drainSizeCap)
+            if let nl = truncData.lastIndex(of: UInt8(ascii: "\n")) {
+                content = String(
+                    decoding: truncData[...nl], as: UTF8.self
+                ) + "[truncated]\n"
+            } else {
+                content = String(
+                    decoding: truncData, as: UTF8.self
+                ) + "\n[truncated]\n"
+            }
+        }
+
+        let payloadId = Self.payloadIdFromDrainFile(fileURL)
+        let envelope: [String: Any] = [
+            "type": "watchLogs",
+            "payloadId": payloadId,
+            "data": content
+        ]
+
+        let filePath = fileURL.path
+
+        if session.isReachable {
+            guard prepareSessionForImmediateSend() else {
+                await storePendingPayload(
+                    payloadId: payloadId,
+                    type: "watchLogs",
+                    filePath: filePath
+                )
+                _ = session.transferUserInfo(envelope)
+                await log(
+                    "⌚️ Drain logs queued for background delivery"
+                        + " (payloadId: \(payloadId))"
+                        + " watch_log_files=\(cachedWatchLogFiles)"
+                        + " drain_files=\(cachedDrainFiles)"
+                        + " note=activation_timeout"
+                )
+                return
+            }
+
+            await storePendingPayload(
+                payloadId: payloadId,
+                type: "watchLogs",
+                filePath: filePath
+            )
+
+            await sendMessageAwaitingReply(
+                envelope,
+                context: "drain payloadId=\(payloadId)"
+            ) { reply in
+                if let ackType = reply["type"] as? String,
+                   ackType == "ack",
+                   let ackId = WatchConnectivityPayloadIds.payloadIdString(
+                       reply["payloadId"]
+                   ),
+                   ackId == payloadId {
+                    let res = WatchLogger.removeFileTracked(
+                        at: fileURL
+                    )
+                    if res.succeeded {
+                        await WatchLogger.shared
+                            .removePendingPayload(payloadId)
+                    }
+                    await WatchLogger.shared
+                        .logCleanup(
+                            path: "ack_reply", flow: "drain",
+                            artifact: "drain",
+                            payloadId: payloadId,
+                            result: res
+                        )
+                }
+            } onError: { error in
+                await WatchLogger.shared.log(
+                    "⌚️ Failed to send drain logs"
+                        + " (payloadId: \(payloadId)): "
+                        + error.localizedDescription
+                )
+                await WatchLogger.shared.storePendingPayload(
+                    payloadId: payloadId,
+                    type: "watchLogs",
+                    filePath: filePath
+                )
+            }
+        } else {
+            _ = session.transferUserInfo(envelope)
+            await storePendingPayload(
+                payloadId: payloadId,
+                type: "watchLogs",
+                filePath: filePath
+            )
+        }
+    }
+
+    // MARK: - Cleanup log helper
+
+    /// Formats and emits a [CLEANUP] line for ack_reply paths.
+    private func logCleanup(
+        path: String, flow: String, artifact: String,
+        payloadId: String, result res: RemoveResult
+    ) async {
+        var msg = "⌚️ [CLEANUP] path=\(path) flow=\(flow)"
+        msg += " artifact=\(artifact)"
+        msg += " payloadId=\(payloadId)"
+        msg += " outcome=\(res.outcome)"
+        if let err = res.error {
+            msg += " result=err error=\(err)"
+        } else {
+            msg += " result=ok"
+        }
+        await log(msg)
+    }
+
+    // MARK: - Observability (E2, E3)
+
+    /// E3: Recompute cached file counts if stale (10s TTL).
+    private func updateCachedCountsIfStale() {
+        let now = Date()
+        guard now.timeIntervalSince(cachedCountsTimestamp) >= 10
+        else { return }
+
+        let fileManager = FileManager.default
+        let logDir = fileManager.urls(
+            for: .documentDirectory, in: .userDomainMask
+        ).first?.appendingPathComponent("logs", isDirectory: true)
+
+        if let logDir, let files = try? fileManager.contentsOfDirectory(
+            at: logDir, includingPropertiesForKeys: nil
+        ) {
+            cachedWatchLogFiles = files.filter {
+                $0.lastPathComponent.hasPrefix("watch_log_")
+                    && $0.lastPathComponent.hasSuffix(".txt")
+                    && $0.lastPathComponent != "watch_log_daily.txt"
+            }.count
+        }
+
+        if let containerURL = ComplicationLogBuffer
+            .sharedContainerURL() {
+            let drainsDir = containerURL.appendingPathComponent(
+                "logs", isDirectory: true
+            )
+            if let files = try? fileManager.contentsOfDirectory(
+                at: drainsDir, includingPropertiesForKeys: nil
+            ) {
+                cachedDrainFiles = files.filter {
+                    $0.lastPathComponent
+                        .hasPrefix("complication_log.drain.")
+                        && $0.lastPathComponent.hasSuffix(".txt")
+                }.count
+            }
+        }
+
+        cachedCountsTimestamp = now
+    }
+
+    /// E2: Best-effort daily inventory of log files and pending payloads.
+    private func logFileInventory() async {
+        let lastInventory = UserDefaults.standard.double(
+            forKey: lastInventoryKey
+        )
+        let now = Date().timeIntervalSince1970
+        guard (now - lastInventory) >= 24 * 60 * 60 else { return }
+
+        let fileManager = FileManager.default
+        var watchLogsCount = 0
+        var watchLogsBytes: UInt64 = 0
+        var drainsCount = 0
+        var drainsBytes: UInt64 = 0
+
+        let logDir = fileManager.urls(
+            for: .documentDirectory, in: .userDomainMask
+        ).first?.appendingPathComponent("logs", isDirectory: true)
+
+        if let logDir, let files = try? fileManager.contentsOfDirectory(
+            at: logDir, includingPropertiesForKeys: [.fileSizeKey]
+        ) {
+            for file in files
+                where file.lastPathComponent.hasPrefix("watch_log_")
+                && file.lastPathComponent.hasSuffix(".txt")
+                && file.lastPathComponent != "watch_log_daily.txt" {
+                watchLogsCount += 1
+                if let attrs = try? fileManager.attributesOfItem(
+                    atPath: file.path
+                ),
+                    let size = attrs[.size] as? UInt64 {
+                    watchLogsBytes += size
+                }
+            }
+        }
+
+        if let containerURL = ComplicationLogBuffer
+            .sharedContainerURL() {
+            let drainsDir = containerURL.appendingPathComponent(
+                "logs", isDirectory: true
+            )
+            if let files = try? fileManager.contentsOfDirectory(
+                at: drainsDir, includingPropertiesForKeys: [.fileSizeKey]
+            ) {
+                for file in files
+                    where file.lastPathComponent
+                    .hasPrefix("complication_log.drain.")
+                    && file.lastPathComponent.hasSuffix(".txt") {
+                    drainsCount += 1
+                    if let attrs = try? fileManager.attributesOfItem(
+                        atPath: file.path
+                    ),
+                        let size = attrs[.size] as? UInt64 {
+                        drainsBytes += size
+                    }
+                }
+            }
+        }
+
+        let pendingCount = (UserDefaults.standard.array(
+            forKey: pendingPayloadsKey
+        ) as? [[String: Any]])?.count ?? 0
+
+        await log(
+            "⌚️ [INVENTORY]"
+                + " watch_logs_count=\(watchLogsCount)"
+                + " watch_logs_bytes=\(watchLogsBytes)"
+                + " drains_count=\(drainsCount)"
+                + " drains_bytes=\(drainsBytes)"
+                + " pending_count=\(pendingCount)"
+        )
+
+        UserDefaults.standard.set(now, forKey: lastInventoryKey)
     }
 }

--- a/Trio Watch App Extension/WatchLogger.swift
+++ b/Trio Watch App Extension/WatchLogger.swift
@@ -1,5 +1,45 @@
 import Foundation
+import WatchKit
 import WatchConnectivity
+
+/// Shared startup transport gate for watch log delivery.
+/// Synchronous access is required so foreground lifecycle code can arm or disarm
+/// suppression before any follow-on log call has a chance to flush.
+enum WatchStartupTransportGate {
+    private static let lock = NSLock()
+    private static var isSuppressed = true
+    private static var activationSequence: Int?
+
+    static func arm(activationSequence: Int?) {
+        lock.lock()
+        defer { lock.unlock() }
+        isSuppressed = true
+        self.activationSequence = activationSequence
+    }
+
+    @discardableResult
+    static func disarm(activationSequence: Int? = nil) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let activationSequence,
+           let currentActivationSequence = self.activationSequence,
+           currentActivationSequence != activationSequence
+        {
+            return false
+        }
+
+        isSuppressed = false
+        self.activationSequence = nil
+        return true
+    }
+
+    static func snapshot() -> (isSuppressed: Bool, activationSequence: Int?) {
+        lock.lock()
+        defer { lock.unlock() }
+        return (isSuppressed, activationSequence)
+    }
+}
 
 // MARK: - WCSession send completion (single resume for reply vs error)
 
@@ -177,6 +217,65 @@ actor WatchLogger {
         }
     }
 
+    // Battery context: enable monitoring once per process; all reads on MainActor.
+    private static var hasEnabledBatteryMonitoring = false
+
+    @MainActor
+    private static func batteryContextOnMain() -> String {
+        let device = WKInterfaceDevice.current()
+        if !hasEnabledBatteryMonitoring {
+            hasEnabledBatteryMonitoring = true
+            device.isBatteryMonitoringEnabled = true
+        }
+        let levelText: String
+        if device.batteryLevel >= 0 {
+            levelText = String(Int((device.batteryLevel * 100).rounded()))
+        } else {
+            levelText = "unknown"
+        }
+        let stateText: String
+        switch device.batteryState {
+        case .unknown:
+            stateText = "unknown"
+        case .unplugged:
+            stateText = "unplugged"
+        case .charging:
+            stateText = "charging"
+        case .full:
+            stateText = "full"
+        @unknown default:
+            stateText = "unknown_default"
+        }
+        return "battery_level_percent=\(levelText) battery_state=\(stateText)"
+    }
+
+    private var lastBatteryContext = "battery_level_percent=unknown battery_state=unknown"
+    private var lastBatteryRefreshEpoch: TimeInterval = 0
+    private var batteryRefreshTask: Task<String, Never>?
+
+    private func batteryContextCached(now: TimeInterval = Date().timeIntervalSince1970) async -> String {
+        if now - lastBatteryRefreshEpoch < 60 {
+            return lastBatteryContext
+        }
+        if let existing = batteryRefreshTask {
+            let result = await existing.value
+            let currentNow = Date().timeIntervalSince1970
+            if currentNow - lastBatteryRefreshEpoch >= 60 {
+                lastBatteryContext = result
+                lastBatteryRefreshEpoch = currentNow
+            }
+            return result
+        }
+        let task = Task { await MainActor.run { Self.batteryContextOnMain() } }
+        batteryRefreshTask = task
+        defer { batteryRefreshTask = nil }
+
+        let result = await task.value
+        lastBatteryContext = result
+        lastBatteryRefreshEpoch = Date().timeIntervalSince1970
+        return result
+    }
+
     // MARK: - Timer
 
     private func startFlushTimer() async {
@@ -199,7 +298,8 @@ actor WatchLogger {
     ) async {
         let shortFile = (file as NSString).lastPathComponent
         let timestamp = Self.dateFormatter.string(from: Date())
-        let entry = "[\(timestamp)] [b:\(build)] [\(shortFile):\(line)] \(function) → \(message)"
+        let batteryContext = await batteryContextCached()
+        let entry = "[\(timestamp)] [b:\(build)] [\(shortFile):\(line)] \(function) → \(message) \(batteryContext)"
 
         logs.append(entry)
         if logs.count > maxEntries {
@@ -246,12 +346,14 @@ actor WatchLogger {
             || logs.count >= flushSizeThreshold
 
         if shouldFlush {
+            guard !WatchStartupTransportGate.snapshot().isSuppressed else { return }
             await flushToPhone()
         }
     }
 
     private func flushToPhone() async {
         guard !logs.isEmpty else { return }
+        guard !WatchStartupTransportGate.snapshot().isSuppressed else { return }
 
         updateCachedCountsIfStale()
         await logFileInventory()
@@ -448,18 +550,22 @@ actor WatchLogger {
 
     // MARK: - Persisted log flush + retention
 
-    func flushPersistedLogs() async {
+    func flushPersistedLogs(startupTransportSuppressedOverride: Bool? = nil) async {
+        let startupTransportSuppressed = startupTransportSuppressedOverride
+            ?? WatchStartupTransportGate.snapshot().isSuppressed
         let lastKnownBuild = UserDefaults.standard.string(
             forKey: lastKnownBuildKey
         )
         if lastKnownBuild != build {
-            UserDefaults.standard.set(build, forKey: lastKnownBuildKey)
             await log(
                 "[UPGRADE] build changed"
                     + " from \(lastKnownBuild ?? "nil") to \(build)",
-                force: true
+                force: !startupTransportSuppressed
             )
+            UserDefaults.standard.set(build, forKey: lastKnownBuildKey)
         }
+
+        guard !startupTransportSuppressed else { return }
 
         updateCachedCountsIfStale()
         await logFileInventory()
@@ -481,7 +587,7 @@ actor WatchLogger {
                 && file.lastPathComponent != "watch_log_daily.txt"
         }
 
-        _ = await applyWatchLogRetention(
+        let validFiles = await applyWatchLogRetention(
             perPayloadFiles: perPayloadFiles
         )
 
@@ -644,6 +750,7 @@ actor WatchLogger {
     // MARK: - Resend pending payloads
 
     func resendPendingPayloads() async {
+        guard !WatchStartupTransportGate.snapshot().isSuppressed else { return }
         guard session.isReachable else { return }
         guard prepareSessionForImmediateSend() else {
             await log(

--- a/Trio Watch App Extension/WatchState+G7ComplicationPipeline.swift
+++ b/Trio Watch App Extension/WatchState+G7ComplicationPipeline.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+@MainActor
+extension WatchState {
+    /// Apply a G7 eavesdrop EGV: update shared `TrioComplicationDataStore`, then `WatchState` for the main view.
+    func applyG7DirectFromObserver(
+        glucoseMgDl: Int,
+        trend: String?,
+        readingDate: Date,
+        glucoseColorHex: String
+    ) {
+        let trendV = trend ?? ""
+        var deltaV = delta ?? "--"
+        if let prev = G7ComplicationDeltaState.previousGlucose, prev != glucoseMgDl {
+            let d = glucoseMgDl - prev
+            if d > 0 { deltaV = "+\(d)" } else if d < 0 { deltaV = "\(d)" } else { deltaV = "0" }
+        }
+        G7ComplicationDeltaState.previousGlucose = glucoseMgDl
+
+        let snap = TrioComplicationSnapshot(
+            glucose: String(glucoseMgDl),
+            trend: trendV,
+            delta: deltaV,
+            readingDate: readingDate,
+            date: Date(),
+            glucoseColor: glucoseColorHex,
+            dataSource: .g7DirectBLE
+        )
+        if !TrioComplicationDataStore.shared.wouldAcceptMainThreadSave(snap) {
+            G7BLELog.log("event=g7_ble_snapshot_skipped reason=dedup_or_older reading_date=\(readingDate) glucose=\(glucoseMgDl)")
+            return
+        }
+        TrioComplicationDataStore.shared.save(snap, minInterval: 5)
+        currentGlucose = String(glucoseMgDl)
+        self.trend = trendV
+        delta = deltaV
+        currentGlucoseColorString = glucoseColorHex
+        if let a = Int(readingDate.timeIntervalSinceNow / -60.0) {
+            lastLoopTime = "\(max(0, a)) min"
+        }
+        lastWatchStateUpdate = readingDate
+        displayedComplicationDataSource = .g7DirectBLE
+    }
+}
+
+@MainActor
+enum G7ComplicationDeltaState {
+    static var previousGlucose: Int?
+}

--- a/Trio Watch App Extension/WatchState+Requests.swift
+++ b/Trio Watch App Extension/WatchState+Requests.swift
@@ -234,6 +234,8 @@ extension WatchState {
             Task {
                 await WatchLogger.shared.log("⌚️ No session available for state update")
             }
+            clearStartupFirstRefreshInFlightOnMain()
+            loadFallbackDataFromComplication()
             return
         }
 
@@ -242,6 +244,8 @@ extension WatchState {
                 await WatchLogger.shared.log("⌚️ Session not activated. Activating...")
             }
             session.activate()
+            clearStartupFirstRefreshInFlightOnMain()
+            loadFallbackDataFromComplication()
             return
         }
 
@@ -258,11 +262,31 @@ extension WatchState {
                     await WatchLogger.shared.log("⌚️ Saving logs to disk as fallback!")
                     await WatchLogger.shared.flushPersistedLogs()
                 }
+                DispatchQueue.main.async {
+                    self.clearStartupFirstRefreshInFlightOnMain()
+                    self.loadFallbackDataFromComplication()
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) {
+                        self.requestWatchStateUpdate()
+                    }
+                }
             }
+
+            syncTimeoutWorkItem?.cancel()
+            let timeoutWorkItem = DispatchWorkItem { [weak self] in
+                Task {
+                    await WatchLogger.shared.log("WatchState update timeout - using fallback data")
+                }
+                self?.clearStartupFirstRefreshInFlightOnMain()
+                self?.loadFallbackDataFromComplication()
+            }
+            syncTimeoutWorkItem = timeoutWorkItem
+            DispatchQueue.main.asyncAfter(deadline: .now() + 30.0, execute: timeoutWorkItem)
         } else {
             Task {
                 await WatchLogger.shared.log("⌚️ Phone not reachable for WatchState update")
             }
+            clearStartupFirstRefreshInFlightOnMain()
+            loadFallbackDataFromComplication()
         }
     }
 }

--- a/Trio Watch App Extension/WatchState+Requests.swift
+++ b/Trio Watch App Extension/WatchState+Requests.swift
@@ -61,7 +61,7 @@ extension WatchState {
             Task {
                 await WatchLogger.shared.log("Error sending carbs request: \(error)")
                 await WatchLogger.shared.log("⌚️ Saving logs to disk as fallback!")
-                await WatchLogger.shared.persistLogsLocally()
+                await WatchLogger.shared.flushPersistedLogs()
             }
         }
 
@@ -93,7 +93,7 @@ extension WatchState {
             Task {
                 await WatchLogger.shared.log("⌚️ Error sending cancel override request: \(error)")
                 await WatchLogger.shared.log("⌚️ Saving logs to disk as fallback!")
-                await WatchLogger.shared.persistLogsLocally()
+                await WatchLogger.shared.flushPersistedLogs()
             }
         }
 
@@ -126,7 +126,7 @@ extension WatchState {
             Task {
                 await WatchLogger.shared.log("⌚️ Error sending activate override request: \(error)")
                 await WatchLogger.shared.log("⌚️ Saving logs to disk as fallback!")
-                await WatchLogger.shared.persistLogsLocally()
+                await WatchLogger.shared.flushPersistedLogs()
             }
         }
 
@@ -158,7 +158,7 @@ extension WatchState {
             Task {
                 await WatchLogger.shared.log("⌚️ Error sending cancel temp target request: \(error)")
                 await WatchLogger.shared.log("⌚️ Saving logs to disk as fallback!")
-                await WatchLogger.shared.persistLogsLocally()
+                await WatchLogger.shared.flushPersistedLogs()
             }
         }
 
@@ -191,7 +191,7 @@ extension WatchState {
             Task {
                 await WatchLogger.shared.log("⌚️ Error sending activate temp target request: \(error)")
                 await WatchLogger.shared.log("⌚️ Saving logs to disk as fallback!")
-                await WatchLogger.shared.persistLogsLocally()
+                await WatchLogger.shared.flushPersistedLogs()
             }
         }
 
@@ -224,7 +224,7 @@ extension WatchState {
             Task {
                 await WatchLogger.shared.log("Error requesting bolus recommendation: \(error)")
                 await WatchLogger.shared.log("⌚️ Saving logs to disk as fallback!")
-                await WatchLogger.shared.persistLogsLocally()
+                await WatchLogger.shared.flushPersistedLogs()
             }
         }
     }
@@ -256,7 +256,7 @@ extension WatchState {
                 Task {
                     await WatchLogger.shared.log("⌚️ Error requesting WatchState update: \(error)")
                     await WatchLogger.shared.log("⌚️ Saving logs to disk as fallback!")
-                    await WatchLogger.shared.persistLogsLocally()
+                    await WatchLogger.shared.flushPersistedLogs()
                 }
             }
         } else {

--- a/Trio Watch App Extension/WatchState.swift
+++ b/Trio Watch App Extension/WatchState.swift
@@ -153,7 +153,7 @@ import WatchConnectivity
                 Task {
                     await WatchLogger.shared.log("⌚️ Watch session activation failed: \(error)", force: true)
                     await WatchLogger.shared.log("⌚️ Saving logs to disk as fallback!")
-                    await WatchLogger.shared.persistLogsLocally()
+                    await WatchLogger.shared.flushPersistedLogs()
                 }
                 return
             }
@@ -274,7 +274,7 @@ import WatchConnectivity
             Task {
                 await WatchLogger.shared.log("⌚️ transferUserInfo failed with error: \(error)")
                 await WatchLogger.shared.log("⌚️ Saving logs to disk as fallback!")
-                await WatchLogger.shared.persistLogsLocally()
+                await WatchLogger.shared.flushPersistedLogs()
             }
         }
     }

--- a/Trio Watch App Extension/WatchState.swift
+++ b/Trio Watch App Extension/WatchState.swift
@@ -1,20 +1,48 @@
 import Foundation
+import HealthKit
 import SwiftUI
 import WatchConnectivity
+import WatchKit
 
-/// WatchState manages the communication between the Watch app and the iPhone app using WatchConnectivity.
-/// It handles glucose data synchronization and sending treatment requests (bolus, carbs) to the phone.
+// MARK: - BackgroundTaskWindowCounter (Phase 2.2)
+
+/// In-memory monotonic counter for correlating WKWatchConnectivityRefreshBackgroundTask wake windows with didReceiveUserInfo.
+/// Watch app extension only; used by handleBackgroundTasks and WCSession delegate.
+enum BackgroundTaskWindowCounter {
+    private static let lock = NSLock()
+    private static var lastWindowId = 0
+    private static var lastReceivedAt: Date?
+
+    /// Advance counter, record time, return (windowId, receivedAt). Thread-safe.
+    static func next() -> (windowId: Int, receivedAt: Date) {
+        lock.lock()
+        defer { lock.unlock() }
+        lastWindowId += 1
+        let receivedAt = Date()
+        lastReceivedAt = receivedAt
+        return (lastWindowId, receivedAt)
+    }
+
+    /// Current window id only if last received was within 30s; else nil. Thread-safe.
+    static func currentOrNil() -> Int? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let at = lastReceivedAt else { return nil }
+        return Date().timeIntervalSince(at) <= 30 ? lastWindowId : nil
+    }
+}
+
 @Observable final class WatchState: NSObject, WCSessionDelegate {
-    // MARK: - Properties
+    static let shared = WatchState()
 
-    /// The WatchConnectivity session instance used for communication
+    // MARK: - WatchConnectivity
+
     var session: WCSession?
-    /// Indicates if the paired iPhone is currently reachable
     var isReachable = false
+    var lastWatchStateUpdate: Date?
 
-    var lastWatchStateUpdate: TimeInterval?
+    // MARK: - Main view metrics
 
-    /// main view relevant metrics
     var currentGlucose: String = "--"
     var currentGlucoseColorString: String = "#ffffff"
     var trend: String? = ""
@@ -28,59 +56,436 @@ import WatchConnectivity
     var overridePresets: [OverridePresetWatch] = []
     var tempTargetPresets: [TempTargetPresetWatch] = []
 
-    /// treatments inputs
-    /// used to store carbs for combined meal-bolus-treatments
+    // MARK: - Treatment inputs
+
     var carbsAmount: Int = 0
     var fatAmount: Int = 0
     var proteinAmount: Int = 0
     var bolusAmount: Double = 0.0
     var confirmationProgress: Double = 0.0
 
-    // Safety limits
+    // MARK: - Safety limits
+
     var maxBolus: Decimal = 10
     var maxCarbs: Decimal = 250
     var maxFat: Decimal = 250
     var maxProtein: Decimal = 250
 
-    // Pump specific dosing increment
+    // MARK: - Pump-specific increments
+
     var bolusIncrement: Decimal = 0.05
     var confirmBolusFaster: Bool = false
 
-    // Acknowlegement handling
+    // MARK: - Acknowledgment handling
+
     var showCommsAnimation: Bool = false
     var showAcknowledgmentBanner: Bool = false
     var acknowledgementStatus: AcknowledgementStatus = .pending
     var acknowledgmentMessage: String = ""
     var shouldNavigateToRoot: Bool = true
 
-    // Bolus calculation progress
-    var showBolusCalculationProgress: Bool = false
+    // MARK: - Progress state
 
-    // Meal bolus-specific properties
+    var showBolusCalculationProgress: Bool = false
     var mealBolusStep: MealBolusStep = .savingCarbs
     var isMealBolusCombo: Bool = false
-
     var recommendedBolus: Decimal = 0
 
-    // MARK: - Debouncing and batch processing helpers
+    // MARK: - Debouncing and sync helpers
 
-    /// Temporary storage for new data arriving via WatchConnectivity.
     private var pendingData: [String: Any] = [:]
-
-    /// Work item to schedule finalizing the pending data.
     private var finalizeWorkItem: DispatchWorkItem?
-
-    /// A flag to tell the UI we’re still updating.
     var showSyncingAnimation: Bool = false
+    var syncTimeoutWorkItem: DispatchWorkItem?
+
+    /// Connectivity background tasks held until userInfo processing finishes. Main queue only.
+    private var pendingConnectivityTasks: [WKRefreshBackgroundTask] = []
+    /// R5d — persisted via App Group UserDefaults for sleep-gap detection across process restarts.
+    private var lastDataReceivedAt: Date? {
+        get { TrioComplicationDataStore.shared.lastDataReceivedAt() }
+        set {
+            if let date = newValue {
+                TrioComplicationDataStore.shared.setLastDataReceivedAt(date)
+            }
+        }
+    }
+    /// R5c — set in didReceiveUserInfo and passed through to saveComplicationSnapshot for decode_ms (reading_epoch there is derived from the payload being saved to avoid misattribution).
+    private var lastUserInfoReceiveTimestamp: Date?
+    private var quietWindowWorkItem: DispatchWorkItem?
+
+    private var activationTimestamp: Date?
+    private var forcedSinceActivation = false
+
+    private var transferRetryCount = 0
+    private let maxTransferRetries = 3
+    private var retryWorkItem: DispatchWorkItem?
+
+    // MARK: - Startup coordination
+
+    private let startupWatchStateDelaySeconds: TimeInterval = 2.0
+    private let startupHealthKitDelaySeconds: TimeInterval = 10.0
+    private let startupFlushDelaySeconds: TimeInterval = 10.0
+
+    private var startupActivationSequence = 0
+    private var startupCurrentActivationSequence: Int?
+    private var startupIsForegroundActive = false
+    private var startupBackgroundLaunchDisarmWorkItem: DispatchWorkItem?
+    private var startupDeferredWatchStateWorkItem: DispatchWorkItem?
+    private var startupDeferredHealthKitWorkItem: DispatchWorkItem?
+    private var startupDeferredPersistedLogFlushWorkItem: DispatchWorkItem?
+    private var startupFirstRefreshFiredActivationSequence: Int?
+    private var startupFirstRefreshInFlight = false
+    private var hasInitializedHealthKitSetupInProcess = false
+
+    /// Resident memory sample budget — see `Helper/WatchResidentTelemetry.swift`.
+    var residentTelemetryBudget = WatchResidentTelemetryBudget()
+
+    /// Set when the root SwiftUI main view’s `.onAppear` ran before `startupCurrentActivationSequence` existed; flushed after the next foreground activation is established.
+    private var pendingResidentSampleFirstMainView = false
+
+    // MARK: - HealthKit (R6)
+
+    private var healthKitStore: HKHealthStore?
+    private var glucoseObserverQuery: HKObserverQuery?
+
+    /// Path B4 — max samples for nil-anchor bootstrap (`HKSampleQuery`, descending). **64** ≈ enough for latest + delta/trend context within a dense CGM window while capping peak batch size vs unbounded anchored pulls.
+    private static let hkBootstrapSampleLimit = 64
+
+    private var backgroundRefreshCount = 0
+    private var lastBackgroundRefreshDate: Date?
+    private var lastConnectivityTerminalAt: Date?
+    private var lastConnectivityTerminalPath: String?
+    private var deferredConnectivityCompletionWorkItem: DispatchWorkItem?
+    private var deferredConnectivityCompletionDeadline: Date?
+    private var deferredConnectivityCompletionPath: String?
+    private var deferredConnectivityCompletionAttempt = 0
+    private let connectivityLateTaskWindowSeconds: TimeInterval = 2.0
+    private let connectivityDeferredRetryInitialDelaySeconds: TimeInterval = 0.2
+    private let connectivityDeferredRetryMaxDelaySeconds: TimeInterval = 1.0
+    private let connectivityDeferredRetryBudgetSeconds: TimeInterval = 4.0
+
+    /// Guards against duplicate requestWatchStateUpdate() calls on cold start.
+    /// Reset in noteAppBecameActive() on each active transition. Main-thread confined.
+    private var hasRequestedInitialUpdate = false
 
     var deviceType = WatchSize.current
+
+    private var isColdStart: Bool {
+        guard let activationTimestamp = activationTimestamp else { return true }
+        return Date().timeIntervalSince(activationTimestamp) < 60
+    }
 
     override init() {
         super.init()
         setupSession()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            self.forceComplicationUpdate()
+            self.scheduleBackgroundRefresh()
+        }
     }
 
-    /// Configures the WatchConnectivity session if supported on the device
+    func noteAppBecameActive() {
+        assert(Thread.isMainThread, "noteAppBecameActive must be called on main thread")
+        activationTimestamp = Date()
+        forcedSinceActivation = false
+        hasRequestedInitialUpdate = false
+        startupFirstRefreshInFlight = false
+    }
+
+    func scheduleBackgroundLaunchDisarmIfNeeded() {
+        assert(Thread.isMainThread, "scheduleBackgroundLaunchDisarmIfNeeded must be called on main thread")
+        startupBackgroundLaunchDisarmWorkItem?.cancel()
+
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.startupBackgroundLaunchDisarmWorkItem = nil
+            guard !self.startupIsForegroundActive else { return }
+
+            WatchStartupTransportGate.disarm()
+            Task {
+                await WatchLogger.shared.log(
+                    "event=watch_startup_background_launch_disarm"
+                        + " reason=no_foreground_entry"
+                )
+            }
+        }
+
+        startupBackgroundLaunchDisarmWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0, execute: workItem)
+    }
+
+    func handleForegroundActiveEntry() {
+        assert(Thread.isMainThread, "handleForegroundActiveEntry must be called on main thread")
+        guard !startupIsForegroundActive else { return }
+
+        startupIsForegroundActive = true
+        startupActivationSequence += 1
+        let activationSequence = startupActivationSequence
+        startupCurrentActivationSequence = activationSequence
+        startupFirstRefreshFiredActivationSequence = nil
+        residentTelemetryBudget.resetForNewActivation(activationSequence)
+        flushPendingFirstMainViewResidentSampleIfNeeded()
+
+        startupBackgroundLaunchDisarmWorkItem?.cancel()
+        startupBackgroundLaunchDisarmWorkItem = nil
+        WatchStartupTransportGate.arm(activationSequence: activationSequence)
+        noteAppBecameActive()
+        WatchErrorReporter.markBecameActiveImmediately()
+        scheduleStartupSequenceOnMain(activationSequence: activationSequence)
+
+        Task {
+            await WatchLogger.shared.log(
+                "event=watch_startup_grace_scheduled"
+                    + " activation_seq=\(activationSequence)"
+                    + " watch_state_delay_s=\(Int(startupWatchStateDelaySeconds))"
+                    + " healthkit_delay_s=\(Int(startupHealthKitDelaySeconds))"
+                    + " flush_delay_s=\(Int(startupFlushDelaySeconds))"
+            )
+            await WatchErrorReporter.shared.startup()
+        }
+    }
+
+    func handleForegroundInactiveOrBackground() {
+        assert(Thread.isMainThread, "handleForegroundInactiveOrBackground must be called on main thread")
+        guard startupIsForegroundActive else { return }
+
+        pendingResidentSampleFirstMainView = false
+
+        startupIsForegroundActive = false
+        startupFirstRefreshInFlight = false
+        let activationSequence = startupCurrentActivationSequence
+        let pendingTasks = startupPendingTasksFieldOnMain()
+        cancelStartupSequenceOnMain()
+        startupCurrentActivationSequence = nil
+        WatchErrorReporter.markEnteredBackgroundOrInactiveImmediately()
+
+        if let activationSequence {
+            WatchStartupTransportGate.disarm(activationSequence: activationSequence)
+            if pendingTasks != "none" {
+                Task {
+                    await WatchLogger.shared.log(
+                        "event=watch_startup_grace_canceled"
+                            + " activation_seq=\(activationSequence)"
+                            + " reason=left_active_before_fire"
+                            + " pending=\(pendingTasks)"
+                    )
+                }
+            }
+        }
+    }
+
+    /// Root main view (`TrioMainWatchView`) `.onAppear` — **main thread only.** Latches `first_main_view` until `startupCurrentActivationSequence` exists if needed.
+    func noteMainWatchRootViewAppearedForResidentTelemetry() {
+        assert(Thread.isMainThread, "noteMainWatchRootViewAppearedForResidentTelemetry must be called on main thread")
+        guard WatchResidentTelemetryGate.isEnabled else { return }
+        if let seq = startupCurrentActivationSequence {
+            emitResidentMemorySample(checkpoint: "first_main_view", activationSequence: seq)
+        } else {
+            pendingResidentSampleFirstMainView = true
+        }
+    }
+
+    /// Chart tab (page 1) became visible — **main thread only.**
+    func noteChartTabBecameVisibleForResidentTelemetry() {
+        assert(Thread.isMainThread, "noteChartTabBecameVisibleForResidentTelemetry must be called on main thread")
+        emitResidentMemorySample(checkpoint: "chart_visible", activationSequence: startupCurrentActivationSequence)
+    }
+
+    private func flushPendingFirstMainViewResidentSampleIfNeeded() {
+        assert(Thread.isMainThread, "flushPendingFirstMainViewResidentSampleIfNeeded must be called on main thread")
+        guard pendingResidentSampleFirstMainView else { return }
+        guard let seq = startupCurrentActivationSequence else { return }
+        pendingResidentSampleFirstMainView = false
+        emitResidentMemorySample(checkpoint: "first_main_view", activationSequence: seq)
+    }
+
+    private func scheduleStartupSequenceOnMain(activationSequence: Int) {
+        assert(Thread.isMainThread, "scheduleStartupSequenceOnMain must be called on main thread")
+        cancelStartupSequenceOnMain()
+
+        let watchStateWorkItem = DispatchWorkItem { [weak self] in
+            self?.fireDeferredStartupWatchStateRefreshOnMain(
+                activationSequence: activationSequence
+            )
+        }
+        startupDeferredWatchStateWorkItem = watchStateWorkItem
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + startupWatchStateDelaySeconds,
+            execute: watchStateWorkItem
+        )
+
+        let healthKitWorkItem = DispatchWorkItem { [weak self] in
+            self?.fireDeferredStartupHealthKitSetupOnMain(
+                activationSequence: activationSequence
+            )
+        }
+        startupDeferredHealthKitWorkItem = healthKitWorkItem
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + startupHealthKitDelaySeconds,
+            execute: healthKitWorkItem
+        )
+
+        let flushWorkItem = DispatchWorkItem { [weak self] in
+            self?.fireDeferredStartupPersistedLogFlushOnMain(
+                activationSequence: activationSequence
+            )
+        }
+        startupDeferredPersistedLogFlushWorkItem = flushWorkItem
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + startupFlushDelaySeconds,
+            execute: flushWorkItem
+        )
+    }
+
+    private func cancelStartupSequenceOnMain() {
+        assert(Thread.isMainThread, "cancelStartupSequenceOnMain must be called on main thread")
+        startupDeferredWatchStateWorkItem?.cancel()
+        startupDeferredWatchStateWorkItem = nil
+        startupDeferredHealthKitWorkItem?.cancel()
+        startupDeferredHealthKitWorkItem = nil
+        startupDeferredPersistedLogFlushWorkItem?.cancel()
+        startupDeferredPersistedLogFlushWorkItem = nil
+    }
+
+    private func startupPendingTasksFieldOnMain() -> String {
+        assert(Thread.isMainThread, "startupPendingTasksFieldOnMain must be called on main thread")
+
+        var pendingTasks: [String] = []
+        if startupDeferredWatchStateWorkItem != nil {
+            pendingTasks.append("watch_state")
+        }
+        if startupDeferredHealthKitWorkItem != nil {
+            pendingTasks.append("healthkit")
+        }
+        if startupDeferredPersistedLogFlushWorkItem != nil {
+            pendingTasks.append("flush")
+        }
+
+        return pendingTasks.isEmpty ? "none" : pendingTasks.joined(separator: "|")
+    }
+
+    private func fireDeferredStartupWatchStateRefreshOnMain(activationSequence: Int) {
+        assert(Thread.isMainThread, "fireDeferredStartupWatchStateRefreshOnMain must be called on main thread")
+        guard startupIsForegroundActive,
+              startupCurrentActivationSequence == activationSequence
+        else { return }
+
+        startupDeferredWatchStateWorkItem = nil
+        startupFirstRefreshFiredActivationSequence = activationSequence
+        hasRequestedInitialUpdate = true
+        startupFirstRefreshInFlight = true
+        showSyncingAnimation = true
+
+        Task {
+            await WatchLogger.shared.log(
+                "event=watch_startup_deferred_watch_state_refresh_fired"
+                    + " activation_seq=\(activationSequence)"
+            )
+        }
+
+        emitResidentMemorySample(
+            checkpoint: "deferred_watch_state_fired",
+            activationSequence: activationSequence
+        )
+
+        requestWatchStateUpdate()
+    }
+
+    private func fireDeferredStartupHealthKitSetupOnMain(activationSequence: Int) {
+        assert(Thread.isMainThread, "fireDeferredStartupHealthKitSetupOnMain must be called on main thread")
+        guard startupIsForegroundActive,
+              startupCurrentActivationSequence == activationSequence
+        else { return }
+
+        startupDeferredHealthKitWorkItem = nil
+        let alreadyInitialized = hasInitializedHealthKitSetupInProcess
+
+        Task {
+            await WatchLogger.shared.log(
+                "event=watch_startup_deferred_healthkit_setup_fired"
+                    + " activation_seq=\(activationSequence)"
+                    + " already_initialized=\(alreadyInitialized)"
+            )
+        }
+
+        guard !alreadyInitialized else { return }
+
+        hasInitializedHealthKitSetupInProcess = true
+        setupHealthKitBackgroundDelivery()
+    }
+
+    private func fireDeferredStartupPersistedLogFlushOnMain(activationSequence: Int) {
+        assert(Thread.isMainThread, "fireDeferredStartupPersistedLogFlushOnMain must be called on main thread")
+        guard startupIsForegroundActive,
+              startupCurrentActivationSequence == activationSequence
+        else { return }
+
+        startupDeferredPersistedLogFlushWorkItem = nil
+
+        Task {
+            await WatchLogger.shared.log(
+                "event=watch_startup_deferred_persisted_log_flush_fired"
+                    + " activation_seq=\(activationSequence)"
+            )
+            let didDisarm = WatchStartupTransportGate.disarm(
+                activationSequence: activationSequence
+            )
+            await WatchLogger.shared.flushPersistedLogs(
+                startupTransportSuppressedOverride: didDisarm ? false : nil
+            )
+            await MainActor.run {
+                self.emitResidentMemorySample(
+                    checkpoint: "post_startup_flush",
+                    activationSequence: activationSequence
+                )
+            }
+        }
+    }
+
+    private func shouldSuppressStartupSignalOnMain() -> Bool {
+        assert(Thread.isMainThread, "shouldSuppressStartupSignalOnMain must be called on main thread")
+
+        guard activationTimestamp != nil else { return true }
+
+        guard startupIsForegroundActive,
+              let activationSequence = startupCurrentActivationSequence
+        else { return false }
+
+        return startupFirstRefreshFiredActivationSequence != activationSequence
+    }
+
+    private func logStartupSignalSuppressedOnMain() {
+        assert(Thread.isMainThread, "logStartupSignalSuppressedOnMain must be called on main thread")
+        guard startupIsForegroundActive,
+              let activationSequence = startupCurrentActivationSequence
+        else { return }
+
+        Task {
+            await WatchLogger.shared.log(
+                "event=watch_startup_transport_suppressed"
+                    + " activation_seq=\(activationSequence)"
+                    + " path=startup_signal"
+                    + " reason=startup_grace"
+            )
+        }
+    }
+
+    private func requestWatchStateUpdateRespectingStartupGraceOnMain() {
+        assert(Thread.isMainThread, "requestWatchStateUpdateRespectingStartupGraceOnMain must be called on main thread")
+        if shouldSuppressStartupSignalOnMain() {
+            logStartupSignalSuppressedOnMain()
+            return
+        }
+
+        requestWatchStateUpdate()
+    }
+
+    func clearStartupFirstRefreshInFlightOnMain() {
+        assert(Thread.isMainThread, "clearStartupFirstRefreshInFlightOnMain must be called on main thread")
+        startupFirstRefreshInFlight = false
+    }
+
     private func setupSession() {
         if WCSession.isSupported() {
             let session = WCSession.default
@@ -88,16 +493,380 @@ import WatchConnectivity
             session.activate()
             self.session = session
             Task {
-                await WatchLogger.shared.log("⌚️ WCSession setup complete.")
+                await WatchLogger.shared.log("WCSession setup complete.")
             }
         } else {
             Task {
-                await WatchLogger.shared.log("⌚️ WCSession is not supported on this device")
+                await WatchLogger.shared.log("WCSession is not supported on this device")
             }
         }
     }
 
-    // MARK: – Handle Acknowledgement Messages FROM Phone
+    // MARK: - HealthKit background delivery (R6)
+
+    private func setupHealthKitBackgroundDelivery() {
+        guard HKHealthStore.isHealthDataAvailable() else { return }
+        let store = HKHealthStore()
+        guard let bgType = HKQuantityType.quantityType(forIdentifier: .bloodGlucose) else { return }
+
+        store.requestAuthorization(toShare: nil, read: Set([bgType])) { [weak self] granted, error in
+            guard let self else { return }
+            guard granted, error == nil else {
+                Task {
+                    await WatchLogger.shared.log("❌ hk_authorization_failed granted=\(granted) error=\(error?.localizedDescription ?? "nil")")
+                }
+                return
+            }
+
+            store.enableBackgroundDelivery(for: bgType, frequency: .immediate) { success, error in
+                if let error = error {
+                    Task {
+                        await WatchLogger.shared.log("❌ hk_background_delivery_registration_failed error=\(error.localizedDescription)")
+                    }
+                } else if success {
+                    Task {
+                        await WatchLogger.shared.log("✅ hk_background_delivery_registered success=true low_power_mode=\(ProcessInfo.processInfo.isLowPowerModeEnabled)")
+                    }
+                } else {
+                    Task {
+                        await WatchLogger.shared.log("⚠️ hk_background_delivery_registered success=false low_power_mode=\(ProcessInfo.processInfo.isLowPowerModeEnabled)")
+                    }
+                }
+            }
+
+            self.setupGlucoseObserverQuery(store: store, sampleType: bgType)
+        }
+    }
+
+    private func setupGlucoseObserverQuery(store: HKHealthStore, sampleType: HKQuantityType) {
+        healthKitStore = store
+        let query = HKObserverQuery(sampleType: sampleType, predicate: nil) { [weak self] _, completionHandler, error in
+            let fireId = UUID()
+            guard error == nil else {
+                Task {
+                    await WatchLogger.shared.log("❌ hk_observer_error fire_id=\(fireId) error=\(error!.localizedDescription)")
+                }
+                completionHandler()
+                return
+            }
+            guard let self else {
+                completionHandler()
+                return
+            }
+            self.fetchLatestGlucoseFromHealthKit(fireId: fireId, completionHandler: completionHandler)
+        }
+        store.execute(query)
+        glucoseObserverQuery = query
+    }
+
+    /// Path B4 — shared post-fetch processing for **both** bootstrap (`HKSampleQuery`) and incremental (`HKAnchoredObjectQuery`) paths. Persists `HKQueryAnchor` when `newAnchor` is non-nil (incremental path). Bootstrap anchor persistence is handled separately via `establishHealthKitGlucoseTimelineAnchorAfterBootstrap` after a successful sample query.
+    private func finishHKGlucoseObserverFetch(
+        fireId: UUID,
+        anchorWasNil: Bool,
+        samples: [HKQuantitySample]?,
+        newAnchor: HKQueryAnchor?,
+        error: Error?,
+        mgDlUnit: HKUnit,
+        completionHandler: @escaping () -> Void
+    ) {
+        let dataStore = TrioComplicationDataStore.shared
+        if let err = error {
+            Task {
+                await WatchLogger.shared.log("❌ hk_observer_query_error fire_id=\(fireId) error=\(err.localizedDescription)")
+            }
+            completionHandler()
+            return
+        }
+
+        let added = samples ?? []
+        // Stable batch events: `hk_sample_query_batch` (bootstrap `HKSampleQuery`) vs `hk_anchored_query_batch` (incremental `HKAnchoredObjectQuery`) — split so Better Stack filters are not misleading (Claude review).
+        let batchEventName = anchorWasNil ? "hk_sample_query_batch" : "hk_anchored_query_batch"
+        Task {
+            await WatchLogger.shared
+                .log("event=\(batchEventName) fire_id=\(fireId) anchor_was_nil=\(anchorWasNil) samples_count=\(added.count)")
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.emitResidentMemorySample(
+                checkpoint: "hk_batch",
+                activationSequence: self.startupCurrentActivationSequence
+            )
+        }
+
+        if let newAnchor,
+           let anchorData = try? NSKeyedArchiver.archivedData(withRootObject: newAnchor, requiringSecureCoding: true) {
+            dataStore.saveHKGlucoseAnchor(anchorData)
+        }
+
+        let sortedByDate = added.sorted { $0.startDate > $1.startDate }
+        if sortedByDate.isEmpty {
+            Task {
+                await WatchLogger.shared.log("⚠️ hk_observer_no_new_samples fire_id=\(fireId)")
+            }
+            completionHandler()
+            return
+        }
+
+        let latest = sortedByDate[0]
+        let latestEpoch = latest.startDate.timeIntervalSince1970
+        let latestMgDl = latest.quantity.doubleValue(for: mgDlUnit)
+
+        if latestEpoch == dataStore.hkLastReceivedGlucoseEpoch() {
+            Task {
+                await WatchLogger.shared.log("⚠️ hk_observer_skipped_known_epoch fire_id=\(fireId) epoch=\(Int(latestEpoch))")
+            }
+            completionHandler()
+            return
+        }
+
+        var previousMgDl: Double?
+        var previousEpoch: TimeInterval?
+        if sortedByDate.count >= 2 {
+            let prev = sortedByDate[1]
+            previousMgDl = prev.quantity.doubleValue(for: mgDlUnit)
+            previousEpoch = prev.startDate.timeIntervalSince1970
+        } else {
+            let storedEpoch = dataStore.hkLastReceivedGlucoseEpoch()
+            if storedEpoch > 0 {
+                previousEpoch = storedEpoch
+                previousMgDl = dataStore.hkLastReceivedGlucoseValueMgDl()
+            }
+        }
+
+        let timeDelta = previousEpoch.map { latestEpoch - $0 } ?? 0
+        let plausibilityOK = timeDelta > 0 && timeDelta < 15 * 60
+
+        var deltaString = "--"
+        var trendString = ""
+        var trendDerived = false
+
+        if let prev = previousMgDl, plausibilityOK {
+            let rawDeltaMgDl = latestMgDl - prev
+            let deltaInt = Int(rawDeltaMgDl.rounded())
+            deltaString = String(format: "%+d", deltaInt)
+            trendString = Self.hkTrendString(fromDeltaMgDl: deltaInt)
+            trendDerived = true
+        }
+
+        dataStore.setHKLastReceivedGlucoseEpoch(latestEpoch)
+        dataStore.setHKLastReceivedGlucoseValueMgDl(latestMgDl)
+
+        let readingDate = latest.startDate
+        let glucoseString = String(Int(latestMgDl.rounded()))
+        let syncLag = Int(Date().timeIntervalSince(readingDate))
+
+        // Stable tokens for validation / Better Stack: batch lines use `hk_sample_query_batch` | `hk_anchored_query_batch` above; `query_type` uses `sampleQuery_bootstrap` | `anchoredQuery`. Do not rename casually.
+        let queryLabel = anchorWasNil ? "sampleQuery_bootstrap" : "anchoredQuery"
+        Task {
+            await WatchLogger.shared.log(
+                "🏥 hk_observer_fired fire_id=\(fireId) reading_epoch=\(Int(readingDate.timeIntervalSince1970)) sync_lag=\(syncLag) glucose=\(glucoseString) delta=\(deltaString) trend=\(trendString) trend_derived=\(trendDerived) samples_in_batch=\(sortedByDate.count) query_type=\(queryLabel)"
+            )
+        }
+
+        let snapshot = TrioComplicationSnapshot(
+            glucose: glucoseString,
+            trend: trendString,
+            delta: deltaString,
+            readingDate: readingDate,
+            date: Date(),
+            glucoseColor: nil
+        )
+
+        DispatchQueue.main.async {
+            TrioComplicationDataStore.shared.save(snapshot, minInterval: 5)
+            completionHandler()
+        }
+    }
+
+    /// Path B4 — After a successful bounded `HKSampleQuery` bootstrap, persist an `HKQueryAnchor` at the current timeline (“samples from `Date()` onward” + `.strictStartDate` is typically an **empty** forward window) so the next observer cycle uses incremental `HKAnchoredObjectQuery` instead of repeating bootstrap. Calls `completion` when the establishment query finishes (success or failure) so the HK observer callback is not released before the anchor write attempt.
+    ///
+    /// **Memory safety:** Uses `HKObjectQueryNoLimit`, but boundedness relies on the **predicate** yielding an effectively empty forward timeline—not on the limit parameter (ChatGPT review P2).
+    private func establishHealthKitGlucoseTimelineAnchorAfterBootstrap(
+        store: HKHealthStore,
+        bgType: HKQuantityType,
+        fireId: UUID,
+        completion: @escaping () -> Void
+    ) {
+        let now = Date()
+        let predicate = HKQuery.predicateForSamples(withStart: now, end: nil, options: .strictStartDate)
+        let anchorQuery = HKAnchoredObjectQuery(
+            type: bgType,
+            predicate: predicate,
+            anchor: nil,
+            limit: HKObjectQueryNoLimit,
+            resultsHandler: { _, samples, _, newAnchor, error in
+                defer { completion() }
+                if let err = error {
+                    Task {
+                        await WatchLogger.shared
+                            .log("⚠️ hk_bootstrap_anchor_establish_failed fire_id=\(fireId) error=\(err.localizedDescription)")
+                    }
+                    return
+                }
+                guard let newAnchor,
+                      let anchorData = try? NSKeyedArchiver.archivedData(withRootObject: newAnchor, requiringSecureCoding: true)
+                else {
+                    Task {
+                        await WatchLogger.shared.log("⚠️ hk_bootstrap_anchor_establish_no_anchor fire_id=\(fireId)")
+                    }
+                    return
+                }
+                TrioComplicationDataStore.shared.saveHKGlucoseAnchor(anchorData)
+                let n = (samples as? [HKQuantitySample])?.count ?? 0
+                Task {
+                    await WatchLogger.shared
+                        .log("✅ hk_bootstrap_anchor_established fire_id=\(fireId) timeline_predicate_samples_count=\(n)")
+                }
+            }
+        )
+        store.execute(anchorQuery)
+    }
+
+    private func fetchLatestGlucoseFromHealthKit(fireId: UUID, completionHandler: @escaping () -> Void) {
+        guard let store = healthKitStore,
+              let bgType = HKQuantityType.quantityType(forIdentifier: .bloodGlucose) else {
+            Task {
+                await WatchLogger.shared.log("❌ hk_observer_guard_failed fire_id=\(fireId) reason=nil_store_or_type")
+            }
+            completionHandler()
+            return
+        }
+
+        let dataStore = TrioComplicationDataStore.shared
+        let mgDlUnit = HKUnit.gramUnit(with: .milli).unitDivided(by: .literUnit(with: .deci))
+
+        // R6.1 — Load anchor; decode failure → nil + 24h cap
+        var anchor: HKQueryAnchor?
+        if let data = dataStore.hkGlucoseAnchor() {
+            if let decoded = try? NSKeyedUnarchiver.unarchivedObject(ofClass: HKQueryAnchor.self, from: data) {
+                anchor = decoded
+            } else {
+                Task {
+                    await WatchLogger.shared.log("⚠️ hk_anchor_decode_failed fire_id=\(fireId)")
+                }
+            }
+        } else {
+            Task {
+                await WatchLogger.shared.log("⚠️ hk_observer_nil_anchor fire_id=\(fireId)")
+            }
+        }
+
+        let anchorWasNil = (anchor == nil)
+
+        // R6.1 — Nil anchor: cap to 24h. With anchor: no date cap. SyncIdentifier filter deferred (see plan §Source Predicate).
+        let twentyFourHoursAgo = Date().addingTimeInterval(-24 * 3600)
+        let bootstrapPredicate = HKQuery.predicateForSamples(withStart: twentyFourHoursAgo, end: nil, options: .strictStartDate)
+
+        // Path B4 — No durable anchor: use descending `HKSampleQuery` so a positive limit still returns the *newest* samples (anchored queries enumerate oldest-first).
+        if anchorWasNil {
+            let sort = NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: false)
+            let sampleQuery = HKSampleQuery(
+                sampleType: bgType,
+                predicate: bootstrapPredicate,
+                limit: Self.hkBootstrapSampleLimit,
+                sortDescriptors: [sort]
+            ) { [weak self] _, samples, error in
+                guard let self else {
+                    completionHandler()
+                    return
+                }
+                if error != nil {
+                    self.finishHKGlucoseObserverFetch(
+                        fireId: fireId,
+                        anchorWasNil: true,
+                        samples: samples as? [HKQuantitySample],
+                        newAnchor: nil,
+                        error: error,
+                        mgDlUnit: mgDlUnit,
+                        completionHandler: completionHandler
+                    )
+                    return
+                }
+                let afterBootstrap: () -> Void = {
+                    self.establishHealthKitGlucoseTimelineAnchorAfterBootstrap(
+                        store: store,
+                        bgType: bgType,
+                        fireId: fireId,
+                        completion: completionHandler
+                    )
+                }
+                self.finishHKGlucoseObserverFetch(
+                    fireId: fireId,
+                    anchorWasNil: true,
+                    samples: samples as? [HKQuantitySample],
+                    newAnchor: nil,
+                    error: nil,
+                    mgDlUnit: mgDlUnit,
+                    completionHandler: afterBootstrap
+                )
+            }
+            store.execute(sampleQuery)
+            return
+        }
+
+        let query = HKAnchoredObjectQuery(
+            type: bgType,
+            predicate: nil,
+            anchor: anchor,
+            limit: HKObjectQueryNoLimit,
+            resultsHandler: { [weak self] _, samples, _, newAnchor, error in
+                guard let self else {
+                    completionHandler()
+                    return
+                }
+                self.finishHKGlucoseObserverFetch(
+                    fireId: fireId,
+                    anchorWasNil: false,
+                    samples: samples as? [HKQuantitySample],
+                    newAnchor: newAnchor,
+                    error: error,
+                    mgDlUnit: mgDlUnit,
+                    completionHandler: completionHandler
+                )
+            }
+        )
+        store.execute(query)
+    }
+
+    /// R6.1 — Same integer threshold semantics as BloodGlucose.Direction.init(trend:) (raw direction strings).
+    private static func hkTrendString(fromDeltaMgDl delta: Int) -> String {
+        switch delta {
+        case ...(-30): return "DoubleDown"
+        case -29 ... (-20): return "SingleDown"
+        case -19 ... (-10): return "FortyFiveDown"
+        case -9 ..< 10: return "Flat"
+        case 10 ..< 20: return "FortyFiveUp"
+        case 20 ..< 30: return "SingleUp"
+        default: return "DoubleUp"
+        }
+    }
+
+    /// Path B1 — Summarize inbound WC messages without stringifying nested `glucoseValues` (avoids large transient `String` allocations).
+    private static func watchConnectivityInboundSummary(_ message: [String: Any]) -> String {
+        let topKeys = message.keys.sorted().joined(separator: ",")
+        var parts = ["event=watch_wc_inbound channel=message top_level_keys=\(topKeys)"]
+        if let type = message["type"] as? String {
+            parts.append("type=\(type)")
+        }
+        if let ws = message[WatchMessageKeys.watchState] as? [String: Any] {
+            let gv = ws[WatchMessageKeys.glucoseValues]
+            let gvCount: Int
+            if let arr = gv as? [Any] {
+                gvCount = arr.count
+            } else if gv != nil {
+                gvCount = -1
+            } else {
+                gvCount = 0
+            }
+            let epoch = (ws[WatchMessageKeys.readingEpoch] as? TimeInterval).map { Int($0) } ?? -1
+            let wsKeys = ws.keys.sorted().joined(separator: ",")
+            parts.append("watchState_keys=\(wsKeys) glucoseValues_count=\(gvCount) reading_epoch=\(epoch)")
+        }
+        return parts.joined(separator: " ")
+    }
+
+    // MARK: - Acknowledgement handling
 
     func handleAcknowledgment(success: Bool, message: String, isFinal: Bool = true) {
         Task {
@@ -106,21 +875,17 @@ import WatchConnectivity
 
         if success {
             Task {
-                await WatchLogger.shared.log("⌚️ Acknowledgment received: \(message)")
+                await WatchLogger.shared.log("Acknowledgment received: \(message)")
             }
             acknowledgementStatus = .success
             acknowledgmentMessage = message
-
-            // Hide progress animation
             DispatchQueue.main.async {
                 self.showCommsAnimation = false
             }
         } else {
             Task {
-                await WatchLogger.shared.log("⌚️ Acknowledgment failed: \(message)")
+                await WatchLogger.shared.log("Acknowledgment failed: \(message)")
             }
-
-            // Hide progress animation
             DispatchQueue.main.async {
                 self.showCommsAnimation = false
             }
@@ -135,7 +900,7 @@ import WatchConnectivity
 
             DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                 self.showAcknowledgmentBanner = false
-                self.showSyncingAnimation = false // Just ensure this is 100% set to false
+                self.showSyncingAnimation = false
                 Task {
                     await WatchLogger.shared.log("Cleared ack banner and syncing animation")
                 }
@@ -145,14 +910,12 @@ import WatchConnectivity
 
     // MARK: - WCSessionDelegate
 
-    /// Called when the session has completed activation
-    /// Updates the reachability status and logs the activation state
     func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
         DispatchQueue.main.async {
             if let error = error {
                 Task {
-                    await WatchLogger.shared.log("⌚️ Watch session activation failed: \(error)", force: true)
-                    await WatchLogger.shared.log("⌚️ Saving logs to disk as fallback!")
+                    await WatchLogger.shared.log("Watch session activation failed: \(error)", force: true)
+                    await WatchLogger.shared.log("Saving logs to disk as fallback.")
                     await WatchLogger.shared.flushPersistedLogs()
                 }
                 return
@@ -160,184 +923,570 @@ import WatchConnectivity
 
             if activationState == .activated {
                 Task {
-                    await WatchLogger.shared.log("⌚️ Watch session activated with state: \(activationState.rawValue)")
+                    await WatchLogger.shared.log("Watch session activated with state: \(activationState.rawValue)")
                 }
 
-                self.forceConditionalWatchStateUpdate()
-
+                _ = self.forceConditionalWatchStateUpdate()
                 self.isReachable = session.isReachable
 
                 Task {
-                    await WatchLogger.shared.log("⌚️ Watch isReachable after activation: \(session.isReachable)")
+                    await WatchLogger.shared.log("Watch isReachable after activation: \(session.isReachable)")
                 }
             }
         }
     }
 
-    /// Handles incoming messages from the paired iPhone when Phone is in the foreground
     func session(_: WCSession, didReceiveMessage message: [String: Any]) {
-        Task {
-            await WatchLogger.shared.log("⌚️ Watch received data: \(message)")
-        }
-
-        // If the message has a nested "watchState" dictionary with date as TimeInterval
-        if let watchStateDict = message[WatchMessageKeys.watchState] as? [String: Any],
-           let timestamp = watchStateDict[WatchMessageKeys.date] as? TimeInterval
-        {
-            let date = Date(timeIntervalSince1970: timestamp)
-
-            // Check if it's not older than 15 min
-            if date >= Date().addingTimeInterval(-15 * 60) {
-                Task {
-                    await WatchLogger.shared.log("⌚️ Handling watchState from \(date)")
-                }
-                processWatchMessage(message)
-            } else {
-                Task {
-                    await WatchLogger.shared.log("⌚️ Received outdated watchState data (\(date))")
-                }
-                DispatchQueue.main.async {
-                    self.showSyncingAnimation = false
-                }
+        if let type = message["type"] as? String, type == "batchAck" {
+            let ackIds = WatchConnectivityPayloadIds.payloadIdStrings(
+                from: message["ackIds"]
+            )
+            if !ackIds.isEmpty {
+                Task { await WatchLogger.shared.deleteFilesForPayloadIds(ackIds) }
             }
             return
         }
 
-        // Else if the message is an "ack" at the top level
-        // e.g. { "acknowledged": true, "message": "Started Temp Target...", "date": Date(...) }
-        else if
+        if let type = message["type"] as? String, type == "ack",
+           let pid = WatchConnectivityPayloadIds.payloadIdString(message["payloadId"])
+        {
+            Task { await WatchLogger.shared.deleteFilesForPayloadIds([pid]) }
+            return
+        }
+
+        Task {
+            await WatchLogger.shared.log(Self.watchConnectivityInboundSummary(message))
+        }
+
+        // R5b — message is the sendMessage envelope [WatchMessageKeys.watchState: fullMessage]; watchStateDict is the inner payload (same shape as iPhone fullMessage) so readingEpoch is correct for end-to-end timing.
+        if let watchStateDict = message[WatchMessageKeys.watchState] as? [String: Any],
+           let date = dateValue(from: watchStateDict[WatchMessageKeys.date])
+        {
+            if date >= Date().addingTimeInterval(-15 * 60) {
+                let extractedEpoch = (watchStateDict[WatchMessageKeys.readingEpoch] as? TimeInterval).map { Int($0) } ?? -1
+                Task {
+                    await WatchLogger.shared.log("📬 didReceiveMessage reading_epoch=\(extractedEpoch) receive_wall=\(Date().timeIntervalSince1970)")
+                }
+                Task {
+                    await WatchLogger.shared.log("Handling watchState from \(date)")
+                }
+                processWatchMessage(message)
+            } else {
+                Task {
+                    await WatchLogger.shared.log("Received outdated watchState data (\(date))")
+                }
+                DispatchQueue.main.async {
+                    self.clearStartupFirstRefreshInFlightOnMain()
+                    self.showSyncingAnimation = false
+                    self.completePendingConnectivityTasksOnMain(
+                        path: "message_outdated",
+                        requiresNoPendingContent: true
+                    )
+                }
+            }
+            return
+        } else if
             let acknowledged = message[WatchMessageKeys.acknowledged] as? Bool,
             let ackMessage = message[WatchMessageKeys.message] as? String,
             let ackCodeRaw = message[WatchMessageKeys.ackCode] as? String
         {
             Task {
                 await WatchLogger.shared
-                    .log("⌚️ Handling ack with message: \(ackMessage), success: \(acknowledged), ackCode: \(ackCodeRaw)")
+                    .log("Handling ack with message: \(ackMessage), success: \(acknowledged), ackCode: \(ackCodeRaw)")
             }
             DispatchQueue.main.async {
-                // For ack messages, we do NOT show “Syncing...”
                 self.showSyncingAnimation = false
             }
             processWatchMessage(message)
             return
-
-                    // Recommended bolus is also not part of the WatchState message, hence the extra condition here
-        } else if
-            let recommendedBolus = message[WatchMessageKeys.recommendedBolus] as? NSNumber
-        {
+        } else if let recommendedBolus = message[WatchMessageKeys.recommendedBolus] as? NSNumber {
             Task {
-                await WatchLogger.shared.log("⌚️ Received recommended bolus: \(recommendedBolus)")
+                await WatchLogger.shared.log("Received recommended bolus: \(recommendedBolus)")
             }
 
             DispatchQueue.main.async {
                 self.recommendedBolus = recommendedBolus.decimalValue
                 self.showBolusCalculationProgress = false
             }
-
             return
         } else {
             Task {
-                await WatchLogger.shared.log("⌚️ Faulty data. Skipping...")
+                await WatchLogger.shared.log("Faulty data. Skipping.")
             }
             DispatchQueue.main.async {
+                self.clearStartupFirstRefreshInFlightOnMain()
                 self.showSyncingAnimation = false
+                self.completePendingConnectivityTasksOnMain(
+                    path: "message_invalid",
+                    requiresNoPendingContent: true
+                )
             }
         }
     }
 
     func session(_: WCSession, didReceiveUserInfo userInfo: [String: Any] = [:]) {
-        guard let snapshot = WatchStateSnapshot(from: userInfo) else {
-            Task {
-                await WatchLogger.shared.log("⌚️ Invalid snapshot received", force: true)
+        if let type = userInfo["type"] as? String, type == "watchLogConfirm" {
+            let payloadIds = WatchConnectivityPayloadIds.payloadIdStrings(
+                from: userInfo["payloadIds"]
+            )
+            if !payloadIds.isEmpty {
+                Task { await WatchLogger.shared.deleteFilesForPayloadIds(payloadIds) }
+            }
+            DispatchQueue.main.async { [self] in
+                completePendingConnectivityTasksOnMain(
+                    path: "watch_log_confirm",
+                    requiresNoPendingContent: true
+                )
             }
             return
         }
 
-        let lastProcessed = WatchStateSnapshot.loadLatestDateFromDisk()
+        Task {
+            await WatchLogger.shared.log("Received userInfo with keys: \(userInfo.keys.joined(separator: ", "))")
+        }
 
-        guard snapshot.date > lastProcessed else {
+        let payload = (userInfo[WatchMessageKeys.watchState] as? [String: Any]) ?? userInfo
+
+        let readingDate: Date
+        switch resolveEffectiveCGMReadingDate(from: payload) {
+        case let .found(date):
+            readingDate = date
+        case .rejectedDateOnly:
             Task {
-                await WatchLogger.shared.log("⌚️ Ignoring outdated or duplicate WatchState snapshot", force: true)
+                await WatchLogger.shared.log(
+                    "Invalid snapshot received: no CGM reading timestamp"
+                        + " (top-level date is state/snapshot time only — not used as reading)"
+                )
+            }
+            DispatchQueue.main.async { [weak self] in
+                self?.completePendingConnectivityTasksOnMain(
+                    path: "invalid_no_pending",
+                    requiresNoPendingContent: true
+                )
+            }
+            return
+        case .missing:
+            Task {
+                await WatchLogger.shared.log(
+                    "Invalid snapshot received: no valid CGM reading timestamp"
+                        + " (no reading_epoch, glucoseValues samples, or parseable date)"
+                )
+            }
+            DispatchQueue.main.async { [weak self] in
+                self?.completePendingConnectivityTasksOnMain(
+                    path: "invalid_no_pending",
+                    requiresNoPendingContent: true
+                )
             }
             return
         }
 
-        WatchStateSnapshot.saveLatestDateToDisk(snapshot.date)
+        // Log using already-decoded readingDate (no extra decode); epoch only when we have it.
+        let readingDateEpoch = Int(readingDate.timeIntervalSince1970)
+        lastUserInfoReceiveTimestamp = Date()
+        Task {
+            await WatchLogger.shared.log("event=complication_did_receive_user_info window_id=\(BackgroundTaskWindowCounter.currentOrNil() ?? -1) reading_date_epoch=\(readingDateEpoch)")
+        }
 
-        DispatchQueue.main.async {
-            self.scheduleUIUpdate(with: snapshot.payload)
+        // Phase 3.0 — pre-dispatch dedup. saveOnMain is authoritative.
+        // state is not populated here (defaults to nil) because no call site currently sets it.
+        // If state is ever set during snapshot construction, add it here too — otherwise this
+        // fingerprint will always differ from the saved one, defeating dedup for this path.
+        let tempSnapshot = TrioComplicationSnapshot(
+            glucose: payload[WatchMessageKeys.currentGlucose] as? String ?? "--",
+            trend: payload[WatchMessageKeys.trend] as? String ?? "",
+            delta: payload[WatchMessageKeys.delta] as? String ?? "",
+            readingDate: readingDate,
+            date: Date()
+        )
+        if TrioComplicationDataStore.shared.shouldSkipPreDispatch(for: tempSnapshot, handler: "userInfo") {
+            DispatchQueue.main.async { [weak self] in
+                self?.completePendingConnectivityTasksOnMain(
+                    path: "dedup_no_pending",
+                    requiresNoPendingContent: true
+                )
+            }
+            return
+        }
+
+        DispatchQueue.main.async { [self] in
+            // R5d: compute gap BEFORE updating timestamp
+            let gap = lastDataReceivedAt.map { Date().timeIntervalSince($0) } ?? .infinity
+            let isSleepGap = gap > 600
+
+            // R5d ordering: when a sleep gap is detected, save the snapshot synchronously
+            // so forceWidgetReloadIfStale reads fresh App Group data. Normal-cadence
+            // deliveries use the deferred path; shouldUpdate dedup prevents double-writes.
+            if isSleepGap {
+                saveComplicationSnapshot(from: payload)
+            }
+
+            if pendingConnectivityTasks.isEmpty {
+                let wid = BackgroundTaskWindowCounter.currentOrNil() ?? -1
+                Task {
+                    await WatchLogger.shared.log("event=complication_userinfo_no_pending_tasks window_id=\(wid) reading_date_epoch=\(readingDateEpoch) note=race_or_foreground")
+                }
+                scheduleUIUpdate(
+                    with: payload,
+                    fromUserInfo: true,
+                    userInfoReceiveTimestamp: lastUserInfoReceiveTimestamp,
+                    pendingConnectivityCompletionPath: "fast"
+                )
+            } else {
+                pendingData.merge(payload) { _, new in new }
+                quietWindowWorkItem?.cancel()
+                finalizeWorkItem?.cancel()
+                let receiveTs = lastUserInfoReceiveTimestamp
+                let work = DispatchWorkItem { [self] in
+                    finalizePendingData(
+                        fromUserInfo: true,
+                        userInfoReceiveTimestamp: receiveTs,
+                        pendingConnectivityCompletionPath: "fast"
+                    )
+                }
+                quietWindowWorkItem = work
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: work)
+            }
+
+            // R5d: update timestamp AFTER save
+            lastDataReceivedAt = Date()
+
+            // R5d: sleep-gap forced reload (snapshot already saved synchronously above)
+            if isSleepGap {
+                let gapDisplay = gap.isInfinite ? "first_receive" : "\(Int(gap))"
+                Task {
+                    await WatchLogger.shared.log("💤 sleep_gap_detected gap_seconds=\(gapDisplay)")
+                }
+                forceWidgetReloadIfStale(receivedGap: gap)
+            }
         }
     }
 
     func session(_: WCSession, didFinish _: WCSessionUserInfoTransfer, error: (any Error)?) {
         if let error = error {
             Task {
-                await WatchLogger.shared.log("⌚️ transferUserInfo failed with error: \(error)")
-                await WatchLogger.shared.log("⌚️ Saving logs to disk as fallback!")
+                await WatchLogger.shared.log("transferUserInfo failed with error: \(error)")
+                await WatchLogger.shared.log("Saving logs to disk as fallback.")
                 await WatchLogger.shared.flushPersistedLogs()
             }
+
+            if transferRetryCount < maxTransferRetries {
+                transferRetryCount += 1
+                let retryDelay = TimeInterval(transferRetryCount * 2)
+
+                retryWorkItem?.cancel()
+                retryWorkItem = DispatchWorkItem { [weak self] in
+                    self?.requestWatchStateUpdateRespectingStartupGraceOnMain()
+                }
+
+                DispatchQueue.main.asyncAfter(deadline: .now() + retryDelay, execute: retryWorkItem!)
+            } else {
+                transferRetryCount = 0
+                loadFallbackDataFromComplication()
+            }
+        } else {
+            transferRetryCount = 0
         }
     }
 
-    /// Called when the reachability status of the paired iPhone changes
-    /// Updates the local reachability status
     func sessionReachabilityDidChange(_ session: WCSession) {
         DispatchQueue.main.async {
             Task {
-                await WatchLogger.shared.log("⌚️ Watch reachability changed: \(session.isReachable)")
+                await WatchLogger.shared.log("Watch reachability changed: \(session.isReachable)")
             }
 
-            if session.isReachable {
-                self.forceConditionalWatchStateUpdate()
+            self.isReachable = session.isReachable
 
-                // reset input amounts
+            if session.isReachable {
+                if self.isColdStart, !self.forcedSinceActivation {
+                    _ = self.forceConditionalWatchStateUpdate()
+                }
+
                 self.bolusAmount = 0
                 self.carbsAmount = 0
-
-                // reset auth progress
                 self.confirmationProgress = 0
             }
         }
     }
 
-    /// Conditionally triggers a watch state update if the last known update was too long ago or has never occurred.
-    ///
-    /// This method checks the `lastWatchStateUpdate` timestamp to determine how many seconds
-    /// have elapsed since the last update under the following conditions
-    ///  - If `lastWatchStateUpdate` is `nil` (meaning there has never been an update), or
-    ///  - If more than 15 seconds have passed,
-    ///
-    /// it will show a syncing animation and request a new watch state update from the iPhone app.
-    private func forceConditionalWatchStateUpdate() {
+    // R4: applicationContext safety net — parallel delivery channel from iOS during budget exhaustion.
+    // R5d: integrated sleep-gap detection (same three-constraint ordering as didReceiveUserInfo).
+    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String: Any]) {
+        Task { await WatchLogger.shared.log("📦 didReceiveApplicationContext") }
+        guard let payload = applicationContext[WatchMessageKeys.watchState] as? [String: Any] else {
+            return
+        }
+        let readingResolution = resolveEffectiveCGMReadingDate(from: payload)
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            let gap = self.lastDataReceivedAt.map { Date().timeIntervalSince($0) } ?? .infinity
+            self.saveComplicationSnapshot(from: payload)
+            if case .found = readingResolution {
+                self.scheduleUIUpdate(with: payload)
+            }
+            self.lastDataReceivedAt = Date()
+            if gap > 600 {
+                let gapDisplay = gap.isInfinite ? "first_receive" : "\(Int(gap))"
+                Task {
+                    await WatchLogger.shared.log("💤 sleep_gap_detected_context gap_seconds=\(gapDisplay)")
+                }
+                self.forceWidgetReloadIfStale(receivedGap: gap)
+            }
+            let completionPath: String
+            let requiresNoPendingContent: Bool
+            switch readingResolution {
+            case .found:
+                completionPath = "application_context"
+                requiresNoPendingContent = false
+            case .rejectedDateOnly, .missing:
+                completionPath = "application_context_invalid"
+                requiresNoPendingContent = true
+            }
+            self.completePendingConnectivityTasksOnMain(
+                path: completionPath,
+                requiresNoPendingContent: requiresNoPendingContent,
+                recordMarkerWithoutPendingTasks: !requiresNoPendingContent
+            )
+        }
+    }
+
+    @discardableResult
+    private func forceConditionalWatchStateUpdate() -> Bool {
+        assert(Thread.isMainThread, "forceConditionalWatchStateUpdate must be called on main thread")
+        if shouldSuppressStartupSignalOnMain() {
+            logStartupSignalSuppressedOnMain()
+            return false
+        }
+
+        guard !startupFirstRefreshInFlight else {
+            return false
+        }
+
         guard let lastUpdateTimestamp = lastWatchStateUpdate else {
+            guard !hasRequestedInitialUpdate else { return false }
+            hasRequestedInitialUpdate = true
             Task {
                 await WatchLogger.shared.log("Forcing initial WatchState update")
             }
-
-            // If there's no recorded timestamp, we must force a fresh update immediately.
             showSyncingAnimation = true
             requestWatchStateUpdate()
-            return
+            forcedSinceActivation = true
+            return true
         }
 
-        let now = Date().timeIntervalSince1970
-        let secondsSinceUpdate = now - lastUpdateTimestamp
+        let now = Date()
+        let secondsSinceUpdate = now.timeIntervalSince(lastUpdateTimestamp)
         Task {
             await WatchLogger.shared.log("Time since last update: \(secondsSinceUpdate) seconds")
         }
 
-        // If more than 15 seconds have elapsed since the last update, force an(other) update.
-        if secondsSinceUpdate > 15 {
+        if secondsSinceUpdate > 15 || isColdStart {
             showSyncingAnimation = true
             requestWatchStateUpdate()
-            return
+            forcedSinceActivation = true
+            return true
         }
+
+        return false
     }
 
-    /// Handles incoming messages that either contain an acknowledgement or fresh watchState data  (<15 min)
+    private func connectivitySessionHasPendingContent() -> Bool {
+        if let session {
+            return session.hasContentPending
+        }
+        guard WCSession.isSupported() else { return false }
+        return WCSession.default.hasContentPending
+    }
+
+    private func canonicalConnectivityTerminalPath(_ path: String) -> String {
+        var basePath = path
+        let suffix = "_late_task"
+        while basePath.hasSuffix(suffix) {
+            basePath.removeLast(suffix.count)
+        }
+        return basePath.isEmpty ? path : basePath
+    }
+
+    private func clearDeferredConnectivityCompletionRetryOnMain() {
+        assert(Thread.isMainThread, "clearDeferredConnectivityCompletionRetryOnMain must be called on main thread")
+        deferredConnectivityCompletionWorkItem?.cancel()
+        deferredConnectivityCompletionWorkItem = nil
+        deferredConnectivityCompletionDeadline = nil
+        deferredConnectivityCompletionPath = nil
+        deferredConnectivityCompletionAttempt = 0
+    }
+
+    private func scheduleDeferredConnectivityCompletionRetryOnMain(path: String) {
+        assert(Thread.isMainThread, "scheduleDeferredConnectivityCompletionRetryOnMain must be called on main thread")
+
+        guard !pendingConnectivityTasks.isEmpty else {
+            clearDeferredConnectivityCompletionRetryOnMain()
+            return
+        }
+
+        let now = Date()
+        if deferredConnectivityCompletionPath != path {
+            deferredConnectivityCompletionWorkItem?.cancel()
+            deferredConnectivityCompletionWorkItem = nil
+            deferredConnectivityCompletionPath = path
+            deferredConnectivityCompletionDeadline = now.addingTimeInterval(connectivityDeferredRetryBudgetSeconds)
+            deferredConnectivityCompletionAttempt = 0
+        } else if deferredConnectivityCompletionWorkItem != nil {
+            return
+        }
+
+        let attempt = deferredConnectivityCompletionAttempt + 1
+        let delay = min(
+            connectivityDeferredRetryInitialDelaySeconds * pow(2.0, Double(max(attempt - 1, 0))),
+            connectivityDeferredRetryMaxDelaySeconds
+        )
+
+        deferredConnectivityCompletionWorkItem?.cancel()
+        let work = DispatchWorkItem { [self] in
+            deferredConnectivityCompletionWorkItem = nil
+            deferredConnectivityCompletionAttempt = attempt
+
+            guard !pendingConnectivityTasks.isEmpty else {
+                clearDeferredConnectivityCompletionRetryOnMain()
+                return
+            }
+
+            let wid = BackgroundTaskWindowCounter.currentOrNil() ?? -1
+            if !connectivitySessionHasPendingContent() {
+                Task {
+                    await WatchLogger.shared.log(
+                        "event=complication_bgtask_completion_retry_ready path=\(path)"
+                            + " window_id=\(wid)"
+                            + " attempt=\(attempt)"
+                            + " pending_content=false"
+                    )
+                }
+                _ = completePendingConnectivityTasksOnMain(
+                    path: path,
+                    requiresNoPendingContent: true
+                )
+                return
+            }
+
+            guard let deadline = deferredConnectivityCompletionDeadline,
+                  Date() < deadline else {
+                Task {
+                    await WatchLogger.shared.log(
+                        "event=complication_bgtask_completion_retry_expired path=\(path)"
+                            + " window_id=\(wid)"
+                            + " attempt=\(attempt)"
+                            + " pending_count=\(pendingConnectivityTasks.count)"
+                            + " pending_content=true"
+                    )
+                }
+                clearDeferredConnectivityCompletionRetryOnMain()
+                return
+            }
+
+            Task {
+                await WatchLogger.shared.log(
+                    "event=complication_bgtask_completion_retry_pending path=\(path)"
+                        + " window_id=\(wid)"
+                        + " attempt=\(attempt)"
+                        + " pending_count=\(pendingConnectivityTasks.count)"
+                        + " pending_content=true"
+                )
+            }
+            scheduleDeferredConnectivityCompletionRetryOnMain(path: path)
+        }
+        deferredConnectivityCompletionWorkItem = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+    }
+
+    private func recentConnectivityTerminalBasePathOnMain() -> String? {
+        assert(Thread.isMainThread, "recentConnectivityTerminalBasePathOnMain must be called on main thread")
+
+        guard let terminalAt = lastConnectivityTerminalAt,
+              let terminalPath = lastConnectivityTerminalPath else { return nil }
+
+        guard Date().timeIntervalSince(terminalAt) <= connectivityLateTaskWindowSeconds else {
+            lastConnectivityTerminalAt = nil
+            lastConnectivityTerminalPath = nil
+            return nil
+        }
+
+        return terminalPath
+    }
+
+    @discardableResult
+    private func completePendingConnectivityTasksOnMain(
+        path: String,
+        requiresNoPendingContent: Bool = false,
+        recordMarkerWithoutPendingTasks: Bool = false
+    ) -> Int {
+        assert(Thread.isMainThread, "completePendingConnectivityTasksOnMain must be called on main thread")
+
+        let pendingCount = pendingConnectivityTasks.count
+        let hasPendingContent = connectivitySessionHasPendingContent()
+        if requiresNoPendingContent, hasPendingContent {
+            let wid = BackgroundTaskWindowCounter.currentOrNil() ?? -1
+            Task {
+                await WatchLogger.shared.log(
+                    "event=complication_bgtask_completion_deferred path=\(path)"
+                        + " window_id=\(wid)"
+                        + " task_type=WKWatchConnectivityRefreshBackgroundTask"
+                        + " pending_count=\(pendingCount)"
+                        + " pending_content=true"
+                )
+            }
+            if pendingCount > 0 {
+                scheduleDeferredConnectivityCompletionRetryOnMain(path: path)
+            }
+            return 0
+        }
+
+        // Successful terminal paths need a short-lived marker even when the task
+        // arrives after processing completed. Guarded/no-pending paths use
+        // requiresNoPendingContent instead.
+        if pendingCount > 0 || requiresNoPendingContent || recordMarkerWithoutPendingTasks {
+            lastConnectivityTerminalAt = Date()
+            lastConnectivityTerminalPath = canonicalConnectivityTerminalPath(path)
+        }
+
+        guard pendingCount > 0 else {
+            let wid = BackgroundTaskWindowCounter.currentOrNil() ?? -1
+            if recordMarkerWithoutPendingTasks {
+                Task {
+                    await WatchLogger.shared.log(
+                        "event=complication_bgtask_terminal_marker path=\(canonicalConnectivityTerminalPath(path))"
+                            + " window_id=\(wid)"
+                            + " pending_count=0"
+                    )
+                }
+            }
+            return 0
+        }
+
+        let wid = BackgroundTaskWindowCounter.currentOrNil() ?? -1
+        Task {
+            await WatchLogger.shared.log(
+                "event=complication_bgtask_completing path=\(path)"
+                    + " window_id=\(wid)"
+                    + " task_type=WKWatchConnectivityRefreshBackgroundTask"
+                    + " completed_count=\(pendingCount)"
+                    + " pending_content=\(hasPendingContent)"
+                    + " 📡 BGTask completing (\(path)) window_id=\(wid) count=\(pendingCount)"
+            )
+        }
+
+        clearDeferredConnectivityCompletionRetryOnMain()
+
+        // Keep `false` here: complication freshness is driven by the save/reload path,
+        // and changing snapshot semantics is outside the scope of this task-lifecycle fix.
+        for task in pendingConnectivityTasks {
+            task.setTaskCompletedWithSnapshot(false)
+        }
+        pendingConnectivityTasks.removeAll()
+        return pendingCount
+    }
+
     private func processWatchMessage(_ message: [String: Any]) {
         DispatchQueue.main.async {
-            // 1) Acknowledgment logic
             if let acknowledged = message[WatchMessageKeys.acknowledged] as? Bool,
                let ackMessage = message[WatchMessageKeys.message] as? String,
                let ackCodeRaw = message[WatchMessageKeys.ackCode] as? String,
@@ -348,7 +1497,7 @@ import WatchConnectivity
                 }
 
                 Task {
-                    await WatchLogger.shared.log("⌚️ Received acknowledgment: \(ackMessage), success: \(acknowledged)")
+                    await WatchLogger.shared.log("Received acknowledgment: \(ackMessage), success: \(acknowledged)")
                 }
 
                 switch ackCode {
@@ -371,26 +1520,63 @@ import WatchConnectivity
                 }
             }
 
-            // 2) Raw watchState data
             if let watchStateData = message[WatchMessageKeys.watchState] as? [String: Any] {
-                self.scheduleUIUpdate(with: watchStateData)
+                let completionPath = self.pendingConnectivityTasks.isEmpty ? nil : "message"
+                self.scheduleUIUpdate(
+                    with: watchStateData,
+                    fromUserInfo: false,
+                    pendingConnectivityCompletionPath: completionPath
+                )
             }
         }
     }
 
-    /// Accumulate new data, set isSyncing, and debounce final update
-    private func scheduleUIUpdate(with newData: [String: Any]) {
-        if let incomingTimestamp = newData[WatchMessageKeys.date] as? TimeInterval,
-           let lastTimestamp = lastWatchStateUpdate,
-           incomingTimestamp <= lastTimestamp
-        {
-            Task {
-                await WatchLogger.shared.log("Skipping UI update — outdated WatchState (\(incomingTimestamp))")
+    private func scheduleUIUpdate(
+        with newData: [String: Any],
+        fromUserInfo: Bool = false,
+        userInfoReceiveTimestamp: Date? = nil,
+        pendingConnectivityCompletionPath: String? = nil
+    ) {
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { [self] in
+                scheduleUIUpdate(
+                    with: newData,
+                    fromUserInfo: fromUserInfo,
+                    userInfoReceiveTimestamp: userInfoReceiveTimestamp,
+                    pendingConnectivityCompletionPath: pendingConnectivityCompletionPath
+                )
             }
             return
         }
 
-        // 1) Mark as syncing
+        guard let incomingDate = dateValue(from: newData[WatchMessageKeys.date]) else {
+            Task {
+                await WatchLogger.shared.log("Invalid date format in WatchState data")
+            }
+            if let pendingConnectivityCompletionPath {
+                completePendingConnectivityTasksOnMain(
+                    path: "\(pendingConnectivityCompletionPath)_invalid",
+                    requiresNoPendingContent: true
+                )
+            }
+            return
+        }
+
+        if let lastTimestamp = lastWatchStateUpdate,
+           incomingDate <= lastTimestamp
+        {
+            Task {
+                await WatchLogger.shared.log("Skipping UI update — outdated WatchState (\(incomingDate))")
+            }
+            if let pendingConnectivityCompletionPath {
+                completePendingConnectivityTasksOnMain(
+                    path: "\(pendingConnectivityCompletionPath)_outdated",
+                    requiresNoPendingContent: true
+                )
+            }
+            return
+        }
+
         DispatchQueue.main.async {
             self.showSyncingAnimation = true
         }
@@ -399,69 +1585,105 @@ import WatchConnectivity
             await WatchLogger.shared.log("Merging new WatchState data with keys: \(newData.keys.joined(separator: ", "))")
         }
 
-        // 2) Merge data into our pendingData
         pendingData.merge(newData) { _, newVal in newVal }
 
-        // 3) Cancel any previous finalization
         finalizeWorkItem?.cancel()
 
-        // 4) Create and schedule a new finalization
+        let fromUserInfoCapture = fromUserInfo
+        let userInfoTsCapture = userInfoReceiveTimestamp
+        let completionPathCapture = pendingConnectivityCompletionPath
         let workItem = DispatchWorkItem { [self] in
             Task {
-                await WatchLogger.shared.log("⏳ Debounced update fired")
+                await WatchLogger.shared.log("Debounced update fired")
             }
-            self.finalizePendingData()
+            self.finalizePendingData(
+                fromUserInfo: fromUserInfoCapture,
+                userInfoReceiveTimestamp: userInfoTsCapture,
+                pendingConnectivityCompletionPath: completionPathCapture
+            )
         }
         finalizeWorkItem = workItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4, execute: workItem)
+        let delay: TimeInterval = isColdStart ? 0.2 : 0.1
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
     }
 
-    /// Applies all pending data to the watch state in one shot
-    private func finalizePendingData() {
+    private func finalizePendingData(
+        fromUserInfo: Bool = false,
+        userInfoReceiveTimestamp: Date? = nil,
+        pendingConnectivityCompletionPath: String? = nil
+    ) {
         guard !pendingData.isEmpty else {
             Task {
-                await WatchLogger.shared.log("⚠️ finalizePendingData called with empty data")
+                await WatchLogger.shared.log("finalizePendingData called with empty data")
             }
 
-            // If we have no actual data, just end syncing
             DispatchQueue.main.async {
                 self.showSyncingAnimation = false
+            }
+            if let pendingConnectivityCompletionPath {
+                completePendingConnectivityTasksOnMain(
+                    path: "\(pendingConnectivityCompletionPath)_empty",
+                    requiresNoPendingContent: true
+                )
             }
             return
         }
 
         Task {
-            await WatchLogger.shared.log("⌚️ Finalizing pending data")
+            await WatchLogger.shared.log("Finalizing pending data")
         }
 
-        // Actually set your main UI properties here
-        processRawDataForWatchState(pendingData)
-
-        // Clear
+        processRawDataForWatchState(pendingData, fromUserInfo: fromUserInfo, userInfoReceiveTimestamp: userInfoReceiveTimestamp)
         pendingData.removeAll()
 
-        // Done - hide sync animation
         DispatchQueue.main.async {
             self.showSyncingAnimation = false
         }
 
         Task {
-            await WatchLogger.shared.log("✅ Watch UI update complete")
+            await WatchLogger.shared.log("Watch UI update complete")
+        }
+
+        guard let pendingConnectivityCompletionPath else { return }
+        let pendingCountBeforeCompletion = pendingConnectivityTasks.count
+        let wid = BackgroundTaskWindowCounter.currentOrNil() ?? -1
+        if pendingCountBeforeCompletion > 0 {
+            Task {
+                await WatchLogger.shared.log("event=complication_finalize_begin window_id=\(wid) pending_count=\(pendingCountBeforeCompletion)")
+            }
+        } else {
+            Task {
+                await WatchLogger.shared.log(
+                    "event=complication_finalize_no_pending_tasks window_id=\(wid)"
+                        + " path=\(pendingConnectivityCompletionPath)"
+                )
+            }
+        }
+        let clearedCount = completePendingConnectivityTasksOnMain(
+            path: pendingConnectivityCompletionPath,
+            recordMarkerWithoutPendingTasks: true
+        )
+        if clearedCount > 0 {
+            Task {
+                await WatchLogger.shared.log("event=complication_finalize_end window_id=\(wid) cleared_count=\(clearedCount)")
+            }
         }
     }
 
-    /// Updates the UI properties
-    private func processRawDataForWatchState(_ message: [String: Any]) {
+    private func processRawDataForWatchState(_ message: [String: Any], fromUserInfo: Bool = false, userInfoReceiveTimestamp: Date? = nil) {
         Task {
             await WatchLogger.shared.log("Processing raw WatchState data with keys: \(message.keys.joined(separator: ", "))")
         }
 
-        if let timestamp = message[WatchMessageKeys.date] as? TimeInterval {
-            lastWatchStateUpdate = timestamp
-            Task {
-                await WatchLogger.shared.log("Updated lastWatchStateUpdate: \(timestamp)")
-            }
+        startupFirstRefreshInFlight = false
+
+        if let date = dateValue(from: message[WatchMessageKeys.date]) {
+            lastWatchStateUpdate = date
+            forcedSinceActivation = false
         }
+
+        syncTimeoutWorkItem?.cancel()
+        syncTimeoutWorkItem = nil
 
         if let currentGlucose = message[WatchMessageKeys.currentGlucose] as? String {
             self.currentGlucose = currentGlucose
@@ -494,29 +1716,27 @@ import WatchConnectivity
         if let glucoseData = message[WatchMessageKeys.glucoseValues] as? [[String: Any]] {
             glucoseValues = glucoseData.compactMap { data in
                 guard let glucose = data["glucose"] as? Double,
-                      let timestamp = data["date"] as? TimeInterval,
                       let colorString = data["color"] as? String
                 else { return nil }
 
-                return (
-                    Date(timeIntervalSince1970: timestamp),
-                    glucose,
-                    colorString.toColor() // Convert colorString to Color
-                )
+                let dateValue = dateValue(from: data["date"])
+                guard let date = dateValue else { return nil }
+
+                return (date: date, glucose: glucose, color: colorString.toColor())
             }
             .sorted { $0.date < $1.date }
         }
 
-        if let minYAxisValue = message[WatchMessageKeys.minYAxisValue] {
-            if let decimalValue = (minYAxisValue as? NSNumber)?.decimalValue {
-                self.minYAxisValue = decimalValue
-            }
+        if let minYAxisValue = message[WatchMessageKeys.minYAxisValue],
+           let decimalValue = (minYAxisValue as? NSNumber)?.decimalValue
+        {
+            self.minYAxisValue = decimalValue
         }
 
-        if let maxYAxisValue = message[WatchMessageKeys.maxYAxisValue] {
-            if let decimalValue = (maxYAxisValue as? NSNumber)?.decimalValue {
-                self.maxYAxisValue = decimalValue
-            }
+        if let maxYAxisValue = message[WatchMessageKeys.maxYAxisValue],
+           let decimalValue = (maxYAxisValue as? NSNumber)?.decimalValue
+        {
+            self.maxYAxisValue = decimalValue
         }
 
         if let overrideData = message[WatchMessageKeys.overridePresets] as? [[String: Any]] {
@@ -537,41 +1757,376 @@ import WatchConnectivity
             }
         }
 
-        if let maxBolusValue = message[WatchMessageKeys.maxBolus] {
-            if let decimalValue = (maxBolusValue as? NSNumber)?.decimalValue {
-                maxBolus = decimalValue
+        if let maxBolusValue = message[WatchMessageKeys.maxBolus],
+           let decimalValue = (maxBolusValue as? NSNumber)?.decimalValue
+        {
+            maxBolus = decimalValue
+        }
+
+        if let maxCarbsValue = message[WatchMessageKeys.maxCarbs],
+           let decimalValue = (maxCarbsValue as? NSNumber)?.decimalValue
+        {
+            maxCarbs = decimalValue
+        }
+
+        if let maxFatValue = message[WatchMessageKeys.maxFat],
+           let decimalValue = (maxFatValue as? NSNumber)?.decimalValue
+        {
+            maxFat = decimalValue
+        }
+
+        if let maxProteinValue = message[WatchMessageKeys.maxProtein],
+           let decimalValue = (maxProteinValue as? NSNumber)?.decimalValue
+        {
+            maxProtein = decimalValue
+        }
+
+        if let bolusIncrement = message[WatchMessageKeys.bolusIncrement],
+           let decimalValue = (bolusIncrement as? NSNumber)?.decimalValue
+        {
+            self.bolusIncrement = max(decimalValue, 0.05)
+        }
+
+        if let confirmBolusFaster = message[WatchMessageKeys.confirmBolusFaster] as? Bool {
+            self.confirmBolusFaster = confirmBolusFaster
+        }
+
+        saveComplicationSnapshot(from: message, fromUserInfo: fromUserInfo, userInfoReceiveTimestamp: userInfoReceiveTimestamp)
+
+        emitResidentMemorySample(
+            checkpoint: "first_watch_state_apply",
+            activationSequence: startupCurrentActivationSequence
+        )
+    }
+
+    private func saveComplicationSnapshot(from message: [String: Any], fromUserInfo: Bool = false, userInfoReceiveTimestamp: Date? = nil) {
+        Task {
+            await WatchLogger.shared.log("📸 saveComplicationSnapshot called with keys: \(message.keys.joined(separator: ", "))")
+        }
+
+        // R3: effective CGM reading time (shared resolver; see `resolveEffectiveCGMReadingDate`)
+        let readingDate: Date
+        switch resolveEffectiveCGMReadingDate(from: message) {
+        case let .found(date):
+            readingDate = date
+        case .rejectedDateOnly:
+            Task {
+                await WatchLogger.shared.log(
+                    "⚠️ saveComplicationSnapshot: no reading_epoch or glucoseValues;"
+                        + " top-level date is state snapshot time only — refusing as CGM reading — skipping save"
+                )
+            }
+            return
+        case .missing:
+            Task {
+                await WatchLogger.shared.log(
+                    "📸 saveComplicationSnapshot SKIPPED: no valid CGM reading timestamp"
+                        + " (no reading_epoch, glucoseValues, or parseable date)"
+                )
+            }
+            return
+        }
+
+        let glucoseValue = message[WatchMessageKeys.currentGlucose] as? String ?? currentGlucose
+        let trendValue = message[WatchMessageKeys.trend] as? String ?? trend ?? ""
+        let deltaValue = message[WatchMessageKeys.delta] as? String ?? delta ?? ""
+        let glucoseColorValue = (message[WatchMessageKeys.currentGlucoseColorString] as? String) ?? currentGlucoseColorString
+
+        Task {
+            await WatchLogger.shared.log("📸 Saving snapshot: glucose=\(glucoseValue), trend=\(trendValue), delta=\(deltaValue), readingDate=\(readingDate)")
+            await WatchLogger.shared.log("🔍 Debug: glucoseValue source - message: \(message[WatchMessageKeys.currentGlucose] as? String ?? "nil"), currentGlucose: \(currentGlucose)")
+        }
+
+        let snapshot = TrioComplicationSnapshot(
+            glucose: glucoseValue,
+            trend: trendValue,
+            delta: deltaValue,
+            readingDate: readingDate,
+            date: Date(),
+            glucoseColor: glucoseColorValue
+        )
+
+        // Phase 3.0 — pre-dispatch dedup. saveOnMain is authoritative.
+        if TrioComplicationDataStore.shared.shouldSkipPreDispatch(for: snapshot, handler: "message") {
+            return
+        }
+
+        TrioComplicationDataStore.shared.save(snapshot, minInterval: 5)
+
+        // R5c — log decode latency and reading_epoch for the payload we just saved (avoids misattribution when overlapping userInfo deliveries).
+        // Use only the threaded userInfoReceiveTimestamp; no fallback to instance state so attribution stays unambiguous.
+        if fromUserInfo, let start = userInfoReceiveTimestamp {
+            let decodeMs = Int(Date().timeIntervalSince(start) * 1000)
+            let readingEpoch = Int(readingDate.timeIntervalSince1970)
+            Task {
+                await WatchLogger.shared.log("⏱️ userInfo_decoded reading_epoch=\(readingEpoch) decode_ms=\(decodeMs)")
+            }
+        }
+        if fromUserInfo {
+            lastUserInfoReceiveTimestamp = nil
+        }
+    }
+
+    func forceComplicationUpdate() {
+        Task {
+            await WatchLogger.shared.log("🔄 forceComplicationUpdate called")
+        }
+
+        guard !currentGlucose.isEmpty,
+              !currentGlucose.contains("??"),
+              !currentGlucose.localizedCaseInsensitiveContains("error")
+        else {
+            Task {
+                await WatchLogger.shared.log("🔄 forceComplicationUpdate SKIPPED: invalid glucose '\(currentGlucose)'")
+            }
+            return
+        }
+
+        if let glucoseValue = Double(currentGlucose.replacingOccurrences(of: " mg/dL", with: "")) {
+            guard glucoseValue >= 40 && glucoseValue <= 400 else {
+                Task {
+                    await WatchLogger.shared.log("🔄 forceComplicationUpdate SKIPPED: glucose out of range")
+                }
+                return
             }
         }
 
-        if let maxCarbsValue = message[WatchMessageKeys.maxCarbs] {
-            if let decimalValue = (maxCarbsValue as? NSNumber)?.decimalValue {
-                maxCarbs = decimalValue
+        guard let effectiveReadingDate = TrioComplicationDataStore.lastValidTimestamp else {
+            Task {
+                await WatchLogger.shared.log("🔄 forceComplicationUpdate SKIPPED: no valid CGM reading timestamp")
+            }
+            return
+        }
+
+        let snapshot = TrioComplicationSnapshot(
+            glucose: currentGlucose,
+            trend: trend ?? "",
+            delta: delta ?? "",
+            readingDate: effectiveReadingDate,
+            date: Date(),
+            glucoseColor: currentGlucoseColorString
+        )
+
+        Task {
+            await WatchLogger.shared.log("🔄 forceComplicationUpdate: glucose=\(currentGlucose), readingDate=\(effectiveReadingDate)")
+        }
+
+        TrioComplicationDataStore.shared.save(snapshot, triggerReload: false)
+        TrioComplicationDataStore.shared.forceReload(scheduleRetry: false)
+    }
+
+    /// R5d: after a detected sleep gap, force a widget reload. Rate-limited to 5 minutes.
+    /// Stale-backlog detection is diagnostic only — the reload always fires.
+    private func forceWidgetReloadIfStale(receivedGap: TimeInterval) {
+        let store = TrioComplicationDataStore.shared
+
+        // Rate limiter: 5-minute minimum between forced reloads
+        if let lastReload = store.lastWidgetReloadAt(),
+           Date().timeIntervalSince(lastReload) < 300 {
+            Task {
+                await WatchLogger.shared.log("💤 sleep_gap_reload_skipped reason=rate_limited last_reload_ago=\(Int(Date().timeIntervalSince(lastReload)))s")
+            }
+            return
+        }
+
+        // Diagnostic snapshot read: measures I/O latency and detects stale-backlog scenarios.
+        // No snapshot-age guard — callers save before calling this, so latestSnapshot() reflects
+        // just-saved data. A freshness guard would block the reload in precisely the scenario
+        // this function exists for. The rate limiter above is the correct storm guard.
+        let readStart = CFAbsoluteTimeGetCurrent()
+        let snapshot = store.latestSnapshot()
+        let snapshotReadMs = Int((CFAbsoluteTimeGetCurrent() - readStart) * 1000)
+        let snapshotEpoch = snapshot.map { Int($0.readingDate.timeIntervalSince1970) } ?? -1
+        let snapshotAgeSeconds = snapshot.map { Int(Date().timeIntervalSince($0.readingDate)) }
+        let snapshotAgeDisplay = snapshotAgeSeconds.map { "\($0)s" } ?? "no_snapshot"
+        let gapDisplay = receivedGap.isInfinite ? "first_receive" : "\(Int(receivedGap))"
+
+        let isStaleBacklog: Bool
+        if let age = snapshotAgeSeconds, !receivedGap.isInfinite {
+            isStaleBacklog = age > Int(receivedGap - 60)
+        } else {
+            isStaleBacklog = true
+        }
+        if isStaleBacklog {
+            Task {
+                await WatchLogger.shared.log("⚠️ sleep_gap_reload_stale_backlog reading_epoch=\(snapshotEpoch) snapshot_age=\(snapshotAgeDisplay) gap=\(gapDisplay)s read_ms=\(snapshotReadMs)")
+            }
+        } else {
+            Task {
+                await WatchLogger.shared.log("💤 sleep_gap_reload_firing reading_epoch=\(snapshotEpoch) snapshot_age=\(snapshotAgeDisplay) gap=\(gapDisplay)s read_ms=\(snapshotReadMs)")
             }
         }
 
-        if let maxFatValue = message[WatchMessageKeys.maxFat] {
-            if let decimalValue = (maxFatValue as? NSNumber)?.decimalValue {
-                maxFat = decimalValue
+        store.setLastWidgetReloadAt(Date())
+        store.forceReload(scheduleRetry: false)
+    }
+
+    #if os(watchOS)
+        func scheduleBackgroundRefresh() {
+            let hasRecentData = lastWatchStateUpdate != nil &&
+                Date().timeIntervalSince(lastWatchStateUpdate!) < 300
+
+            let nextInterval: TimeInterval
+            if isReachable {
+                nextInterval = hasRecentData ? 300 : 180
+            } else {
+                nextInterval = hasRecentData ? 900 : 600
+            }
+
+            let refreshDate = Date().addingTimeInterval(nextInterval)
+            WKExtension.shared().scheduleBackgroundRefresh(withPreferredDate: refreshDate, userInfo: nil) { error in
+                Task {
+                    if let error = error {
+                        await WatchLogger.shared.log("Failed to schedule background refresh: \(error)")
+                    } else {
+                        await WatchLogger.shared.log("Scheduled background refresh at \(refreshDate)")
+                    }
+                }
             }
         }
 
-        if let maxProteinValue = message[WatchMessageKeys.maxProtein] {
-            if let decimalValue = (maxProteinValue as? NSNumber)?.decimalValue {
-                maxProtein = decimalValue
+        func handleBackgroundTasks(_ tasks: Set<WKRefreshBackgroundTask>) {
+            Task {
+                await WatchLogger.shared.log("Handling background tasks: \(tasks.count)")
             }
+
+            for task in tasks {
+                if let refreshTask = task as? WKApplicationRefreshBackgroundTask {
+                    backgroundRefreshCount += 1
+                    lastBackgroundRefreshDate = Date()
+
+                    if isReachable {
+                        requestWatchStateUpdate()
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                            self.forceComplicationUpdate()
+                        }
+                    } else {
+                        loadFallbackDataFromComplication()
+                        forceComplicationUpdate()
+                    }
+
+                    refreshTask.setTaskCompletedWithSnapshot(false)
+                    scheduleBackgroundRefresh()
+                } else if task is WKWatchConnectivityRefreshBackgroundTask {
+                    let (bgTaskWindowId, receivedAt) = BackgroundTaskWindowCounter.next()
+                    Task {
+                        await WatchLogger.shared.log("event=complication_bgtask_received window_id=\(bgTaskWindowId) task_type=WKWatchConnectivityRefreshBackgroundTask 📡 BGTask received: WKWatchConnectivityRefreshBackgroundTask window_id=\(bgTaskWindowId)")
+                    }
+                    // Hold until userInfo processing completes (quiet-window or 5s safety timeout). All access on main.
+                    // Multiple tasks in one wake are all stored; multiple didReceiveUserInfo reset the 300ms quiet window; last timer runs, then one finalize and complete all. If handle(_:backgroundTasks:) is delivered after the terminal path already fired (userInfo/context first, then task), the short-lived terminal marker rescues the late task; the 5s timeout remains the final fallback.
+                    DispatchQueue.main.async { [self] in
+                        pendingConnectivityTasks.append(task)
+                        let pendingCount = pendingConnectivityTasks.count
+                        Task {
+                            await WatchLogger.shared.log("event=complication_bgtask_enqueued window_id=\(bgTaskWindowId) task_type=WKWatchConnectivityRefreshBackgroundTask pending_count=\(pendingCount)")
+                        }
+                        if let terminalPath = recentConnectivityTerminalBasePathOnMain() {
+                            let lateCompletionPath = "\(terminalPath)_late_task"
+                            let clearedCount = completePendingConnectivityTasksOnMain(
+                                path: lateCompletionPath,
+                                requiresNoPendingContent: true
+                            )
+                            if clearedCount > 0 { return }
+                        }
+                        let taskToComplete = task
+                        let windowId = bgTaskWindowId
+                        let receivedAtCapture = receivedAt
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) { [self] in
+                            if let idx = pendingConnectivityTasks.firstIndex(where: { $0 === taskToComplete }) {
+                                pendingConnectivityTasks.remove(at: idx)
+                                if pendingConnectivityTasks.isEmpty {
+                                    clearDeferredConnectivityCompletionRetryOnMain()
+                                }
+                                let completionDelayMs = Int(Date().timeIntervalSince(receivedAtCapture) * 1000)
+                                Task {
+                                    await WatchLogger.shared.log("event=complication_bgtask_completing path=timeout window_id=\(windowId) task_type=WKWatchConnectivityRefreshBackgroundTask completion_delay_ms=\(completionDelayMs) completed_count=1 📡 BGTask completing (timeout) window_id=\(windowId)")
+                                }
+                                taskToComplete.setTaskCompletedWithSnapshot(false)
+                            }
+                        }
+                    }
+                } else {
+                    task.setTaskCompletedWithSnapshot(false)
+                }
+            }
+        }
+    #endif
+
+    func loadFallbackDataFromComplication() {
+        guard let snapshot = TrioComplicationDataStore.shared.latestSnapshot() else {
+            DispatchQueue.main.async {
+                self.showSyncingAnimation = false
+            }
+            return
         }
 
-        if let bolusIncrement = message[WatchMessageKeys.bolusIncrement] {
-            if let decimalValue = (bolusIncrement as? NSNumber)?.decimalValue {
-                // limit minimum to 0.05 to avoid dealing with 0.025 increments
-                self.bolusIncrement = max(decimalValue, 0.05)
+        if let lastUpdate = lastWatchStateUpdate,
+           Date().timeIntervalSince(lastUpdate) <= 15
+        {
+            DispatchQueue.main.async {
+                self.showSyncingAnimation = false
             }
+            return
         }
 
-        if let confirmBolusFaster = message[WatchMessageKeys.confirmBolusFaster] {
-            if let booleanValue = confirmBolusFaster as? Bool {
-                self.confirmBolusFaster = booleanValue
+        DispatchQueue.main.async {
+            self.currentGlucose = snapshot.glucose
+            self.trend = snapshot.trend
+            self.delta = snapshot.delta
+            if let glucoseColor = snapshot.glucoseColor {
+                self.currentGlucoseColorString = glucoseColor
             }
+            self.lastWatchStateUpdate = snapshot.readingDate
+            self.showSyncingAnimation = false
+            self.syncTimeoutWorkItem?.cancel()
         }
+    }
+
+    private func dateValue(from value: Any?) -> Date? {
+        if let date = value as? Date {
+            return date
+        }
+        if let seconds = value as? TimeInterval {
+            return Date(timeIntervalSince1970: seconds)
+        }
+        if let number = value as? NSNumber {
+            return Date(timeIntervalSince1970: number.doubleValue)
+        }
+        return nil
+    }
+
+    private func latestGlucoseDate(from message: [String: Any]) -> Date? {
+        guard let glucoseData = message[WatchMessageKeys.glucoseValues] as? [[String: Any]] else {
+            return nil
+        }
+
+        let dates = glucoseData.compactMap { data in
+            dateValue(from: data["date"])
+        }
+        return dates.max()
+    }
+
+    private enum EffectiveCGMReadingDateResolution {
+        case found(Date)
+        case rejectedDateOnly
+        case missing
+    }
+
+    /// Resolves the CGM reading timestamp from a watch state / complication payload.
+    /// Uses `dateValue(from:)` for `reading_epoch` so bridged `NSNumber` / `Date` / `TimeInterval` match other timestamp fields.
+    /// Order: `reading_epoch` (R1a), then newest `glucoseValues` sample.
+    /// The top-level `date` key is **build/state snapshot time**, not the CGM reading time; if that is the only
+    /// parseable timestamp, the result is `.rejectedDateOnly` so callers never treat it as a reading.
+    private func resolveEffectiveCGMReadingDate(from message: [String: Any]) -> EffectiveCGMReadingDateResolution {
+        if let d = dateValue(from: message[WatchMessageKeys.readingEpoch]) {
+            return .found(d)
+        }
+        if let d = latestGlucoseDate(from: message) {
+            return .found(d)
+        }
+        if dateValue(from: message[WatchMessageKeys.date]) != nil {
+            return .rejectedDateOnly
+        }
+        return .missing
     }
 }

--- a/Trio Watch App Extension/WatchState.swift
+++ b/Trio Watch App Extension/WatchState.swift
@@ -53,6 +53,16 @@ enum BackgroundTaskWindowCounter {
     var cob: String? = "--"
     var iob: String? = "--"
     var lastLoopTime: String? = "--"
+
+    /// Which data path last *won* the complication store for the value on screen.
+    var displayedComplicationDataSource: TrioComplicationDataSource = .unknown
+
+    // MARK: - G7 direct BLE observer (watch)
+
+    var g7DirectBLEStatus: G7DirectBLEStatus = .off
+    var lastG7DirectBLEEventDate: Date?
+    var g7DirectBLEStatusLabel: String = ""
+
     var overridePresets: [OverridePresetWatch] = []
     var tempTargetPresets: [TempTargetPresetWatch] = []
 
@@ -670,11 +680,13 @@ enum BackgroundTaskWindowCounter {
             delta: deltaString,
             readingDate: readingDate,
             date: Date(),
-            glucoseColor: nil
+            glucoseColor: nil,
+            dataSource: .healthKit
         )
 
-        DispatchQueue.main.async {
+        DispatchQueue.main.async { [self] in
             TrioComplicationDataStore.shared.save(snapshot, minInterval: 5)
+            displayedComplicationDataSource = .healthKit
             completionHandler()
         }
     }
@@ -1097,7 +1109,8 @@ enum BackgroundTaskWindowCounter {
             trend: payload[WatchMessageKeys.trend] as? String ?? "",
             delta: payload[WatchMessageKeys.delta] as? String ?? "",
             readingDate: readingDate,
-            date: Date()
+            date: Date(),
+            dataSource: .watchConnectivityPhone
         )
         if TrioComplicationDataStore.shared.shouldSkipPreDispatch(for: tempSnapshot, handler: "userInfo") {
             DispatchQueue.main.async { [weak self] in
@@ -1843,7 +1856,8 @@ enum BackgroundTaskWindowCounter {
             delta: deltaValue,
             readingDate: readingDate,
             date: Date(),
-            glucoseColor: glucoseColorValue
+            glucoseColor: glucoseColorValue,
+            dataSource: .watchConnectivityPhone
         )
 
         // Phase 3.0 — pre-dispatch dedup. saveOnMain is authoritative.
@@ -1852,6 +1866,7 @@ enum BackgroundTaskWindowCounter {
         }
 
         TrioComplicationDataStore.shared.save(snapshot, minInterval: 5)
+        displayedComplicationDataSource = .watchConnectivityPhone
 
         // R5c — log decode latency and reading_epoch for the payload we just saved (avoids misattribution when overlapping userInfo deliveries).
         // Use only the threaded userInfoReceiveTimestamp; no fallback to instance state so attribution stays unambiguous.
@@ -1904,7 +1919,8 @@ enum BackgroundTaskWindowCounter {
             delta: delta ?? "",
             readingDate: effectiveReadingDate,
             date: Date(),
-            glucoseColor: currentGlucoseColorString
+            glucoseColor: currentGlucoseColorString,
+            dataSource: .watchConnectivityPhone
         )
 
         Task {

--- a/Trio Watch App/Info.plist
+++ b/Trio Watch App/Info.plist
@@ -2,10 +2,19 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>EXAppExtensionAttributes</key>
-	<dict>
-		<key>EXExtensionPointIdentifier</key>
-		<string>com.apple.appintents-extension</string>
-	</dict>
+	<!--
+	  Watch app Info.plist “merge” file.
+
+	  The `Trio Watch App` target uses `GENERATE_INFOPLIST_FILE = YES`.
+	  Xcode’s generated watch app Info.plist output has not been reliably emitting custom keys
+	  via `INFOPLIST_KEY_*` (e.g. `INFOPLIST_KEY_AppGroupID`), so we provide a real Info.plist
+	  file and configure the target to merge it at build time (`INFOPLIST_FILE`).
+	-->
+	<key>AppGroupID</key>
+	<string>$(TRIO_APP_GROUP_ID)</string>
+	<key>NSHealthShareUsageDescription</key>
+	<string>Trio reads your blood glucose data to keep the watch complication current when wireless sync is unavailable.</string>
+	<key>NSHealthUpdateUsageDescription</key>
+	<string>Trio may save blood glucose readings to Apple Health to keep your health data synchronized.</string>
 </dict>
 </plist>

--- a/Trio Watch App/TrioWatchApp.entitlements
+++ b/Trio Watch App/TrioWatchApp.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.healthkit</key>
+	<true/>
+	<key>com.apple.developer.healthkit.background-delivery</key>
+	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>$(TRIO_APP_GROUP_ID)</string>
+	</array>
+</dict>
+</plist>

--- a/Trio Watch Complication/Info.plist
+++ b/Trio Watch Complication/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>AppGroupID</key>
+	<string>$(TRIO_APP_GROUP_ID)</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/Trio Watch Complication/TrioWatchComplication.entitlements
+++ b/Trio Watch Complication/TrioWatchComplication.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>$(TRIO_APP_GROUP_ID)</string>
+	</array>
+</dict>
+</plist>

--- a/Trio Watch Complication/TrioWatchComplication.swift
+++ b/Trio Watch Complication/TrioWatchComplication.swift
@@ -1,40 +1,277 @@
+import Foundation
 import SwiftUI
 import WidgetKit
 
-// MARK: - Timeline Entry
+private enum ComplicationDefaults {
+    static let widgetKind = TrioComplicationDataStore.complicationKind
+    static let fallbackGlucose = "--"
+    static let fallbackDelta = "--"
+    static let fallbackTrend = "↔︎"
+}
 
 struct TrioWatchComplicationEntry: TimelineEntry {
     let date: Date
-}
+    let readingDate: Date
+    let glucose: String
+    let trend: String
+    let delta: String
+    let state: String?
+    let glucoseColor: String?
 
-// MARK: - Provider
-
-struct TrioWatchComplicationProvider: TimelineProvider {
-    func placeholder(in _: Context) -> TrioWatchComplicationEntry {
-        TrioWatchComplicationEntry(date: Date())
+    init(
+        date: Date,
+        readingDate: Date? = nil,
+        glucose: String,
+        trend: String,
+        delta: String,
+        state: String? = nil,
+        glucoseColor: String? = nil
+    ) {
+        self.date = date
+        self.readingDate = readingDate ?? date
+        self.glucose = glucose
+        self.trend = trend
+        self.delta = delta
+        self.state = state
+        self.glucoseColor = glucoseColor
     }
 
-    func getSnapshot(in _: Context, completion: @escaping (TrioWatchComplicationEntry) -> Void) {
-        let entry = TrioWatchComplicationEntry(date: Date())
+    init(snapshot: TrioComplicationSnapshot) {
+        self.init(
+            date: Date(),
+            readingDate: snapshot.readingDate,
+            glucose: snapshot.glucose,
+            trend: snapshot.trend,
+            delta: snapshot.delta,
+            state: snapshot.state,
+            glucoseColor: snapshot.glucoseColor
+        )
+    }
+
+    var trendSymbol: String {
+        TrendSymbolMapper.symbol(from: trend)
+    }
+
+    var glucoseNumber: String {
+        let trimmed = glucose.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? ComplicationDefaults.fallbackGlucose : trimmed
+    }
+
+    var trendSymbolOnly: String {
+        trendSymbol
+    }
+
+    var statePrefix: String {
+        let stateText = state ?? ""
+        return stateText.isEmpty ? "" : "\(stateText) "
+    }
+
+    var deltaDisplayText: String {
+        let trimmed = delta.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? ComplicationDefaults.fallbackDelta : trimmed
+    }
+
+    var hasValidReading: Bool {
+        let trimmed = glucose.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !trimmed.isEmpty && trimmed != ComplicationDefaults.fallbackGlucose && state == nil
+    }
+
+    var glucoseDisplayColor: Color {
+        if let hexColor = glucoseColor, let color = Color(hex: hexColor) {
+            return color
+        }
+
+        guard let glucoseValue = Double(glucose) else {
+            return .secondary
+        }
+
+        let lowThreshold: Double = 70
+        let highThreshold: Double = 180
+
+        if glucoseValue <= lowThreshold {
+            return .red
+        } else if glucoseValue >= highThreshold {
+            return .orange
+        } else {
+            return .green
+        }
+    }
+}
+
+private enum TrendSymbolMapper {
+    static func symbol(from rawValue: String) -> String {
+        switch rawValue {
+        case "TripleUp": return "↑↑↑"
+        case "DoubleUp": return "↑↑"
+        case "SingleUp": return "↑"
+        case "FortyFiveUp": return "↗︎"
+        case "Flat": return "→"
+        case "FortyFiveDown": return "↘︎"
+        case "SingleDown": return "↓"
+        case "DoubleDown": return "↓↓"
+        case "TripleDown": return "↓↓↓"
+        case "NONE", "NOT COMPUTABLE", "NotComputable", "RATE OUT OF RANGE": return "↔︎"
+        default:
+            if rawValue.contains("↑") || rawValue.contains("↓") || rawValue.contains("→") ||
+                rawValue.contains("↗") || rawValue.contains("↘︎")
+            {
+                return rawValue
+            }
+            return ""
+        }
+    }
+}
+
+private enum ProviderProcessState {
+    static let instanceID = UUID()
+    static var lastSeenGeneration: Int?
+    static var isFirstCall = true
+}
+
+struct TrioWatchComplicationProvider: TimelineProvider {
+    private let refreshInterval: TimeInterval = 300
+
+    func placeholder(in _: Context) -> TrioWatchComplicationEntry {
+        TrioWatchComplicationEntry(
+            date: Date(),
+            readingDate: Date(),
+            glucose: "110",
+            trend: "Flat",
+            delta: "+1"
+        )
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (TrioWatchComplicationEntry) -> Void) {
+        if context.isPreview {
+            completion(placeholder(in: context))
+            return
+        }
+        let entry = loadLatestEntry()
+        let getSnapshotAtEpochSeconds = Int(Date().timeIntervalSince1970)
+        let dataAgeSeconds: Int = {
+            let rd = entry.readingDate
+            if rd == .distantPast || rd.timeIntervalSince1970 <= 0 { return -1 }
+            return max(0, Int(Date().timeIntervalSince(rd)))
+        }()
+        TrioComplicationDataStore.shared.logWidgetGetSnapshotInvocation(
+            getSnapshotAtEpochSeconds: getSnapshotAtEpochSeconds,
+            dataAgeSeconds: dataAgeSeconds
+        )
         completion(entry)
     }
 
     func getTimeline(in _: Context, completion: @escaping (Timeline<TrioWatchComplicationEntry>) -> Void) {
-        let entry = TrioWatchComplicationEntry(date: Date())
-        let timeline = Timeline(entries: [entry], policy: .never)
-        completion(timeline)
+        let store = TrioComplicationDataStore.shared
+        let nowEpochSeconds = Int(Date().timeIntervalSince1970)
+        let appGroupAvailable = store.isAppGroupAvailable()
+
+        let observedGeneration: Int
+        let generationSource: String
+        if !appGroupAvailable {
+            observedGeneration = -1
+            generationSource = "unavailable"
+        } else if let gen = store.currentReloadGeneration() {
+            observedGeneration = gen
+            generationSource = "set"
+        } else {
+            observedGeneration = 0
+            generationSource = "unset"
+        }
+
+        let lastReloadEpoch = store.lastReloadRequestEpochSeconds()
+
+        let isRestart = ProviderProcessState.isFirstCall
+        ProviderProcessState.isFirstCall = false
+
+        let generationDelta: Int
+        if !appGroupAvailable {
+            generationDelta = -1
+        } else if let lastSeen = ProviderProcessState.lastSeenGeneration {
+            generationDelta = observedGeneration - lastSeen
+        } else {
+            generationDelta = -1
+        }
+
+        if appGroupAvailable {
+            ProviderProcessState.lastSeenGeneration = observedGeneration
+        }
+
+        let latencyValid: Bool
+        let latencySeconds: Int
+        if let epoch = lastReloadEpoch {
+            let elapsed = nowEpochSeconds - epoch
+            latencyValid = elapsed >= 0 && elapsed <= TrioComplicationDataStore.latencyValidityWindowSeconds
+            latencySeconds = latencyValid ? elapsed : -1
+        } else {
+            latencyValid = false
+            latencySeconds = -1
+        }
+
+        let reloadId = store.newestReloadRecord()?.id.uuidString ?? "none"
+
+        let snapshot = loadLatestEntry()
+        let getTimelineAtEpochSeconds = Int(Date().timeIntervalSince1970)
+        let dataAgeSeconds: Int = {
+            let rd = snapshot.readingDate
+            if rd == .distantPast || rd.timeIntervalSince1970 <= 0 { return -1 }
+            return max(0, Int(Date().timeIntervalSince(rd)))
+        }()
+
+        store.logWidgetGetTimelineInvocation(
+            appGroupAvailable: appGroupAvailable,
+            observedGenerationSource: generationSource,
+            observedReloadGeneration: observedGeneration,
+            generationDelta: generationDelta,
+            providerInstanceId: ProviderProcessState.instanceID.uuidString,
+            providerRestart: isRestart,
+            latencyValid: latencyValid,
+            latencySeconds: latencySeconds,
+            reloadRequestedAtEpochSeconds: lastReloadEpoch ?? -1,
+            mostRecentReloadId: reloadId,
+            getTimelineAtEpochSeconds: getTimelineAtEpochSeconds,
+            dataAgeSeconds: dataAgeSeconds
+        )
+        var entries: [TrioWatchComplicationEntry] = []
+        let now = Date().roundedDownToMinute
+
+        for minuteOffset in 0 ..< 30 {
+            let entryDate = now.addingTimeInterval(TimeInterval(minuteOffset * 60))
+            let entry = TrioWatchComplicationEntry(
+                date: entryDate,
+                readingDate: snapshot.readingDate,
+                glucose: snapshot.glucose,
+                trend: snapshot.trend,
+                delta: snapshot.delta,
+                state: snapshot.state,
+                glucoseColor: snapshot.glucoseColor
+            )
+            entries.append(entry)
+        }
+        let nextRefresh = now.addingTimeInterval(refreshInterval)
+        completion(Timeline(entries: entries, policy: .after(nextRefresh)))
+    }
+
+    private func loadLatestEntry() -> TrioWatchComplicationEntry {
+        if let snapshot = TrioComplicationDataStore.shared.latestSnapshot() {
+            return TrioWatchComplicationEntry(snapshot: snapshot)
+        }
+        return TrioWatchComplicationEntry(
+            date: Date(),
+            readingDate: .distantPast,
+            glucose: ComplicationDefaults.fallbackGlucose,
+            trend: ComplicationDefaults.fallbackTrend,
+            delta: ComplicationDefaults.fallbackDelta,
+            state: "--"
+        )
     }
 }
 
-// MARK: - Views
-
-//// Displayed View Wrapper
 struct TrioWatchComplicationEntryView: View {
-    @Environment(\.widgetFamily) private var widgetFamily
-
     var entry: TrioWatchComplicationEntry
 
-    var body: some View {
+    @Environment(\.widgetFamily) private var widgetFamily
+
+    @ViewBuilder var body: some View {
         switch widgetFamily {
         case .accessoryCircular:
             TrioAccessoryCircularView(entry: entry)
@@ -43,48 +280,130 @@ struct TrioWatchComplicationEntryView: View {
         default:
             Image("ComplicationIcon")
                 .widgetAccentable()
-                .widgetBackground(backgroundView: Color.clear)
         }
     }
 }
 
-/// Corner Complication
 struct TrioAccessoryCornerView: View {
-    var entry: TrioWatchComplicationProvider.Entry
+    var entry: TrioWatchComplicationEntry
 
     var body: some View {
-        Text("")
+        Text(attributedGlucoseLine)
+            .font(.system(size: 12, weight: .semibold, design: .rounded))
+            .minimumScaleFactor(0.6)
+            .widgetAccentable()
             .widgetCurvesContent()
             .widgetLabel {
-                Text("Trio")
+                let age = max(0, entry.date.timeIntervalSince(entry.readingDate))
+                let recencyColor: Color = age < 5 * 60 ? .green :
+                    age < 15 * 60 ? .yellow : .red
+                let deltaText = entry.deltaDisplayText
+                let timeText = shortRelativeTime(from: entry.readingDate, now: entry.date)
+                let hasDelta = !deltaText.isEmpty && deltaText != ComplicationDefaults.fallbackDelta
+                let hasReading = entry.hasValidReading
+
+                Text(attributedSecondLine(
+                    deltaText: deltaText,
+                    timeText: timeText,
+                    recencyColor: recencyColor,
+                    hasDelta: hasDelta,
+                    hasReading: hasReading
+                ))
+                .font(.system(size: 10, weight: .medium, design: .rounded))
+                .lineLimit(1)
+                .minimumScaleFactor(0.5)
+                .truncationMode(.tail)
             }
-            .widgetBackground(backgroundView: Color.clear)
+    }
+
+    private var attributedGlucoseLine: AttributedString {
+        var result = AttributedString()
+
+        if !entry.statePrefix.isEmpty {
+            var stateAttr = AttributedString(entry.statePrefix)
+            stateAttr.foregroundColor = .white
+            result.append(stateAttr)
+        }
+
+        var glucoseAttr = AttributedString(entry.glucoseNumber)
+        glucoseAttr.foregroundColor = entry.glucoseDisplayColor
+        result.append(glucoseAttr)
+
+        if !entry.trendSymbolOnly.isEmpty {
+            var spaceAttr = AttributedString(" ")
+            spaceAttr.foregroundColor = .white
+            result.append(spaceAttr)
+        }
+
+        if !entry.trendSymbolOnly.isEmpty {
+            var trendAttr = AttributedString(entry.trendSymbolOnly)
+            trendAttr.foregroundColor = .white
+            result.append(trendAttr)
+        }
+
+        return result
+    }
+
+    private func attributedSecondLine(
+        deltaText: String,
+        timeText: String,
+        recencyColor: Color,
+        hasDelta: Bool,
+        hasReading: Bool
+    ) -> AttributedString {
+        var result = AttributedString()
+
+        if hasReading && hasDelta {
+            var deltaAttr = AttributedString(deltaText)
+            deltaAttr.foregroundColor = .white
+            result.append(deltaAttr)
+
+            var separatorAttr = AttributedString(" • ")
+            separatorAttr.foregroundColor = .white
+            result.append(separatorAttr)
+
+            var timeAttr = AttributedString(timeText)
+            timeAttr.foregroundColor = recencyColor
+            result.append(timeAttr)
+        } else if hasReading {
+            var timeAttr = AttributedString(timeText)
+            timeAttr.foregroundColor = recencyColor
+            result.append(timeAttr)
+        } else {
+            var fallbackAttr = AttributedString(ComplicationDefaults.fallbackDelta)
+            fallbackAttr.foregroundColor = .white
+            result.append(fallbackAttr)
+        }
+
+        return result
     }
 }
 
-/// Circular Complication
 struct TrioAccessoryCircularView: View {
-    var entry: TrioWatchComplicationProvider.Entry
+    var entry: TrioWatchComplicationEntry
 
     var body: some View {
-        Image("ComplicationIcon")
-            .resizable()
-            .widgetAccentable()
-            .widgetBackground(backgroundView: Color.clear)
+        VStack {
+            Text(entry.glucoseNumber)
+                .font(.headline)
+                .foregroundColor(entry.glucoseDisplayColor)
+            Text(entry.trendSymbolOnly)
+                .foregroundColor(.white)
+        }
+        .widgetAccentable()
     }
 }
 
-// MARK: - Widget Configuration
-
 @main struct TrioWatchComplication: Widget {
-    let kind: String = "TrioWatchComplication"
+    let kind: String = ComplicationDefaults.widgetKind
 
     var body: some WidgetConfiguration {
         StaticConfiguration(kind: kind, provider: TrioWatchComplicationProvider()) { entry in
             TrioWatchComplicationEntryView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
         }
-        .configurationDisplayName("Trio")
-        .description("Displays Trio app icon as complication")
+        .configurationDisplayName(String(localized: "Trio Glucose"))
+        .description(String(localized: "Shows current glucose, delta, and trend data."))
         .supportedFamilies([
             .accessoryCorner,
             .accessoryCircular
@@ -92,14 +411,59 @@ struct TrioAccessoryCircularView: View {
     }
 }
 
-extension View {
-    func widgetBackground(backgroundView: some View) -> some View {
-        if #available(watchOS 10.0, iOSApplicationExtension 17.0, iOS 17.0, *) {
-            return containerBackground(for: .widget) {
-                backgroundView
-            }
-        } else {
-            return background(backgroundView)
+private func shortRelativeTime(from readingDate: Date, now: Date = Date()) -> String {
+    if readingDate == .distantPast { return "--" }
+
+    let interval = max(0, now.timeIntervalSince(readingDate))
+    if interval < 60 { return "NOW" }
+
+    // Use floor division to avoid rounding up (e.g., 61 minutes should show "1h", not "2h")
+    let totalMinutes = Int(interval / 60)
+
+    if totalMinutes < 60 {
+        return "\(totalMinutes)m"
+    } else if totalMinutes < 1440 {
+        // For times between 1 hour and 24 hours, show hours
+        // Use integer division (not ceil) to avoid showing "2h" for 61 minutes
+        let hours = totalMinutes / 60
+        return "\(hours)h"
+    } else {
+        let days = totalMinutes / 1440
+        return "\(days)d"
+    }
+}
+
+extension Color {
+    init?(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let a, r, g, b: UInt64
+        switch hex.count {
+        case 3:
+            (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
+        case 6:
+            (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
+        case 8:
+            (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
+        default:
+            return nil
         }
+
+        self.init(
+            .sRGB,
+            red: Double(r) / 255,
+            green: Double(g) / 255,
+            blue: Double(b) / 255,
+            opacity: Double(a) / 255
+        )
+    }
+}
+
+extension Date {
+    var roundedDownToMinute: Date {
+        let calendar = Calendar.current
+        let components = calendar.dateComponents([.year, .month, .day, .hour, .minute], from: self)
+        return calendar.date(from: components) ?? self
     }
 }

--- a/Trio Watch Complication/TrioWatchComplicationPreview.swift
+++ b/Trio Watch Complication/TrioWatchComplicationPreview.swift
@@ -1,0 +1,124 @@
+import SwiftUI
+import WidgetKit
+
+#if DEBUG
+    struct TrioWatchComplicationPreview: PreviewProvider {
+        static var previews: some View {
+            Group {
+                TrioAccessoryCornerView(
+                    entry: .init(
+                        snapshot: TrioComplicationSnapshot(
+                            glucose: "110",
+                            trend: "Flat",
+                            delta: "+2",
+                            readingDate: Date(),
+                            date: Date(),
+                            glucoseColor: "#30D158"
+                        )
+                    )
+                )
+                .containerBackground(.fill.tertiary, for: .widget)
+                .previewDisplayName("Recent (Green)")
+                .previewContext(WidgetPreviewContext(family: .accessoryCorner))
+
+                TrioAccessoryCornerView(
+                    entry: .init(
+                        snapshot: TrioComplicationSnapshot(
+                            glucose: "92",
+                            trend: "SingleDown",
+                            delta: "-4",
+                            readingDate: Date().addingTimeInterval(-4 * 60),
+                            date: Date(),
+                            glucoseColor: "#FF9500"
+                        )
+                    )
+                )
+                .containerBackground(.fill.tertiary, for: .widget)
+                .previewDisplayName("Medium (Yellow)")
+                .previewContext(WidgetPreviewContext(family: .accessoryCorner))
+
+                TrioAccessoryCornerView(
+                    entry: .init(
+                        snapshot: TrioComplicationSnapshot(
+                            glucose: "125",
+                            trend: "SingleUp",
+                            delta: "+4",
+                            readingDate: Date().addingTimeInterval(-10 * 60),
+                            date: Date(),
+                            glucoseColor: "#30D158"
+                        )
+                    )
+                )
+                .containerBackground(.fill.tertiary, for: .widget)
+                .previewDisplayName("Medium (Yellow, 10m)")
+                .previewContext(WidgetPreviewContext(family: .accessoryCorner))
+
+                TrioAccessoryCornerView(
+                    entry: .init(
+                        snapshot: TrioComplicationSnapshot(
+                            glucose: "--",
+                            trend: "",
+                            delta: "--",
+                            readingDate: Date().addingTimeInterval(-30 * 60),
+                            date: Date(),
+                            state: "--",
+                            glucoseColor: nil
+                        )
+                    )
+                )
+                .containerBackground(.fill.tertiary, for: .widget)
+                .previewDisplayName("Stale (Red)")
+                .previewContext(WidgetPreviewContext(family: .accessoryCorner))
+
+                TrioAccessoryCornerView(
+                    entry: .init(
+                        snapshot: TrioComplicationSnapshot(
+                            glucose: "--",
+                            trend: "",
+                            delta: "--",
+                            readingDate: .distantPast,
+                            date: Date(),
+                            state: "!!",
+                            glucoseColor: nil
+                        )
+                    )
+                )
+                .containerBackground(.fill.tertiary, for: .widget)
+                .previewDisplayName("Error State (!!)")
+                .previewContext(WidgetPreviewContext(family: .accessoryCorner))
+
+                TrioAccessoryCornerView(
+                    entry: .init(
+                        snapshot: TrioComplicationSnapshot(
+                            glucose: "250",
+                            trend: "DoubleUp",
+                            delta: "+15",
+                            readingDate: Date().addingTimeInterval(-2 * 60),
+                            date: Date(),
+                            glucoseColor: "#FF9500"
+                        )
+                    )
+                )
+                .containerBackground(.fill.tertiary, for: .widget)
+                .previewDisplayName("High Glucose (Orange)")
+                .previewContext(WidgetPreviewContext(family: .accessoryCorner))
+
+                TrioAccessoryCornerView(
+                    entry: .init(
+                        snapshot: TrioComplicationSnapshot(
+                            glucose: "65",
+                            trend: "SingleDown",
+                            delta: "-8",
+                            readingDate: Date().addingTimeInterval(-1 * 60),
+                            date: Date(),
+                            glucoseColor: "#FF3B30"
+                        )
+                    )
+                )
+                .containerBackground(.fill.tertiary, for: .widget)
+                .previewDisplayName("Low Glucose (Red)")
+                .previewContext(WidgetPreviewContext(family: .accessoryCorner))
+            }
+        }
+    }
+#endif

--- a/Trio Watch Shared/ComplicationLogBuffer.swift
+++ b/Trio Watch Shared/ComplicationLogBuffer.swift
@@ -1,0 +1,347 @@
+import Foundation
+#if os(watchOS)
+import WatchKit
+#endif
+
+/// Hybrid log buffer: in-memory ring (all targets) + optional App Group file (complication only, WIDGET_EXTENSION).
+/// Used by TrioComplicationDataStore.log(). Watch App drains the file and forwards to Better Stack.
+///
+/// Contract:
+/// - Single writer: only the complication extension appends to the file. Watch app drains (read, rename,
+///   truncate, delete); must not append.
+/// - Writer only ever writes to `complication_log.txt`; never to drain files (complication_log.drain.*).
+/// - File format: newline-delimited UTF-8; same path/truncation as 06. Drain is race-safe (atomic
+///   rename-then-read). Truncation is a full-file rewrite and can race with a concurrent drain rename;
+///   we accept best-effort loss and possible rare corrupt chunk in that case.
+enum ComplicationLogBuffer {
+    // MARK: - Ring buffer (all targets)
+    private static let maxEntries = 200
+    private static var entries: [String] = []
+
+    // MARK: - File (06 contract: same path, format, truncation)
+    private static let logFileName = "complication_log.txt"
+    private static let logsSubdir = "logs"
+    private static let sizeCapBytes = 64 * 1024
+    private static let truncateKeepBytes = 32 * 1024
+
+    /// Single queue for ring + file within process. Drain uses atomic rename-then-read; best-effort delivery, rare corruption possible when truncation races with drain.
+    private static let queue = DispatchQueue(label: "ComplicationLogBuffer.queue")
+
+    #if os(watchOS)
+    // Non-widget battery cache (Watch App Extension only; access/mutate only on queue or MainActor per below).
+    // Queue-confined (access/mutate only on ComplicationLogBuffer.queue):
+    private static var nonWidgetLastBatteryContext: String = "battery_level_percent=unknown battery_state=unknown"
+    private static var nonWidgetLastBatteryRefreshEpoch: TimeInterval = 0
+    private static var nonWidgetBatteryRefreshInFlight: Bool = false
+    // MainActor-confined (access/mutate only on MainActor, inside nonWidgetBatteryContextOnMain()):
+    private static var nonWidgetHasEnabledBatteryMonitoring: Bool = false
+
+    @MainActor
+    private static func nonWidgetBatteryContextOnMain() -> String {
+        let device = WKInterfaceDevice.current()
+        if !nonWidgetHasEnabledBatteryMonitoring {
+            nonWidgetHasEnabledBatteryMonitoring = true
+            device.isBatteryMonitoringEnabled = true
+        }
+        let levelText: String
+        if device.batteryLevel >= 0 {
+            levelText = String(Int((device.batteryLevel * 100).rounded()))
+        } else {
+            levelText = "unknown"
+        }
+        let stateText: String
+        switch device.batteryState {
+        case .unknown:
+            stateText = "unknown"
+        case .unplugged:
+            stateText = "unplugged"
+        case .charging:
+            stateText = "charging"
+        case .full:
+            stateText = "full"
+        @unknown default:
+            stateText = "unknown_default"
+        }
+        return "battery_level_percent=\(levelText) battery_state=\(stateText)"
+    }
+    #endif
+
+    #if WIDGET_EXTENSION
+    private static var hasLoggedAppGroupUnavailable = false
+
+    #if os(watchOS)
+    private static var hasEnabledBatteryMonitoring = false
+
+    @MainActor
+    private static func batteryContextOnMain() -> String {
+        let device = WKInterfaceDevice.current()
+        if !hasEnabledBatteryMonitoring {
+            hasEnabledBatteryMonitoring = true
+            device.isBatteryMonitoringEnabled = true
+        }
+        let levelText: String
+        if device.batteryLevel >= 0 {
+            levelText = String(Int((device.batteryLevel * 100).rounded()))
+        } else {
+            levelText = "unknown"
+        }
+        let stateText: String
+        switch device.batteryState {
+        case .unknown:
+            stateText = "unknown"
+        case .unplugged:
+            stateText = "unplugged"
+        case .charging:
+            stateText = "charging"
+        case .full:
+            stateText = "full"
+        @unknown default:
+            stateText = "unknown_default"
+        }
+        return "battery_level_percent=\(levelText) battery_state=\(stateText)"
+    }
+
+    // Queue-confined battery cache (access/mutate only on ComplicationLogBuffer.queue).
+    private static var lastBatteryContext = "battery_level_percent=unknown battery_state=unknown"
+    private static var lastBatteryRefreshEpoch: TimeInterval = 0
+    private static var batteryRefreshInFlight = false
+    #endif
+    #endif
+    private static var hasLoggedFileAppendStatus = false
+
+    private static let build: String = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown"
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
+        return formatter
+    }()
+
+    /// Appends a log line. Ring in all targets; file append only when WIDGET_EXTENSION (complication target).
+    /// In the complication process we use sync so the write completes before return (process may be short-lived).
+    static func append(
+        _ message: String,
+        file: String = #fileID,
+        line: Int = #line,
+        function: String = #function
+    ) {
+        #if WIDGET_EXTENSION
+        queue.sync {
+            let now = Date().timeIntervalSince1970
+            #if os(watchOS)
+            let contextToUse = lastBatteryContext
+            if now - lastBatteryRefreshEpoch >= 60, !batteryRefreshInFlight {
+                batteryRefreshInFlight = true
+                Task {
+                    // Defaults ensure we never write garbage if something goes sideways before refresh completes.
+                    var fresh = lastBatteryContext
+                    var refreshedAt = lastBatteryRefreshEpoch
+
+                    defer {
+                        ComplicationLogBuffer.queue.async {
+                            lastBatteryContext = fresh
+                            lastBatteryRefreshEpoch = refreshedAt
+                            batteryRefreshInFlight = false
+                        }
+                    }
+
+                    fresh = await MainActor.run { ComplicationLogBuffer.batteryContextOnMain() }
+                    refreshedAt = Date().timeIntervalSince1970
+                }
+
+            }
+            #else
+            let contextToUse = "battery_level_percent=unsupported battery_state=unsupported"
+            #endif
+            doAppendWithBattery(message: message, file: file, line: line, function: function, batteryContext: contextToUse)
+        }
+        #else
+        #if os(watchOS)
+        queue.async {
+            // Snapshot queue-confined state once (avoids inconsistent multi-reads).
+            let cachedContext = nonWidgetLastBatteryContext
+            let cachedRefreshedAt = nonWidgetLastBatteryRefreshEpoch
+            let refreshInFlight = nonWidgetBatteryRefreshInFlight
+
+            doAppendRingOnly(message: "\(message) \(cachedContext)")
+
+            let now = Date().timeIntervalSince1970
+            if now - cachedRefreshedAt >= 60, !refreshInFlight {
+                nonWidgetBatteryRefreshInFlight = true
+
+                Task {
+                    // Defaults ensure we never write garbage if something goes sideways before refresh completes.
+                    var fresh = cachedContext
+                    var refreshedAt = cachedRefreshedAt
+
+                    defer {
+                        ComplicationLogBuffer.queue.async {
+                            nonWidgetLastBatteryContext = fresh
+                            nonWidgetLastBatteryRefreshEpoch = refreshedAt
+                            nonWidgetBatteryRefreshInFlight = false
+                        }
+                    }
+
+                    fresh = await MainActor.run { ComplicationLogBuffer.nonWidgetBatteryContextOnMain() }
+                    refreshedAt = Date().timeIntervalSince1970
+                }
+            }
+        }
+        #else
+        queue.async {
+            doAppendRingOnly(message: message)
+        }
+        #endif
+        #endif
+    }
+
+    private static func doAppendRingOnly(message: String) {
+        entries.append(message)
+        if entries.count > maxEntries {
+            entries = Array(entries.suffix(maxEntries))
+        }
+        if !hasLoggedFileAppendStatus {
+            hasLoggedFileAppendStatus = true
+            let bid = Bundle.main.bundleIdentifier ?? "nil"
+            NSLog("[ComplicationLogBuffer] file-append disabled; bundle id=%@", bid)
+        }
+    }
+
+    #if WIDGET_EXTENSION
+    private static func doAppendWithBattery(message: String, file: String, line: Int, function: String, batteryContext: String) {
+        entries.append(message)
+        if entries.count > maxEntries {
+            entries = Array(entries.suffix(maxEntries))
+        }
+        if !hasLoggedFileAppendStatus {
+            hasLoggedFileAppendStatus = true
+            let bid = Bundle.main.bundleIdentifier ?? "nil"
+            NSLog("[ComplicationLogBuffer] file-append enabled; bundle id=%@", bid)
+        }
+        appendToFile(message: message, file: file, line: line, function: function, batteryContext: batteryContext)
+    }
+    #endif
+
+    #if WIDGET_EXTENSION
+    // MARK: - File append (complication target only; same format/path/truncation as 06)
+    private static func appendToFile(message: String, file: String, line: Int, function: String, batteryContext: String) {
+        let shortFile = (file as NSString).lastPathComponent
+        let timestamp = dateFormatter.string(from: Date())
+        let entry = "[\(timestamp)] [b:\(build)] [\(shortFile):\(line)] \(function) → \(message) \(batteryContext)\n"
+
+        guard let logURL = logFileURL() else {
+            NSLog("[ComplicationLogBuffer] %@", String(entry.dropLast()))
+            if !hasLoggedAppGroupUnavailable {
+                hasLoggedAppGroupUnavailable = true
+                NSLog("[ComplicationLogBuffer] App Group unavailable; using NSLog fallback")
+            }
+            return
+        }
+
+        do {
+            let fileManager = FileManager.default
+            let dirURL = logURL.deletingLastPathComponent()
+            if !fileManager.fileExists(atPath: dirURL.path) {
+                try fileManager.createDirectory(at: dirURL, withIntermediateDirectories: true)
+            }
+
+            guard let data = entry.data(using: .utf8) else { return }
+
+            if fileManager.fileExists(atPath: logURL.path) {
+                let handle = try FileHandle(forWritingTo: logURL)
+                handle.seekToEndOfFile()
+                handle.write(data)
+                try? handle.close()
+
+                if let attrs = try? fileManager.attributesOfItem(atPath: logURL.path),
+                   let size = attrs[.size] as? Int64,
+                   size > sizeCapBytes {
+                    truncateKeepingNewest(at: logURL)
+                }
+            } else {
+                try data.write(to: logURL)
+            }
+        } catch {
+            NSLog("[ComplicationLogBuffer] write failed: %@", error.localizedDescription)
+        }
+    }
+
+    // MARK: - Truncation (file only; same as 06)
+    private static func truncateKeepingNewest(at url: URL) {
+        guard let data = try? Data(contentsOf: url),
+              let content = String(data: data, encoding: .utf8) else { return }
+
+        let lines = content.components(separatedBy: "\n").filter { !$0.isEmpty }
+
+        var keptBytes = 0
+        var keptLines: [String] = []
+        for line in lines.reversed() {
+            let lineBytes = (line + "\n").utf8.count
+            if keptBytes + lineBytes > truncateKeepBytes { break }
+            keptBytes += lineBytes
+            keptLines.insert(line, at: 0)
+        }
+
+        let droppedCount = lines.count - keptLines.count
+        let marker = "[dropped \(droppedCount) lines]\n"
+        let newContent = marker + keptLines.map { $0 + "\n" }.joined()
+        try? newContent.write(to: url, atomically: true, encoding: .utf8)
+    }
+    #endif
+
+    // MARK: - File URLs (all targets; drain in Watch App needs these)
+    /// Returns the log file URL in the App Group container, or nil if unavailable.
+    static func logFileURL() -> URL? {
+        guard let containerURL = sharedContainerURL() else { return nil }
+        return containerURL
+            .appendingPathComponent(logsSubdir, isDirectory: true)
+            .appendingPathComponent(logFileName, isDirectory: false)
+    }
+
+    /// Returns the shared container URL. Used by append (Complication) and drain (Watch App).
+    static func sharedContainerURL() -> URL? {
+        var bundle: Bundle = .main
+        let classBundle = Bundle(for: _BundleAnchor.self)
+        if classBundle.object(forInfoDictionaryKey: "AppGroupID") != nil {
+            bundle = classBundle
+        }
+
+        guard let suiteName = resolveAppGroupID(bundle: bundle).value else { return nil }
+        return FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: suiteName)
+    }
+
+    // MARK: - App Group Resolution (mirrors 06; same logic for drain compatibility)
+    private static func appGroupID(forTeamID teamID: String) -> String {
+        "group.org.nightscout.\(teamID).trio.trio-app-group"
+    }
+
+    private static func extractTeamID(fromBundleIdentifier bid: String?) -> String? {
+        guard let bid, !bid.isEmpty else { return nil }
+        let prefix = "org.nightscout."
+        guard let prefixRange = bid.range(of: prefix) else { return nil }
+        let after = bid[prefixRange.upperBound...]
+        guard let trioRange = after.range(of: ".trio") else { return nil }
+        let teamID = String(after[..<trioRange.lowerBound])
+        return teamID.isEmpty ? nil : teamID
+    }
+
+    private static func resolveAppGroupID(bundle: Bundle) -> (value: String?, source: String) {
+        if let value = bundle.object(forInfoDictionaryKey: "AppGroupID") as? String, !value.isEmpty {
+            return (value, "Info.plist(AppGroupID)")
+        }
+        #if os(watchOS)
+        if let companionID = Bundle.main.object(forInfoDictionaryKey: "WKCompanionAppBundleIdentifier") as? String,
+           let teamID = extractTeamID(fromBundleIdentifier: companionID)
+        {
+            return (appGroupID(forTeamID: teamID), "Derived(WKCompanionAppBundleIdentifier)")
+        }
+        #endif
+        if let teamID = extractTeamID(fromBundleIdentifier: bundle.bundleIdentifier) {
+            return (appGroupID(forTeamID: teamID), "Derived(bundleIdentifier)")
+        }
+        return (nil, "Unavailable")
+    }
+}
+
+/// Anchor class for Bundle(for:) lookup since the enum has no instances.
+private final class _BundleAnchor { }

--- a/Trio Watch Shared/TrioComplicationDataSource.swift
+++ b/Trio Watch Shared/TrioComplicationDataSource.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Provenance of the glucose value saved to the complication data store.
+enum TrioComplicationDataSource: String, Sendable, Equatable, Codable, CaseIterable {
+    /// iPhone / WatchConnectivity watchState path.
+    case watchConnectivityPhone
+    /// Direct G7 eavesdrop on the watch.
+    case g7DirectBLE
+    /// R6 HealthKit path.
+    case healthKit
+    /// Unset.
+    case unknown
+}

--- a/Trio Watch Shared/TrioComplicationDataStore.swift
+++ b/Trio Watch Shared/TrioComplicationDataStore.swift
@@ -1,0 +1,1082 @@
+import Foundation
+import os
+#if os(watchOS)
+import WatchConnectivity
+#endif
+import WidgetKit
+
+struct TrioComplicationSnapshot: Equatable, Codable {
+    private enum Constants {
+        static let fallbackGlucose = "--"
+        static let fallbackDelta = "--"
+    }
+
+    let glucose: String
+    let trend: String
+    let delta: String
+    let date: Date
+    let readingDate: Date
+    let state: String?
+    let glucoseColor: String?
+
+    // INVARIANT (Phase 3.4): All display-field sanitization here.
+    // Dedup always compares sanitized values.
+    init(
+        glucose rawGlucose: String,
+        trend rawTrend: String,
+        delta rawDelta: String,
+        readingDate: Date,
+        date: Date,
+        state: String? = nil,
+        glucoseColor: String? = nil
+    ) {
+        glucose = Self.sanitizedGlucose(from: rawGlucose)
+        trend = rawTrend.trimmingCharacters(in: .whitespacesAndNewlines)
+        delta = Self.sanitizedDelta(from: rawDelta)
+        self.readingDate = readingDate
+        self.date = date
+        self.state = state
+        self.glucoseColor = glucoseColor
+    }
+
+    private static func sanitizedGlucose(from value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return Constants.fallbackGlucose }
+        if trimmed == Constants.fallbackGlucose { return Constants.fallbackGlucose }
+
+        let digitsAndSeparators = CharacterSet(charactersIn: "0123456789.")
+        let numericPortion = trimmed
+            .components(separatedBy: digitsAndSeparators.inverted)
+            .joined()
+
+        if let doubleValue = Double(numericPortion), doubleValue > 0 {
+            let rounded = Int(doubleValue.rounded())
+            return String(rounded)
+        }
+
+        return trimmed
+    }
+
+    private static func sanitizedDelta(from value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return Constants.fallbackDelta }
+        if trimmed == Constants.fallbackDelta { return Constants.fallbackDelta }
+
+        let allowed = CharacterSet(charactersIn: "+-0123456789.,")
+        let filteredScalars = trimmed.unicodeScalars.filter { allowed.contains($0) }
+        let normalized = String(filteredScalars).replacingOccurrences(of: ",", with: ".")
+
+        guard !normalized.isEmpty, let numericValue = Double(normalized) else {
+            return trimmed
+        }
+
+        let magnitude = abs(numericValue)
+        let roundedMagnitude = magnitude.rounded()
+        if abs(roundedMagnitude - magnitude) < 0.05 {
+            let signedInt = Int(roundedMagnitude) * (numericValue >= 0 ? 1 : -1)
+            return String(format: "%+d", signedInt)
+        }
+
+        return String(format: "%+.1f", numericValue)
+    }
+}
+
+// Phase 3.0 — pre-dispatch dedup. saveOnMain is authoritative.
+// glucoseColor excluded: see shouldUpdate comment (Phase 3.2) for rationale.
+struct ComplicationSnapshotFingerprint: Codable, Equatable {
+    let readingDateEpoch: Int
+    let glucose: String
+    let trend: String
+    let delta: String
+    let state: String
+}
+
+extension ComplicationSnapshotFingerprint {
+    init(from snapshot: TrioComplicationSnapshot) {
+        readingDateEpoch = Int(snapshot.readingDate.timeIntervalSince1970)
+        glucose = snapshot.glucose
+        trend = snapshot.trend
+        delta = snapshot.delta
+        // Sentinel for nil: state is always optional in the model; sentinel ensures
+        // nil and non-nil are always distinguishable in Equatable comparison.
+        state = snapshot.state ?? "<nil>"
+    }
+}
+
+/// Record of a complication reload request for instrumentation (WidgetKit budget/coalescing correlation).
+/// requestedAtEpochSeconds is the reload request time, not the CGM reading time. Do not use reading_date_epoch here.
+struct ComplicationReloadRecord: Codable {
+    let id: UUID
+    /// Reload request time (Int(Date().timeIntervalSince1970)). Not CGM reading time.
+    let requestedAtEpochSeconds: Int
+}
+
+/// Ring buffer of reload records in App Group UserDefaults. Watch app writes; complication extension reads only.
+/// Best-effort, not lossless: concurrent or overlapping writes can drop records; decode failure on read is treated as empty.
+private enum ComplicationReloadRing {
+    static let key = "complication_reload_ring"
+    static let capacity = 64
+
+    /// Appends a record to the ring (watch app only). Drops oldest if count > capacity.
+    static func append(_ record: ComplicationReloadRecord, suiteName: String) {
+        let defaults = UserDefaults(suiteName: suiteName)
+        guard let defaults else { return }
+        var list = (defaults.data(forKey: key).flatMap { try? JSONDecoder().decode([ComplicationReloadRecord].self, from: $0) }) ?? []
+        list.append(record)
+        if list.count > capacity {
+            list = Array(list.suffix(capacity))
+        }
+        if let data = try? JSONEncoder().encode(list) {
+            defaults.set(data, forKey: key)
+        }
+    }
+
+    /// Returns the newest record (most recent reload request). Complication extension reads only.
+    static func newestRecord(suiteName: String?) -> ComplicationReloadRecord? {
+        guard let suiteName,
+              let defaults = UserDefaults(suiteName: suiteName),
+              let data = defaults.data(forKey: key),
+              let list = try? JSONDecoder().decode([ComplicationReloadRecord].self, from: data),
+              let last = list.last else { return nil }
+        return last
+    }
+}
+
+/// Data store for watch complication snapshots and reload coordination.
+/// This class is main-thread confined: all public API methods (`save`, `coalescedReload`, `forceReload`)
+/// must be called from the main thread or will hop to main before executing.
+final class TrioComplicationDataStore {
+    static let shared = TrioComplicationDataStore()
+    static let complicationKind = "TrioWatchComplication"
+
+    // MARK: - App Group ID Resolution
+
+    /// Canonical App Group ID format used by this project (derived from Team ID).
+    private static func appGroupID(forTeamID teamID: String) -> String {
+        "group.org.nightscout.\(teamID).trio.trio-app-group"
+    }
+
+    /// Attempts to extract the Team ID from a bundle identifier of the form:
+    /// - `org.nightscout.<TEAM>.trio`
+    /// - `org.nightscout.<TEAM>.trio.watchkitapp`
+    /// - `org.nightscout.<TEAM>.trio.watchkitapp.<Something>`
+    private static func extractTeamID(fromNightscoutBundleIdentifier bundleIdentifier: String?) -> String? {
+        guard let bundleIdentifier, !bundleIdentifier.isEmpty else { return nil }
+        let prefix = "org.nightscout."
+        guard let prefixRange = bundleIdentifier.range(of: prefix) else { return nil }
+        let afterPrefix = bundleIdentifier[prefixRange.upperBound...]
+
+        guard let trioRange = afterPrefix.range(of: ".trio") else { return nil }
+        let teamID = String(afterPrefix[..<trioRange.lowerBound])
+        guard !teamID.isEmpty else { return nil }
+        return teamID
+    }
+
+    /// Resolves the App Group ID using multiple fallbacks, in priority order:
+    /// 1) `AppGroupID` key in the chosen bundle's Info.plist
+    /// 2) Derive from the watch app's `WKCompanionAppBundleIdentifier` (watchOS only)
+    /// 3) Derive from the chosen bundle's bundle identifier
+    private static func resolveAppGroupID(bundle: Bundle) -> (value: String?, source: String) {
+        if let value = bundle.object(forInfoDictionaryKey: "AppGroupID") as? String, !value.isEmpty {
+            return (value, "Info.plist(AppGroupID)")
+        }
+
+        #if os(watchOS)
+        if let companionBundleID = Bundle.main.object(forInfoDictionaryKey: "WKCompanionAppBundleIdentifier") as? String,
+           let teamID = extractTeamID(fromNightscoutBundleIdentifier: companionBundleID) {
+            return (appGroupID(forTeamID: teamID), "Derived(WKCompanionAppBundleIdentifier)")
+        }
+        #endif
+
+        if let teamID = extractTeamID(fromNightscoutBundleIdentifier: bundle.bundleIdentifier) {
+            return (appGroupID(forTeamID: teamID), "Derived(bundleIdentifier)")
+        }
+
+        return (nil, "Unavailable")
+    }
+
+    // MARK: - UserDefaults Keys
+
+    private static let lastReloadKey = "TrioComplication_lastReload"
+    private static let lastValidTimestampKey = "TrioComplication_lastValidTimestamp"
+    private static let reloadGenerationTokenKey = "TrioComplication_reloadGenerationToken"
+    private static let reloadGenerationKey = "TrioComplication_reloadGeneration"
+    private static let lastReloadRequestEpochSecondsKey = "TrioComplication_lastReloadRequestEpochSeconds"
+    private static let fingerprintKey = "complication_last_saved_fingerprint"
+    // R5d — last time any data channel delivered data to the watch (persisted for sleep-gap detection)
+    private static let lastDataReceivedAtKey = "TrioComplication_lastDataReceivedAt"
+    private static let lastWidgetReloadAtKey = "TrioComplication_lastWidgetReloadAt"
+
+    // R6.1 — HealthKit anchored query state (watch app extension only)
+    private static let hkGlucoseAnchorKey = "TrioComplication_hkGlucoseAnchor"
+    private static let hkLastReceivedGlucoseEpochKey = "TrioComplication_hkLastReceivedGlucoseEpoch"
+    private static let hkLastReceivedGlucoseValueMgDlKey = "TrioComplication_hkLastReceivedGlucoseValueMgDl"
+    static let latencyValidityWindowSeconds = 600
+
+    /// Reused for structured log fields (reading_date); avoids per-call allocation.
+    private static let iso8601Formatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    // MARK: - Persisted State (shared across processes via UserDefaults in App Group)
+
+    /// Last valid glucose reading timestamp - persisted to survive process restarts.
+    /// Falls back to in-memory storage if appGroupDefaults is unavailable.
+    // Eventually consistent. Monotonic guard reduces but does not eliminate TOCTOU.
+    // Accepted. Do not use NSFileCoordinator (blocks provider) or flock (invalid
+    // cross-process on Darwin). Phase 3.3.
+    static var lastValidTimestamp: Date? {
+        get {
+            if let defaults = shared.appGroupDefaults,
+               let date = defaults.object(forKey: lastValidTimestampKey) as? Date {
+                return date
+            }
+            return shared.inMemoryLastValidTimestamp
+        }
+        set {
+            if let defaults = shared.appGroupDefaults {
+                defaults.set(newValue, forKey: lastValidTimestampKey)
+            } else {
+                shared.inMemoryLastValidTimestamp = newValue
+            }
+        }
+    }
+
+    /// Last reload timestamp - persisted to share debounce state across processes
+    /// Falls back to in-memory storage if appGroupDefaults is unavailable
+    private var lastReload: Date {
+        get {
+            if let defaults = appGroupDefaults,
+               let date = defaults.object(forKey: Self.lastReloadKey) as? Date {
+                return date
+            }
+            return inMemoryLastReload
+        }
+        set {
+            if let defaults = appGroupDefaults {
+                defaults.set(newValue, forKey: Self.lastReloadKey)
+            }
+            inMemoryLastReload = newValue
+        }
+    }
+
+    /// Reload generation token - UUID string regenerated ONLY when an actual WidgetKit reload is initiated
+    /// (coalescedReload passes debounce, or forceReload). Used to detect if a newer reload attempt has
+    /// occurred since a retry was scheduled. Does NOT change on saves - only on actual reload initiation.
+    /// Uses UUID string (not numeric) to avoid UserDefaults type coercion issues.
+    static var reloadGenerationToken: String {
+        get {
+            if let defaults = shared.appGroupDefaults,
+               let token = defaults.string(forKey: reloadGenerationTokenKey) {
+                return token
+            }
+            return shared.inMemoryReloadGenerationToken
+        }
+        set {
+            if let defaults = shared.appGroupDefaults {
+                defaults.set(newValue, forKey: reloadGenerationTokenKey)
+            }
+            shared.inMemoryReloadGenerationToken = newValue
+        }
+    }
+
+    // MARK: - Private Properties
+
+    // Phase 3.0 — serial queue for fingerprint dedup decisions. Decision-only; save dispatched outside.
+    private let dedupQueue = DispatchQueue(label: "com.trio.complication.dedup", qos: .utility)
+
+    private let sharedContainerURLProvider: () -> URL?
+    private let fileManager: FileManager
+    private let snapshotFilename: String
+
+    /// Pending retry work item - cancelled only when a new reload is actually initiated
+    /// All access must be on main queue to avoid race conditions
+    private var pendingRetryWorkItem: DispatchWorkItem?
+
+    /// Unique ID of the currently pending retry (used to identify stale retries without capturing work item)
+    private var pendingRetryID: UUID?
+
+    /// In-memory fallback for lastReload when appGroupDefaults is nil (per-process debounce)
+    private var inMemoryLastReload: Date = .distantPast
+
+    /// In-memory fallback for reloadGenerationToken when appGroupDefaults is nil (per-process token)
+    private var inMemoryReloadGenerationToken: String = UUID().uuidString
+
+    /// In-memory fallback for lastValidTimestamp when appGroupDefaults is nil
+    private var inMemoryLastValidTimestamp: Date?
+
+    /// In-memory cache of the last saved snapshot, used for dedup without per-save disk I/O
+    private var inMemorySavedSnapshot: TrioComplicationSnapshot?
+    /// Remaining cold-start seeding attempts (hydrates inMemorySavedSnapshot from disk)
+    private var seedAttemptsRemaining = 2
+
+    /// Burst window ID — increments each time a reload is triggered (Phase 2.1). In-memory only.
+    private var burstWindowId = 0
+    /// Number of reload calls debounced in the current burst window; reset to 0 when a reload fires (Phase 2.1).
+    private var reloadSuppressionCount = 0
+
+    /// Thread-safe one-time flags for logging (accessed from multiple threads via latestSnapshot).
+    private static let flagLock = OSAllocatedUnfairLock(initialState: (appGroupUnavailable: false, diagnostics: false))
+
+    /// Optional log forwarder (e.g. to WatchLogger). Set only by the Watch App Extension; complication extension never sets it.
+    /// Guarded by logForwarderLock because log() can be called from any thread (e.g. latestSnapshot() from WidgetKit's queue).
+    private static let logForwarderLock = OSAllocatedUnfairLock(initialState: LogForwarderState())
+    private struct LogForwarderState {
+        var forwarder: ((String) -> Void)?
+    }
+
+    /// Set from the Watch App Extension at launch so TrioComplicationDataStore logs also go to WatchLogger. Only set in Watch App Extension; complication extension has no WatchLogger so forwarder stays nil there.
+    static func setLogForwarder(_ forwarder: ((String) -> Void)?) {
+        logForwarderLock.withLock { $0.forwarder = forwarder }
+    }
+
+    private var snapshotFileURL: URL? {
+        sharedContainerURLProvider()?.appendingPathComponent(snapshotFilename)
+    }
+
+    /// Cached at init time to avoid repeated bundle resolution, App Group ID lookup, and logging per access.
+    private let cachedAppGroupDefaults: UserDefaults?
+
+    private var appGroupDefaults: UserDefaults? {
+        cachedAppGroupDefaults
+    }
+
+    // MARK: - Debug Properties (for ComplicationDebugView)
+
+    var lastReloadTimestamp: Date {
+        lastReload
+    }
+
+    var secondsSinceLastReload: TimeInterval {
+        Date().timeIntervalSince(lastReload)
+    }
+
+    var secondsUntilNextReloadAllowed: TimeInterval {
+        max(0, 30 - secondsSinceLastReload)
+    }
+
+    var isDebounceActive: Bool {
+        secondsSinceLastReload < 30
+    }
+
+    var appGroupContainerPath: String? {
+        snapshotFileURL?.deletingLastPathComponent().path
+    }
+
+    // MARK: - Debug Properties for ComplicationDebugView
+
+    var appGroupID: String? {
+        var bundle: Bundle = Bundle.main
+        let classBundle = Bundle(for: type(of: self))
+        if classBundle.object(forInfoDictionaryKey: "AppGroupID") != nil {
+            bundle = classBundle
+        }
+        return Self.resolveAppGroupID(bundle: bundle).value
+    }
+
+    var appGroupContainerURL: URL? {
+        guard let suiteName = appGroupID else { return nil }
+        return FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: suiteName)
+    }
+
+    var appGroupContainerAccessible: Bool {
+        guard let url = appGroupContainerURL else { return false }
+        return FileManager.default.fileExists(atPath: url.path)
+    }
+
+    var snapshotFileExists: Bool {
+        guard let fileURL = snapshotFileURL else { return false }
+        return FileManager.default.fileExists(atPath: fileURL.path)
+    }
+
+    var snapshotFileSize: Int64? {
+        guard let fileURL = snapshotFileURL,
+              FileManager.default.fileExists(atPath: fileURL.path),
+              let attributes = try? FileManager.default.attributesOfItem(atPath: fileURL.path),
+              let size = attributes[.size] as? Int64 else {
+            return nil
+        }
+        return size
+    }
+
+    var snapshotFileAge: TimeInterval? {
+        guard let fileURL = snapshotFileURL,
+              FileManager.default.fileExists(atPath: fileURL.path),
+              let attributes = try? FileManager.default.attributesOfItem(atPath: fileURL.path),
+              let modificationDate = attributes[.modificationDate] as? Date else {
+            return nil
+        }
+        return Date().timeIntervalSince(modificationDate)
+    }
+
+    // MARK: - Initialization
+
+    init(
+        sharedContainerURLProvider: @escaping () -> URL? = TrioComplicationDataStore.defaultSharedContainerURL,
+        fileManager: FileManager = .default,
+        snapshotFilename: String = "snapshot.json"
+    ) {
+        self.sharedContainerURLProvider = sharedContainerURLProvider
+        self.fileManager = fileManager
+        self.snapshotFilename = snapshotFilename
+
+        // Resolve appGroupDefaults once at init (avoids repeated bundle/logging overhead per access).
+        self.cachedAppGroupDefaults = Self.resolveAppGroupDefaultsOnce()
+
+        logAppGroupDiagnosticsOnce(context: "init")
+    }
+
+    /// One-shot resolution of App Group UserDefaults. Called once from init.
+    private static func resolveAppGroupDefaultsOnce() -> UserDefaults? {
+        var bundle: Bundle = Bundle.main
+        let classBundle = Bundle(for: TrioComplicationDataStore.self)
+        if classBundle.object(forInfoDictionaryKey: "AppGroupID") != nil {
+            bundle = classBundle
+        }
+
+        let resolved = resolveAppGroupID(bundle: bundle)
+        guard let suiteName = resolved.value else {
+            flagLock.withLock { state in
+                guard !state.appGroupUnavailable else { return }
+                state.appGroupUnavailable = true
+            }
+            return nil
+        }
+
+        let defaults = UserDefaults(suiteName: suiteName)
+        if defaults == nil {
+            flagLock.withLock { state in
+                guard !state.appGroupUnavailable else { return }
+                state.appGroupUnavailable = true
+            }
+        }
+        return defaults
+    }
+
+    /// One-line, high-signal diagnostics for App Group resolution and container access.
+    /// Safe to call from any process that includes this file (watch app and complication extension).
+    func diagnosticsSummary(context: String = "runtime") -> String {
+        var bundle: Bundle = Bundle.main
+        var bundleSource = "Bundle.main"
+        let classBundle = Bundle(for: type(of: self))
+        if classBundle.object(forInfoDictionaryKey: "AppGroupID") != nil {
+            bundle = classBundle
+            bundleSource = "Bundle(for: type(of: self))"
+        }
+
+        let bundleID = bundle.bundleIdentifier ?? "unknown"
+        let resolved = Self.resolveAppGroupID(bundle: bundle)
+
+        let suiteName = resolved.value
+        let defaultsOK = suiteName.flatMap { UserDefaults(suiteName: $0) } != nil
+        let containerURL = suiteName.flatMap { FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: $0) }
+
+        let snapshotPath = containerURL?.appendingPathComponent(snapshotFilename).path
+        let snapshotExists = snapshotPath.map { fileManager.fileExists(atPath: $0) } ?? false
+
+        return "AppGroupDiagnostics(\(context)): bundle=\(bundleSource) id=\(bundleID) AppGroupID=\(suiteName ?? "nil") source=\(resolved.source) defaults=\(defaultsOK) container=\(containerURL?.path ?? "nil") snapshot=\(snapshotPath ?? "nil") exists=\(snapshotExists)"
+    }
+
+    private func logAppGroupDiagnosticsOnce(context: String) {
+        let shouldLog = Self.flagLock.withLock { state -> Bool in
+            guard !state.diagnostics else { return false }
+            state.diagnostics = true
+            return true
+        }
+        if shouldLog {
+            log(diagnosticsSummary(context: context))
+        }
+    }
+
+    // MARK: - R6.1 HealthKit anchor and previous-sample persistence
+
+    /// R6.1 — Persisted HKQueryAnchor (encoded Data). Used by watch app extension only.
+    func hkGlucoseAnchor() -> Data? {
+        appGroupDefaults?.data(forKey: Self.hkGlucoseAnchorKey)
+    }
+
+    /// R6.1 — Save encoded anchor after successful anchored query.
+    func saveHKGlucoseAnchor(_ data: Data) {
+        appGroupDefaults?.set(data, forKey: Self.hkGlucoseAnchorKey)
+    }
+
+    /// R6.1 — Epoch (startDate.timeIntervalSince1970) of last processed glucose sample.
+    func hkLastReceivedGlucoseEpoch() -> TimeInterval {
+        appGroupDefaults?.double(forKey: Self.hkLastReceivedGlucoseEpochKey) ?? 0
+    }
+
+    func setHKLastReceivedGlucoseEpoch(_ epoch: TimeInterval) {
+        appGroupDefaults?.set(epoch, forKey: Self.hkLastReceivedGlucoseEpochKey)
+    }
+
+    /// R6.1 — Glucose value (mg/dL) of last processed sample (for delta/trend derivation).
+    func hkLastReceivedGlucoseValueMgDl() -> Double {
+        appGroupDefaults?.double(forKey: Self.hkLastReceivedGlucoseValueMgDlKey) ?? 0
+    }
+
+    func setHKLastReceivedGlucoseValueMgDl(_ value: Double) {
+        appGroupDefaults?.set(value, forKey: Self.hkLastReceivedGlucoseValueMgDlKey)
+    }
+
+    // MARK: - R5d Sleep-Gap State
+
+    /// Epoch of last data delivery from any channel. Returns nil if never set.
+    func lastDataReceivedAt() -> Date? {
+        guard let defaults = appGroupDefaults else { return nil }
+        let epoch = defaults.double(forKey: Self.lastDataReceivedAtKey)
+        return epoch > 0 ? Date(timeIntervalSince1970: epoch) : nil
+    }
+
+    func setLastDataReceivedAt(_ date: Date) {
+        appGroupDefaults?.set(date.timeIntervalSince1970, forKey: Self.lastDataReceivedAtKey)
+    }
+
+    /// Epoch of last forced widget reload. Returns nil if never set.
+    func lastWidgetReloadAt() -> Date? {
+        guard let defaults = appGroupDefaults else { return nil }
+        let epoch = defaults.double(forKey: Self.lastWidgetReloadAtKey)
+        return epoch > 0 ? Date(timeIntervalSince1970: epoch) : nil
+    }
+
+    func setLastWidgetReloadAt(_ date: Date) {
+        appGroupDefaults?.set(date.timeIntervalSince1970, forKey: Self.lastWidgetReloadAtKey)
+    }
+
+    // MARK: - Phase 3.2 Canonical Comparator
+
+    // Phase 3.2 — canonical comparator. Use shouldUpdate everywhere.
+    // Field set matches ComplicationSnapshotFingerprint (Phase 3.0):
+    // glucose, trend, delta, state.
+    //
+    // glucoseColor excluded: depends on user settings (low/high thresholds,
+    // glucoseColorScheme, glucose target) — not purely computed from glucose.
+    // Safe to exclude because glucoseColor is stable within a single watch state
+    // update cycle; the ±1s window only deduplicates the same CGM reading arriving
+    // via two paths (userInfo + message). A settings change triggers a new cycle
+    // with a new readingDate, which always passes the >1s check.
+    // Must stay excluded from BOTH here and ComplicationSnapshotFingerprint to
+    // preserve the invariant: pre-dispatch never suppresses a payload saveOnMain
+    // would accept.
+    //
+    // 1s tolerance is semantic policy: two readings within 1s with identical
+    // display data are treated as duplicates. Safe for all supported CGMs (minimum
+    // interval: 1 min for Libre 3, 5 min for G6/G7).
+    //
+    // Test cases:
+    //   Same timestamp, same content     → false
+    //   Same timestamp, different glucose → true
+    //   Newer timestamp (>1s)            → true
+    //   Older timestamp (<-1s)           → false
+    func shouldUpdate(new: TrioComplicationSnapshot, current: TrioComplicationSnapshot) -> Bool {
+        let timeDiff = new.readingDate.timeIntervalSince(current.readingDate)
+        if timeDiff > 1.0  { return true }
+        if timeDiff < -1.0 { return false }
+        return new.glucose != current.glucose
+            || new.trend   != current.trend
+            || new.delta   != current.delta
+            || new.state   != current.state
+    }
+
+    // MARK: - Phase 3.0 Pre-dispatch Dedup
+
+    private func storedFingerprint(defaults: UserDefaults) -> ComplicationSnapshotFingerprint? {
+        guard let data = defaults.data(forKey: Self.fingerprintKey),
+              let fp = try? JSONDecoder().decode(ComplicationSnapshotFingerprint.self, from: data)
+        else { return nil }
+        return fp
+    }
+
+    /// Phase 3.0 — pre-dispatch dedup. Decision-only (no save inside).
+    /// Returns true if the snapshot is a duplicate of the last saved fingerprint and should be skipped.
+    /// Cold-start (no stored fingerprint): always returns false (dispatch).
+    func shouldSkipPreDispatch(for snapshot: TrioComplicationSnapshot, handler: String) -> Bool {
+        let incoming = ComplicationSnapshotFingerprint(from: snapshot)
+        var skip = false
+        var messageToLog: String?
+
+        dedupQueue.sync {
+            guard let defaults = appGroupDefaults else { return }
+            if let stored = storedFingerprint(defaults: defaults), stored == incoming {
+                messageToLog = "⏭️ Pre-dispatch dedup: skipped reading_date_epoch=\(incoming.readingDateEpoch)" + " via \(handler)"
+                skip = true
+                return
+            }
+            messageToLog = "✅ Pre-dispatch: dispatching reading_date_epoch=\(incoming.readingDateEpoch)" + " via \(handler)"
+        }
+
+        if let message = messageToLog {
+            log(message)
+        }
+        return skip
+    }
+
+    // MARK: - Save Methods
+
+    func save(
+        glucose: String,
+        trend: String?,
+        delta: String?,
+        readingDate: Date,
+        date: Date,
+        glucoseColor: String? = nil,
+        triggerReload: Bool = true
+    ) {
+        let snapshot = TrioComplicationSnapshot(
+            glucose: glucose,
+            trend: trend ?? "",
+            delta: delta ?? "",
+            readingDate: readingDate,
+            date: date,
+            glucoseColor: glucoseColor
+        )
+        save(snapshot, triggerReload: triggerReload)
+    }
+
+    /// Saves a snapshot to disk. Main-thread confined.
+    /// - Parameters:
+    ///   - snapshot: The snapshot to save
+    ///   - triggerReload: If true (default), triggers a coalesced reload after saving.
+    ///                    Set to false to skip reload (e.g., if you plan to call `forceReload()` separately).
+    ///                    Note: pending retries are preserved regardless of this flag; they are only
+    ///                    cancelled when an actual reload is initiated.
+    func save(_ snapshot: TrioComplicationSnapshot, triggerReload: Bool = true, minInterval: TimeInterval = 30) {
+        onMain { [self] in
+            saveOnMain(snapshot, triggerReload: triggerReload, minInterval: minInterval)
+        }
+    }
+
+    private func saveOnMain(_ snapshot: TrioComplicationSnapshot, triggerReload: Bool, minInterval: TimeInterval = 30) {
+        assert(Thread.isMainThread, "saveOnMain must be called on main thread")
+        log("saveOnMain entered: glucose=\(snapshot.glucose), readingDate=\(snapshot.readingDate)")
+
+        // Future-skew guard: reject snapshots with readingDate more than 2 minutes in the future.
+        if snapshot.readingDate.timeIntervalSinceNow > 120 {
+            log("⚠️ Dedup: rejected future snapshot (readingDate=\(snapshot.readingDate), now=\(Date()))")
+            return
+        }
+
+        // Cold-start cache seeding: hydrate from disk on first save after process launch.
+        // Allows up to 2 attempts to handle transient I/O failures; if both fail,
+        // the lastValidTimestamp monotonic fallback (below) guards against recency regression.
+        if inMemorySavedSnapshot == nil, seedAttemptsRemaining > 0 {
+            seedAttemptsRemaining -= 1
+            inMemorySavedSnapshot = latestSnapshot()
+            if inMemorySavedSnapshot == nil {
+                log("⚠️ Dedup seed: no persisted snapshot (attempts remaining: \(seedAttemptsRemaining))")
+            }
+        }
+
+        // saveOnMain invariants (Phase 3.1):
+        // (a) future-skew  (b) cold-start  (c) newer-wins  (d) duplicate skip
+        // Authoritative dedup gate. Phase 3.0 pre-dispatch is optimization only.
+        if let existing = inMemorySavedSnapshot {
+            if !shouldUpdate(new: snapshot, current: existing) {
+                let timeDiff = snapshot.readingDate.timeIntervalSince(existing.readingDate)
+                if timeDiff < -1.0 {
+                    log("⏭️ saveOnMain: rejected older snapshot (timeDiff=\(String(format: "%.3f", timeDiff))s)")
+                } else {
+                    log("⏭️ saveOnMain: duplicate skipped (same reading, same content)")
+                }
+                return
+            }
+        } else if let lastTS = Self.lastValidTimestamp {
+            if snapshot.readingDate.timeIntervalSince(lastTS) < 0.0 {
+                log("⏭️ saveOnMain: rejected older snapshot via lastValidTimestamp fallback (readingDate=\(snapshot.readingDate), lastValid=\(lastTS))")
+                return
+            }
+        }
+
+        guard let fileURL = snapshotFileURL else {
+            log("❌ Snapshot save FAILED: no App Group container URL")
+            return
+        }
+
+        log("saveOnMain: passed dedup, writing snapshot")
+        do {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            let data = try encoder.encode(snapshot)
+
+            let containerDir = fileURL.deletingLastPathComponent()
+            try fileManager.createDirectory(
+                at: containerDir,
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
+
+            let backupURL = containerDir.appendingPathComponent("snapshot.bak")
+            if fileManager.fileExists(atPath: fileURL.path) {
+                _ = try? fileManager.removeItem(at: backupURL)
+                _ = try? fileManager.copyItem(at: fileURL, to: backupURL)
+            }
+
+            try data.write(to: fileURL, options: [.atomic])
+            self.inMemorySavedSnapshot = snapshot
+            Self.lastValidTimestamp = snapshot.readingDate
+            log("✅ lastValidTimestamp updated: \(snapshot.readingDate)")
+
+            // Phase 3.0: fingerprint written here and ONLY here.
+            // Not written in didReceiveUserInfo or didReceiveMessage.
+            if let fpData = try? JSONEncoder().encode(ComplicationSnapshotFingerprint(from: snapshot)) {
+                appGroupDefaults?.set(fpData, forKey: Self.fingerprintKey)
+                log(
+                    "✅ Fingerprint written: reading_date_epoch="
+                    + "\(Int(snapshot.readingDate.timeIntervalSince1970))"
+                )
+            }
+
+            let ageSec = max(0, Int(Date().timeIntervalSince(snapshot.readingDate)))
+
+            log("✅ Snapshot saved: glucose=\(snapshot.glucose), trend=\(snapshot.trend), delta=\(snapshot.delta), snapshot_age_seconds=\(ageSec)")
+            log("event=complication_save_age age_seconds=\(ageSec) reading_date_epoch_seconds=\(Int(snapshot.readingDate.timeIntervalSince1970)) reading_date=\(Self.iso8601Formatter.string(from: snapshot.readingDate))")
+
+            #if os(watchOS)
+            if WCSession.isSupported(), WCSession.default.activationState == .activated {
+                do {
+                    try WCSession.default.updateApplicationContext([
+                        "complicationLastValidTimestamp": snapshot.readingDate.timeIntervalSince1970
+                    ])
+                    log("event=complication_age_report_sent epoch=\(Int(snapshot.readingDate.timeIntervalSince1970))")
+                } catch {
+                    log("⚠️ complication_age_report_failed error=\(error.localizedDescription)")
+                }
+            } else if WCSession.isSupported() {
+                log("event=complication_age_report_skipped activation_state=\(WCSession.default.activationState.rawValue)")
+            }
+            #endif
+
+            if triggerReload {
+                coalescedReloadOnMain(minInterval: minInterval, scheduleRetry: false)
+            }
+        } catch {
+            log("❌ Snapshot save FAILED: \(error.localizedDescription) (domain: \((error as NSError).domain), code: \((error as NSError).code))")
+        }
+    }
+
+    // MARK: - Load Methods
+
+    /// Returns the most recent complication reload record, if any (for getTimeline instrumentation).
+    /// Complication extension reads only; do not write from the complication.
+    func newestReloadRecord() -> ComplicationReloadRecord? {
+        ComplicationReloadRing.newestRecord(suiteName: appGroupID)
+    }
+
+    func currentReloadGeneration() -> Int? {
+        guard let defaults = appGroupDefaults else { return nil }
+        return defaults.object(forKey: Self.reloadGenerationKey) != nil
+            ? defaults.integer(forKey: Self.reloadGenerationKey)
+            : nil
+    }
+
+    func lastReloadRequestEpochSeconds() -> Int? {
+        guard let defaults = appGroupDefaults else { return nil }
+        return defaults.object(forKey: Self.lastReloadRequestEpochSecondsKey) != nil
+            ? defaults.integer(forKey: Self.lastReloadRequestEpochSecondsKey)
+            : nil
+    }
+
+    func isAppGroupAvailable() -> Bool {
+        appGroupDefaults != nil
+    }
+
+    /// Loads the latest complication snapshot from disk.
+    /// May be called from any thread. Updates `lastValidTimestamp` as a side-effect (serialized on main
+    /// when App Group defaults are unavailable to protect in-memory fallback).
+    func latestSnapshot() -> TrioComplicationSnapshot? {
+        guard let fileURL = snapshotFileURL else {
+            log("❌ Snapshot load FAILED: no App Group container URL")
+            return fallbackSnapshot(state: "--")
+        }
+
+        guard fileManager.fileExists(atPath: fileURL.path) else {
+            log("⚠️ Snapshot file missing at \(fileURL.lastPathComponent)")
+            return fallbackSnapshot(state: "!!")
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        func decode(from url: URL) throws -> TrioComplicationSnapshot {
+            let data = try Data(contentsOf: url)
+            guard !data.isEmpty else { throw NSError(domain: "EmptySnapshot", code: -1) }
+            let snapshot = try decoder.decode(TrioComplicationSnapshot.self, from: data)
+            let readingDate = snapshot.readingDate
+            if let currentTS = Self.lastValidTimestamp, readingDate.timeIntervalSince(currentTS) <= 0 {
+                log("⏭️ lastValidTimestamp: skipped non-monotonic write (\(readingDate) <= \(currentTS))")
+            } else if appGroupDefaults == nil {
+                onMain {
+                    Self.lastValidTimestamp = readingDate
+                    self.log("✅ lastValidTimestamp updated (main): \(readingDate)")
+                }
+            } else {
+                Self.lastValidTimestamp = readingDate
+                log("✅ lastValidTimestamp updated: \(readingDate)")
+            }
+            return snapshot
+        }
+
+        do {
+            let snapshot = try decode(from: fileURL)
+            return snapshot
+        } catch {
+            let backupURL = fileURL.deletingLastPathComponent().appendingPathComponent("snapshot.bak")
+            if fileManager.fileExists(atPath: backupURL.path),
+               let snapshot = try? decode(from: backupURL) {
+                log("⚠️ Snapshot decode failed, using backup")
+                return snapshot
+            }
+            log("❌ Snapshot decode FAILED: \(error.localizedDescription)")
+            return fallbackSnapshot(state: "??")
+        }
+    }
+
+    // MARK: - Reload Methods
+
+    /// Triggers a complication timeline reload with 30-second debouncing. Main-thread confined.
+    /// - Parameters:
+    ///   - minInterval: Minimum time interval between reloads (default: 30 seconds)
+    ///   - isRetry: If true, this is a retry attempt and should not schedule another retry
+    func coalescedReload(minInterval: TimeInterval = 30, isRetry: Bool = false) {
+        onMain { [self] in
+            coalescedReloadOnMain(minInterval: minInterval, isRetry: isRetry)
+        }
+    }
+
+    private func coalescedReloadOnMain(minInterval: TimeInterval = 30, isRetry: Bool = false, scheduleRetry: Bool = true) {
+        assert(Thread.isMainThread, "coalescedReloadOnMain must be called on main thread")
+        let now = Date()
+        let elapsed = now.timeIntervalSince(lastReload)
+
+        if elapsed < minInterval {
+            reloadSuppressionCount += 1
+            let elapsedStr = String(format: "%.3f", elapsed)
+            let minStr = String(format: "%.3f", minInterval)
+            log("⏳ Reload DEBOUNCED burst_window_id=\(burstWindowId) suppressed=\(reloadSuppressionCount) elapsed=\(elapsedStr)s min=\(minStr)s")
+            return
+        }
+
+        cancelPendingRetryOnMain(reason: "superseded by new reload")
+        Self.reloadGenerationToken = UUID().uuidString
+
+        burstWindowId += 1
+        reloadSuppressionCount = 0
+        let elapsedStr = String(format: "%.3f", elapsed)
+        log("🔄 Reload TRIGGERED burst_window_id=\(burstWindowId) suppressed=\(reloadSuppressionCount) elapsed=\(elapsedStr)s since last reload\(isRetry ? " (retry)" : "")")
+        lastReload = now
+        reloadTimeline()
+
+        guard scheduleRetry else {
+            log("⏭️ Retry skipped: scheduleRetry=false (save path)")
+            return
+        }
+        if !isRetry {
+            let freshnessThreshold: TimeInterval = 60
+            if let snapshot = latestSnapshot(), Date().timeIntervalSince(snapshot.readingDate) < freshnessThreshold {
+                let age = String(format: "%.1f", Date().timeIntervalSince(snapshot.readingDate))
+                log("⏭️ Retry skipped: snapshot fresh (age=\(age)s < \(Int(freshnessThreshold))s)")
+                return
+            }
+            scheduleRetryAfterReloadOnMain(minInterval: minInterval)
+        }
+    }
+
+    /// Forces an immediate complication timeline reload, bypassing the debounce. Main-thread confined.
+    /// - Parameter scheduleRetry: If true (default), schedules a retry after the reload.
+    ///   Pass false for paths that fire infrequently (e.g., forceComplicationUpdate).
+    func forceReload(scheduleRetry: Bool = true) {
+        onMain { [self] in
+            forceReloadOnMain(scheduleRetry: scheduleRetry)
+        }
+    }
+
+    private func forceReloadOnMain(scheduleRetry: Bool = true) {
+        assert(Thread.isMainThread, "forceReloadOnMain must be called on main thread")
+        cancelPendingRetryOnMain(reason: "superseded by force reload")
+        Self.reloadGenerationToken = UUID().uuidString
+        log("🔄 FORCE reload triggered (bypassing debounce)")
+        lastReload = Date()
+        reloadTimeline()
+        if scheduleRetry {
+            scheduleRetryAfterReloadOnMain(minInterval: 30)
+        }
+    }
+
+    #if canImport(WidgetKit)
+        /// Must only be called from the Watch App; the Widget extension must not write the ring (enforced by #if !WIDGET_EXTENSION).
+        private func reloadTimeline() {
+            let requestedAtEpochSeconds = Int(Date().timeIntervalSince1970)
+            let record = ComplicationReloadRecord(id: UUID(), requestedAtEpochSeconds: requestedAtEpochSeconds)
+            var reloadGeneration: Int = -1
+            #if !WIDGET_EXTENSION
+            if let suiteName = appGroupID {
+                ComplicationReloadRing.append(record, suiteName: suiteName)
+            }
+            if let defaults = appGroupDefaults {
+                let current = defaults.integer(forKey: Self.reloadGenerationKey)
+                reloadGeneration = current + 1
+                defaults.set(reloadGeneration, forKey: Self.reloadGenerationKey)
+                defaults.set(requestedAtEpochSeconds, forKey: Self.lastReloadRequestEpochSecondsKey)
+            }
+            #endif
+            log("event=complication_reload_requested reload_generation=\(reloadGeneration) reload_requested_at_epoch_seconds=\(record.requestedAtEpochSeconds) reload_id=\(record.id.uuidString)")
+
+            if let lastTS = Self.lastValidTimestamp {
+                let ageSec = max(0, Int(Date().timeIntervalSince(lastTS)))
+                log("event=complication_reload_age age_seconds=\(ageSec) reading_date_epoch_seconds=\(Int(lastTS.timeIntervalSince1970)) reading_date=\(Self.iso8601Formatter.string(from: lastTS))")
+            }
+            log("🔔 Calling WidgetCenter.reloadTimelines(ofKind: \(Self.complicationKind))")
+
+            let reloadBlock = {
+                if #available(watchOS 10.0, *) {
+                    WidgetCenter.shared.reloadTimelines(ofKind: Self.complicationKind)
+                } else {
+                    WidgetCenter.shared.reloadAllTimelines()
+                }
+            }
+
+            if Thread.isMainThread {
+                reloadBlock()
+            } else {
+                DispatchQueue.main.async(execute: reloadBlock)
+            }
+        }
+    #endif
+
+    // MARK: - Private Helpers (Main-Thread Confined)
+
+    private func onMain(_ block: @escaping () -> Void) {
+        if Thread.isMainThread {
+            block()
+        } else {
+            DispatchQueue.main.async(execute: block)
+        }
+    }
+
+    private func cancelPendingRetryOnMain(reason: String) {
+        assert(Thread.isMainThread, "cancelPendingRetryOnMain must be called on main thread")
+        if pendingRetryWorkItem != nil {
+            pendingRetryWorkItem?.cancel()
+            pendingRetryWorkItem = nil
+            pendingRetryID = nil
+            log("⏹️ Retry CANCELLED: \(reason)")
+        }
+    }
+
+    private func scheduleRetryAfterReloadOnMain(minInterval: TimeInterval) {
+        assert(Thread.isMainThread, "scheduleRetryAfterReloadOnMain must be called on main thread")
+
+        let tokenAtReload = Self.reloadGenerationToken
+        let retryID = UUID()
+        pendingRetryID = retryID
+
+        let retryDelay = minInterval + 1.0
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self = self else { return }
+            guard self.pendingRetryID == retryID else { return }
+
+            self.pendingRetryWorkItem = nil
+            self.pendingRetryID = nil
+
+            if Self.reloadGenerationToken != tokenAtReload {
+                let prefix = String(tokenAtReload.prefix(8))
+                self.log("⏭️ Retry SKIPPED: newer reload occurred (token changed from '\(prefix)...')")
+                return
+            }
+
+            self.log("🔄 Retry reload triggered after \(Int(retryDelay))s")
+            self.coalescedReloadOnMain(minInterval: minInterval, isRetry: true)
+        }
+
+        pendingRetryWorkItem = workItem
+        log("⏰ Retry scheduled: delay=\(Int(retryDelay))s, token='\(tokenAtReload.prefix(8))...'")
+        DispatchQueue.main.asyncAfter(deadline: .now() + retryDelay, execute: workItem)
+    }
+
+    private func fallbackSnapshot(state: String) -> TrioComplicationSnapshot {
+        TrioComplicationSnapshot(
+            glucose: "--",
+            trend: "",
+            delta: "--",
+            readingDate: Self.lastValidTimestamp ?? .distantPast,
+            date: Date(),
+            state: state,
+            glucoseColor: nil
+        )
+    }
+
+    private static func defaultSharedContainerURL() -> URL? {
+        var bundle: Bundle = Bundle.main
+        let classBundle = Bundle(for: TrioComplicationDataStore.self)
+        if classBundle.object(forInfoDictionaryKey: "AppGroupID") != nil {
+            bundle = classBundle
+        }
+
+        let resolved = resolveAppGroupID(bundle: bundle)
+        guard let suiteName = resolved.value else {
+            return nil
+        }
+
+        guard let containerURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: suiteName) else {
+            return nil
+        }
+
+        return containerURL
+    }
+
+    private func formatDate(_ date: Date) -> String {
+        if date == .distantPast { return "distantPast" }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+        return formatter.string(from: date)
+    }
+
+#if WIDGET_EXTENSION
+    func logWidgetGetTimelineInvocation(
+        appGroupAvailable: Bool,
+        observedGenerationSource: String,
+        observedReloadGeneration: Int,
+        generationDelta: Int,
+        providerInstanceId: String,
+        providerRestart: Bool,
+        latencyValid: Bool,
+        latencySeconds: Int,
+        reloadRequestedAtEpochSeconds: Int,
+        mostRecentReloadId: String,
+        getTimelineAtEpochSeconds: Int,
+        dataAgeSeconds: Int
+    ) {
+        log(
+            "event=complication_get_timeline_called"
+            + " app_group_available=\(appGroupAvailable)"
+            + " observed_generation_source=\(observedGenerationSource)"
+            + " observed_reload_generation=\(observedReloadGeneration)"
+            + " generation_delta=\(generationDelta)"
+            + " provider_instance_id=\(providerInstanceId)"
+            + " provider_restart=\(providerRestart)"
+            + " latency_valid=\(latencyValid)"
+            + " latency_seconds=\(latencySeconds)"
+            + " reload_requested_at_epoch_seconds=\(reloadRequestedAtEpochSeconds)"
+            + " most_recent_reload_id=\(mostRecentReloadId)"
+            + " get_timeline_at_epoch_seconds=\(getTimelineAtEpochSeconds)"
+            + " data_age_seconds=\(dataAgeSeconds)"
+        )
+    }
+
+    /// R5f — Snapshot path visible-recency observability.
+    func logWidgetGetSnapshotInvocation(getSnapshotAtEpochSeconds: Int, dataAgeSeconds: Int) {
+        log(
+            "event=complication_get_snapshot_called"
+            + " get_snapshot_at_epoch_seconds=\(getSnapshotAtEpochSeconds)"
+            + " data_age_seconds=\(dataAgeSeconds)"
+        )
+    }
+#endif
+
+    private func log(_ message: String) {
+        ComplicationLogBuffer.append(message)
+        let forwarder = Self.logForwarderLock.withLock { $0.forwarder }
+        forwarder?(message)
+    }
+}

--- a/Trio Watch Shared/TrioComplicationDataStore.swift
+++ b/Trio Watch Shared/TrioComplicationDataStore.swift
@@ -18,6 +18,7 @@ struct TrioComplicationSnapshot: Equatable, Codable {
     let readingDate: Date
     let state: String?
     let glucoseColor: String?
+    let dataSource: TrioComplicationDataSource?
 
     // INVARIANT (Phase 3.4): All display-field sanitization here.
     // Dedup always compares sanitized values.
@@ -28,7 +29,8 @@ struct TrioComplicationSnapshot: Equatable, Codable {
         readingDate: Date,
         date: Date,
         state: String? = nil,
-        glucoseColor: String? = nil
+        glucoseColor: String? = nil,
+        dataSource: TrioComplicationDataSource? = nil
     ) {
         glucose = Self.sanitizedGlucose(from: rawGlucose)
         trend = rawTrend.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -37,6 +39,7 @@ struct TrioComplicationSnapshot: Equatable, Codable {
         self.date = date
         self.state = state
         self.glucoseColor = glucoseColor
+        self.dataSource = dataSource
     }
 
     private static func sanitizedGlucose(from value: String) -> String {
@@ -89,6 +92,8 @@ struct ComplicationSnapshotFingerprint: Codable, Equatable {
     let trend: String
     let delta: String
     let state: String
+    /// Optional for migration: older `UserDefaults` entries omit this key.
+    let dataSource: String?
 }
 
 extension ComplicationSnapshotFingerprint {
@@ -100,6 +105,7 @@ extension ComplicationSnapshotFingerprint {
         // Sentinel for nil: state is always optional in the model; sentinel ensures
         // nil and non-nil are always distinguishable in Equatable comparison.
         state = snapshot.state ?? "<nil>"
+        dataSource = snapshot.dataSource?.rawValue
     }
 }
 
@@ -569,14 +575,41 @@ final class TrioComplicationDataStore {
     //   Same timestamp, different glucose → true
     //   Newer timestamp (>1s)            → true
     //   Older timestamp (<-1s)           → false
+    /// Whether `saveOnMain` would write this snapshot (main thread; mirrors future-skew + dedup checks, not pre-dispatch).
+    @MainActor
+    func wouldAcceptMainThreadSave(_ snapshot: TrioComplicationSnapshot) -> Bool {
+        if snapshot.readingDate.timeIntervalSinceNow > 120 { return false }
+        if let existing = inMemorySavedSnapshot {
+            return shouldUpdate(new: snapshot, current: existing)
+        }
+        if let lastTS = Self.lastValidTimestamp, snapshot.readingDate.timeIntervalSince(lastTS) < 0.0 {
+            return false
+        }
+        return true
+    }
+
     func shouldUpdate(new: TrioComplicationSnapshot, current: TrioComplicationSnapshot) -> Bool {
         let timeDiff = new.readingDate.timeIntervalSince(current.readingDate)
-        if timeDiff > 1.0  { return true }
+        if timeDiff > 1.0 { return true }
         if timeDiff < -1.0 { return false }
-        return new.glucose != current.glucose
-            || new.trend   != current.trend
-            || new.delta   != current.delta
-            || new.state   != current.state
+        if new.glucose != current.glucose
+            || new.trend != current.trend
+            || new.delta != current.delta
+            || new.state != current.state
+        {
+            return true
+        }
+        if new.dataSource == current.dataSource { return false }
+        return dataSourcePriority(new.dataSource) > dataSourcePriority(current.dataSource)
+    }
+
+    private func dataSourcePriority(_ s: TrioComplicationDataSource?) -> Int {
+        switch s {
+        case .g7DirectBLE: 3
+        case .watchConnectivityPhone: 2
+        case .healthKit: 1
+        case .none, .unknown, nil: 0
+        }
     }
 
     // MARK: - Phase 3.0 Pre-dispatch Dedup

--- a/Trio/Resources/TrioWatch.entitlements
+++ b/Trio/Resources/TrioWatch.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>$(TRIO_APP_GROUP_ID)</string>
+	</array>
+</dict>
+</plist>

--- a/Trio/Sources/Application/AppDelegate.swift
+++ b/Trio/Sources/Application/AppDelegate.swift
@@ -7,7 +7,7 @@ import UserNotifications
 class AppDelegate: NSObject, UIApplicationDelegate, ObservableObject, UNUserNotificationCenterDelegate {
     func application(
         _: UIApplication,
-        didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
         FirebaseApp.configure()
 
@@ -20,7 +20,39 @@ class AppDelegate: NSObject, UIApplicationDelegate, ObservableObject, UNUserNoti
         Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(crashReportingEnabled)
         Crashlytics.crashlytics().setCustomValue(Bundle.main.appDevVersion ?? "unknown", forKey: "app_dev_version")
 
+        // Check for unexpected termination from previous launch, then mark this launch.
+        // Note: AppTerminationTracker uses UserDefaults for state persistence. In rare cases
+        // (ultra-rapid termination <1s), the state may not be synced before iOS kills the app.
+        // If this becomes a problem, consider: (A) file-based atomic writes, (B) hybrid
+        // UserDefaults + file approach. For now, UserDefaults is sufficient for most cases.
+        AppTerminationTracker.shared.checkForUnexpectedTermination()
+        AppTerminationTracker.shared.markAppLaunched(launchOptions: launchOptions)
+
         return true
+    }
+
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        AppTerminationTracker.shared.markAppBecameActive()
+    }
+
+    func applicationWillResignActive(_ application: UIApplication) {
+        AppTerminationTracker.shared.markAppWillResignActive()
+    }
+
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        AppTerminationTracker.shared.markAppEnteredBackground()
+    }
+
+    func applicationWillEnterForeground(_ application: UIApplication) {
+        AppTerminationTracker.shared.markAppWillEnterForeground()
+    }
+
+    func applicationWillTerminate(_ application: UIApplication) {
+        AppTerminationTracker.shared.markAppWillTerminate()
+    }
+
+    func applicationDidReceiveMemoryWarning(_ application: UIApplication) {
+        AppTerminationTracker.shared.handleMemoryWarning()
     }
 
     func application(

--- a/Trio/Sources/Application/TrioApp.swift
+++ b/Trio/Sources/Application/TrioApp.swift
@@ -65,26 +65,36 @@ extension Notification.Name {
     }
 
     private func loadServices() {
-        resolver.resolve(AppearanceManager.self)!.setupGlobalAppearance()
-        _ = resolver.resolve(DeviceDataManager.self)!
-        _ = resolver.resolve(APSManager.self)!
-        _ = resolver.resolve(FetchGlucoseManager.self)!
-        _ = resolver.resolve(FetchTreatmentsManager.self)!
-        _ = resolver.resolve(CalendarManager.self)!
-        _ = resolver.resolve(UserNotificationsManager.self)!
-        _ = resolver.resolve(WatchManager.self)!
-        _ = resolver.resolve(ContactImageManager.self)!
-        _ = resolver.resolve(HealthKitManager.self)!
-        _ = resolver.resolve(WatchManager.self)!
-        _ = resolver.resolve(GarminManager.self)!
-        _ = resolver.resolve(ContactImageManager.self)!
-        _ = resolver.resolve(BluetoothStateManager.self)!
-        _ = resolver.resolve(PluginManager.self)!
-        _ = resolver.resolve(AlertPermissionsChecker.self)!
-        if #available(iOS 16.2, *) {
-            _ = resolver.resolve(LiveActivityManager.self)!
+        if let appearance = resolveOrLog(AppearanceManager.self) {
+            appearance.setupGlobalAppearance()
         }
-        _ = resolver.resolve(IOBService.self)!
+        resolveOrLog(DeviceDataManager.self)
+        resolveOrLog(APSManager.self)
+        resolveOrLog(FetchGlucoseManager.self)
+        resolveOrLog(FetchTreatmentsManager.self)
+        resolveOrLog(CalendarManager.self)
+        resolveOrLog(UserNotificationsManager.self)
+        resolveOrLog(WatchManager.self)
+        resolveOrLog(ContactImageManager.self)
+        resolveOrLog(HealthKitManager.self)
+        resolveOrLog(GarminManager.self)
+        resolveOrLog(BluetoothStateManager.self)
+        resolveOrLog(PluginManager.self)
+        resolveOrLog(AlertPermissionsChecker.self)
+        resolveOrLog(CloudLogUploadService.self)
+        if #available(iOS 16.2, *) {
+            resolveOrLog(LiveActivityManager.self)
+        }
+        resolveOrLog(IOBService.self)
+    }
+
+    @discardableResult
+    private func resolveOrLog<T>(_ type: T.Type) -> T? {
+        guard let service = resolver.resolve(type) else {
+            warning(.default, "loadServices: failed to resolve \(type) — skipping")
+            return nil
+        }
+        return service
     }
 
     init() {

--- a/Trio/Sources/Assemblies/ServiceAssembly.swift
+++ b/Trio/Sources/Assemblies/ServiceAssembly.swift
@@ -23,6 +23,7 @@ final class ServiceAssembly: Assembly {
         container.register(GarminManager.self) { r in BaseGarminManager(resolver: r) }
         container.register(ContactImageManager.self) { r in BaseContactImageManager(resolver: r) }
         container.register(AlertPermissionsChecker.self) { r in AlertPermissionsChecker(resolver: r) }
+        container.register(CloudLogUploadService.self) { _ in CloudLogUploadService() }
         if #available(iOS 16.2, *) {
             container.register(LiveActivityManager.self) { r in
                 LiveActivityManager(resolver: r)

--- a/Trio/Sources/Helpers/AppTerminationTracker.swift
+++ b/Trio/Sources/Helpers/AppTerminationTracker.swift
@@ -1,0 +1,306 @@
+import Foundation
+import FirebaseCrashlytics
+import UIKit
+import Darwin
+
+/// Tracks app lifecycle events to detect and report unexpected terminations.
+///
+/// This class monitors app state transitions to identify when the app is terminated
+/// unexpectedly (e.g., by iOS due to memory pressure, watchdog timeout, etc.)
+/// and logs diagnostic information to Crashlytics.
+final class AppTerminationTracker {
+    static let shared = AppTerminationTracker()
+
+    private let userDefaults = UserDefaults.standard
+    private let lastStateKey = "AppTerminationTracker.lastState"
+    private let lastStateTimestampKey = "AppTerminationTracker.lastStateTimestamp"
+    private let appLaunchTimestampKey = "AppTerminationTracker.appLaunchTimestamp"
+    private let memoryWarningCountKey = "AppTerminationTracker.memoryWarningCount"
+    private let memoryWarningTimestampKey = "AppTerminationTracker.memoryWarningTimestamp"
+
+    private enum AppState: String {
+        case launched = "launched"
+        case active = "active"
+        case inactive = "inactive"
+        case background = "background"
+        case terminated = "terminated"
+    }
+
+    enum TerminationReason: String {
+        case normal = "normal" // applicationWillTerminate was called
+        case unexpected = "unexpected" // App was killed without calling applicationWillTerminate
+        case memoryPressure = "memory_pressure" // App was killed due to memory pressure
+        case watchdog = "watchdog" // App was killed due to watchdog timeout
+        case unknown = "unknown"
+    }
+
+    private init() {
+        // Private initializer for singleton
+    }
+
+    // MARK: - Public Methods
+
+    /// Called when app finishes launching
+    func markAppLaunched(launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
+        let timestamp = Date()
+        userDefaults.set(timestamp.timeIntervalSince1970, forKey: appLaunchTimestampKey)
+        userDefaults.set(AppState.launched.rawValue, forKey: lastStateKey)
+        userDefaults.set(timestamp.timeIntervalSince1970, forKey: lastStateTimestampKey)
+
+        // Log launch options for diagnostics
+        if let launchOptions = launchOptions, !launchOptions.isEmpty {
+            let optionsDescription = launchOptions.map { "\($0.key.rawValue)" }.joined(separator: ", ")
+            Crashlytics.crashlytics().log("App launched with options: \(optionsDescription)")
+        }
+
+        let message = "App launched at \(timestamp)"
+        debug(.default, message)
+        info(.default, message, type: .info)
+    }
+
+    /// Called when app becomes active
+    func markAppBecameActive() {
+        updateState(.active)
+        let message = "App became active"
+        debug(.default, message)
+    }
+
+    /// Called when app will resign active
+    func markAppWillResignActive() {
+        updateState(.inactive)
+        let message = "App will resign active"
+        debug(.default, message)
+    }
+
+    /// Called when app enters background
+    func markAppEnteredBackground() {
+        updateState(.background)
+        // Save critical state before going to background
+        saveDiagnosticState()
+        let message = "App entered background"
+        debug(.default, message)
+    }
+
+    /// Called when app will enter foreground
+    func markAppWillEnterForeground() {
+        updateState(.active)
+        let message = "App will enter foreground"
+        debug(.default, message)
+    }
+
+    /// Called when app will terminate normally
+    func markAppWillTerminate(reason: TerminationReason = .normal) {
+        updateState(.terminated)
+        userDefaults.set(reason.rawValue, forKey: "AppTerminationTracker.lastTerminationReason")
+        let message = "App will terminate (reason: \(reason.rawValue))"
+        debug(.default, message)
+        info(.default, message, type: .info)
+    }
+
+    /// Called when iOS sends a memory warning
+    func handleMemoryWarning() {
+        let count = userDefaults.integer(forKey: memoryWarningCountKey) + 1
+        userDefaults.set(count, forKey: memoryWarningCountKey)
+        userDefaults.set(Date().timeIntervalSince1970, forKey: memoryWarningTimestampKey)
+
+        // Log system memory info if available
+        var memoryInfoString = ""
+        if let memoryInfo = getMemoryInfo() {
+            memoryInfoString = " | Memory: \(memoryInfo.map { "\($0.key)=\($0.value)MB" }.joined(separator: ", "))"
+
+            // Log to Crashlytics
+            Crashlytics.crashlytics().log("Memory info: \(memoryInfo)")
+            for (key, value) in memoryInfo {
+                Crashlytics.crashlytics().setCustomValue(value, forKey: "memory_\(key)")
+            }
+        }
+
+        // Log to Crashlytics
+        Crashlytics.crashlytics().log("⚠️ Memory warning received (count: \(count))")
+        Crashlytics.crashlytics().setCustomValue(count, forKey: "memory_warning_count")
+
+        // Log to file and Better Stack with warning level
+        let message = "⚠️ Memory warning received (count: \(count))\(memoryInfoString)"
+        debug(.default, message)
+        warning(.default, message, description: "iOS sent memory pressure warning. This may indicate the app is using too much memory and could be terminated.")
+    }
+
+    /// Checks for unexpected termination from previous session
+    func checkForUnexpectedTermination() {
+        guard let lastStateString = userDefaults.string(forKey: lastStateKey),
+              let lastState = AppState(rawValue: lastStateString),
+              let lastTimestamp = userDefaults.object(forKey: lastStateTimestampKey) as? TimeInterval else {
+            // First launch or no previous state
+            return
+        }
+
+        let lastStateDate = Date(timeIntervalSince1970: lastTimestamp)
+        let timeSinceLastState = Date().timeIntervalSince(lastStateDate)
+
+        // If app was active/inactive/background and didn't terminate normally, it was likely killed
+        if lastState != .terminated {
+            let reason = determineTerminationReason(lastState: lastState, timeSinceLastState: timeSinceLastState)
+            reportUnexpectedTermination(
+                lastState: lastState,
+                timeSinceLastState: timeSinceLastState,
+                reason: reason
+            )
+        } else {
+            // App terminated normally, clear memory warning count
+            userDefaults.removeObject(forKey: memoryWarningCountKey)
+            userDefaults.removeObject(forKey: memoryWarningTimestampKey)
+        }
+    }
+
+    // MARK: - Private Methods
+
+    private func updateState(_ newState: AppState) {
+        userDefaults.set(newState.rawValue, forKey: lastStateKey)
+        userDefaults.set(Date().timeIntervalSince1970, forKey: lastStateTimestampKey)
+    }
+
+    private func saveDiagnosticState() {
+        // Save current diagnostic state that might be useful if app is killed
+        let memoryInfo = getMemoryInfo() ?? [:]
+        userDefaults.set(memoryInfo, forKey: "AppTerminationTracker.lastMemoryInfo")
+
+        // Save scene phase info if available
+        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+            let isActive = windowScene.activationState == .foregroundActive
+            userDefaults.set(isActive, forKey: "AppTerminationTracker.wasActiveBeforeBackground")
+        }
+    }
+
+    private func determineTerminationReason(lastState: AppState, timeSinceLastState: TimeInterval) -> TerminationReason {
+        // Check if we had recent memory warnings
+        if let memoryWarningTimestamp = userDefaults.object(forKey: memoryWarningTimestampKey) as? TimeInterval {
+            let timeSinceWarning = Date().timeIntervalSince1970 - memoryWarningTimestamp
+            if timeSinceWarning < 60 { // Memory warning within last minute
+                return .memoryPressure
+            }
+        }
+
+        // If app was active and killed quickly, might be watchdog
+        if lastState == .active && timeSinceLastState < 10 {
+            return .watchdog
+        }
+
+        // If app was in background and killed, likely memory pressure
+        if lastState == .background {
+            return .memoryPressure
+        }
+
+        return .unexpected
+    }
+
+    private func reportUnexpectedTermination(
+        lastState: AppState,
+        timeSinceLastState: TimeInterval,
+        reason: TerminationReason
+    ) {
+        // Build detailed message
+        var details: [String] = [
+            "Last state: \(lastState.rawValue)",
+            "Time since last state: \(Int(timeSinceLastState))s",
+            "Reason: \(reason.rawValue)"
+        ]
+
+        // Add memory info if available
+        var memoryInfoString = ""
+        if let memoryInfo = userDefaults.dictionary(forKey: "AppTerminationTracker.lastMemoryInfo") {
+            let memoryDetails = memoryInfo.compactMap { key, value -> String? in
+                if let numValue = value as? NSNumber {
+                    return "\(key)=\(numValue.intValue)MB"
+                }
+                return nil
+            }
+            if !memoryDetails.isEmpty {
+                memoryInfoString = " | Last memory: \(memoryDetails.joined(separator: ", "))"
+                details.append("Last memory: \(memoryDetails.joined(separator: ", "))")
+            }
+        }
+
+        // Add memory warning count
+        let memoryWarningCount = userDefaults.integer(forKey: memoryWarningCountKey)
+        if memoryWarningCount > 0 {
+            details.append("Memory warnings before termination: \(memoryWarningCount)")
+        }
+
+        let fullMessage = "🔴 App was unexpectedly terminated. \(details.joined(separator: ", "))"
+        let shortMessage = "App was unexpectedly terminated. Last state: \(lastState.rawValue), Time since: \(Int(timeSinceLastState))s, Reason: \(reason.rawValue)\(memoryInfoString)"
+
+        // Log to file and Better Stack with error level
+        debug(.default, fullMessage)
+        warning(
+            .default,
+            shortMessage,
+            description: "The app was terminated unexpectedly by iOS. This may indicate memory pressure, watchdog timeout, or other system-level issues.",
+            error: NSError(
+                domain: "AppTerminationTracker",
+                code: 1,
+                userInfo: [
+                    NSLocalizedDescriptionKey: shortMessage,
+                    "termination_reason": reason.rawValue,
+                    "last_state": lastState.rawValue,
+                    "time_since_last_state": timeSinceLastState
+                ]
+            )
+        )
+
+        // Log to Crashlytics
+        Crashlytics.crashlytics().log("🔴 Unexpected termination detected: \(fullMessage)")
+        Crashlytics.crashlytics().setCustomValue(reason.rawValue, forKey: "termination_reason")
+        Crashlytics.crashlytics().setCustomValue(lastState.rawValue, forKey: "last_app_state")
+        Crashlytics.crashlytics().setCustomValue(Int(timeSinceLastState), forKey: "time_since_last_state_seconds")
+
+        // Add memory info to Crashlytics
+        if let memoryInfo = userDefaults.dictionary(forKey: "AppTerminationTracker.lastMemoryInfo") {
+            for (key, value) in memoryInfo {
+                if let numValue = value as? NSNumber {
+                    Crashlytics.crashlytics().setCustomValue(numValue.intValue, forKey: "last_memory_\(key)")
+                }
+            }
+        }
+
+        // Add memory warning count to Crashlytics
+        if memoryWarningCount > 0 {
+            Crashlytics.crashlytics().setCustomValue(memoryWarningCount, forKey: "memory_warning_count_before_termination")
+        }
+
+        // Create a non-fatal error to represent the termination
+        let terminationError = NSError(
+            domain: "AppTerminationTracker",
+            code: 1,
+            userInfo: [
+                NSLocalizedDescriptionKey: shortMessage,
+                "termination_reason": reason.rawValue,
+                "last_state": lastState.rawValue,
+                "time_since_last_state": timeSinceLastState
+            ]
+        )
+        Crashlytics.crashlytics().record(error: terminationError)
+    }
+
+    private func getMemoryInfo() -> [String: Int]? {
+        var info = mach_task_basic_info()
+        var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size) / 4
+
+        let kerr: kern_return_t = withUnsafeMutablePointer(to: &info) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: 1) {
+                task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), $0, &count)
+            }
+        }
+
+        guard kerr == KERN_SUCCESS else {
+            return nil
+        }
+
+        let usedMemoryMB = Int(info.resident_size / 1024 / 1024)
+        let virtualMemoryMB = Int(info.virtual_size / 1024 / 1024)
+
+        return [
+            "used_mb": usedMemoryMB,
+            "virtual_mb": virtualMemoryMB
+        ]
+    }
+}

--- a/Trio/Sources/Helpers/BuildDetails.swift
+++ b/Trio/Sources/Helpers/BuildDetails.swift
@@ -50,6 +50,19 @@ class BuildDetails: Injectable {
         return result
     }
 
+    var patches: [(name: String, subject: String, fromSHA: String, date: String)] {
+        guard let patches = dict["com-trio-patches"] as? [[String: Any]] else {
+            return []
+        }
+        return patches.map { patch in
+            let name = patch["name"] as? String ?? String(localized: "Unknown")
+            let subject = patch["subject"] as? String ?? ""
+            let fromSHA = patch["from_sha"] as? String ?? String(localized: "Unknown")
+            let date = patch["date"] as? String ?? String(localized: "Unknown")
+            return (name: name, subject: subject, fromSHA: fromSHA, date: date)
+        }
+    }
+
     // Determine if the build is from TestFlight
     func isTestFlightBuild() -> Bool {
         #if targetEnvironment(simulator)

--- a/Trio/Sources/Logger/CloudLogging/BetterStackLogtailProvider.swift
+++ b/Trio/Sources/Logger/CloudLogging/BetterStackLogtailProvider.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// Better Stack / Logtail provider.
+///
+/// Endpoint: POST <ingestion URL>
+/// Success: HTTP 202 only
+final class BetterStackLogtailProvider: CloudLogProvider {
+    private let tokenProvider: () -> String?
+    private let ingestionURLProvider: () -> URL?
+    private let session: URLSession
+
+    init(
+        tokenProvider: @escaping () -> String?,
+        ingestionURLProvider: @escaping () -> URL? = { URL(string: "https://in.logs.betterstack.com/") },
+        session: URLSession = .shared
+    ) {
+        self.tokenProvider = tokenProvider
+        self.ingestionURLProvider = ingestionURLProvider
+        self.session = session
+    }
+
+    func upload(events: [CloudLogEvent]) async -> Result<Void, CloudLogUploadError> {
+        guard !events.isEmpty else { return .success(()) }
+
+        guard let token = tokenProvider(), !token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            debug(.service, "Cloud logging: not configured (no token)")
+            return .failure(.notConfigured)
+        }
+
+        guard let url = ingestionURLProvider() else {
+            debug(.service, "Cloud logging: invalid URL")
+            return .failure(.invalidURL)
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        do {
+            request.httpBody = try JSONEncoder().encode(events)
+        } catch {
+            debug(.service, "Cloud logging: encoding failed: \(error)")
+            return .failure(.encoding(error))
+        }
+
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                return .failure(.invalidResponse)
+            }
+
+            // Better Stack ingestion success is HTTP 202.
+            guard http.statusCode == 202 else {
+                let preview = String(data: data.prefix(4096), encoding: .utf8)
+
+                debug(
+                    .service,
+                    "Cloud logging upload failed: status=\(http.statusCode) events=\(events.count) bodyPreview=\(preview ?? "<non-utf8>")"
+                )
+
+                return .failure(.unexpectedStatus(code: http.statusCode, bodyPreview: preview))
+            }
+
+            return .success(())
+        } catch {
+            debug(.service, "Cloud logging: transport error: \(error)")
+            return .failure(.transport(error))
+        }
+    }
+}

--- a/Trio/Sources/Logger/CloudLogging/BetterStackSettings.swift
+++ b/Trio/Sources/Logger/CloudLogging/BetterStackSettings.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+struct BetterStackSettings: Decodable {
+    let BetterStackSourceToken: String?
+    let BetterStackIngestionUrl: String?
+}
+
+enum BetterStackSettingsStore {
+    static let relativePath = "settings/BetterStack.json"
+
+    /// Loads Better Stack settings from the app group container (preferred) and falls back to app documents.
+    static func load() -> BetterStackSettings? {
+        // Prefer the configured AppGroupID (Info.plist key "AppGroupID") if present.
+        if let suite = Bundle.main.appGroupSuiteName, !suite.isEmpty {
+            if let settings = load(from: .sharedContainer(appGroupName: suite)) {
+                return settings
+            }
+        }
+
+        // Fallback: some builds use a short app group name like "Trio".
+        if let settings = load(from: .sharedContainer(appGroupName: "Trio")) {
+            return settings
+        }
+
+        // Fallback to local documents directory (useful for simulator/dev environments).
+        return load(from: .documents)
+    }
+
+    private static func load(from directory: Disk.Directory) -> BetterStackSettings? {
+        guard let data = try? Disk.retrieve(relativePath, from: directory, as: Data.self) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(BetterStackSettings.self, from: data)
+    }
+}

--- a/Trio/Sources/Logger/CloudLogging/CloudLogEntryAggregator.swift
+++ b/Trio/Sources/Logger/CloudLogging/CloudLogEntryAggregator.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+enum CloudLogEntryAggregator {
+    /// Aggregates physical log lines into logical log entries using a start-of-entry regex.
+    ///
+    /// - Important: `lines` must be physical lines (already split on `\n`) and must not contain trailing `\n`.
+    static func aggregate(lines: [String], startPattern: NSRegularExpression) -> [String] {
+        guard !lines.isEmpty else { return [] }
+
+        var entries: [String] = []
+        var current: [String] = []
+
+        func isStart(_ line: String) -> Bool {
+            let ns = line as NSString
+            let range = NSRange(location: 0, length: ns.length)
+            return startPattern.firstMatch(in: line, range: range) != nil
+        }
+
+        for line in lines {
+            if isStart(line) {
+                if !current.isEmpty {
+                    entries.append(current.joined(separator: "\n"))
+                }
+                current = [line]
+            } else {
+                if current.isEmpty {
+                    // If we start mid-entry (e.g., offset in the middle), treat it as a single entry.
+                    current = [line]
+                } else {
+                    current.append(line)
+                }
+            }
+        }
+
+        if !current.isEmpty {
+            entries.append(current.joined(separator: "\n"))
+        }
+
+        return entries
+    }
+}

--- a/Trio/Sources/Logger/CloudLogging/CloudLogLineParsing.swift
+++ b/Trio/Sources/Logger/CloudLogging/CloudLogLineParsing.swift
@@ -1,0 +1,298 @@
+import Foundation
+
+enum CloudLogPlatform: String {
+    case ios
+    case watchos
+}
+
+struct CloudParsedLogLine {
+    let dt: String?
+    let category: String?
+    let level: String?
+    let message: String
+    let file: String?
+    let method: String?
+    let lineNumber: String?
+    /// Identifies the log source for BetterStack filtering (e.g. "complication").
+    let source: String?
+    /// Build number embedded at write time, or nil for old-format lines.
+    var build: String? = nil
+}
+
+enum CloudLogLineParser {
+    // iPhone format:
+    // <TIMESTAMP> [b:<BUILD>] [CATEGORY] <File.swift> - <function> - <line> - <LEVEL>: <message>
+    // (the [b:BUILD] token is optional for backward compatibility)
+    static func parseIOS(_ entry: String) -> CloudParsedLogLine? {
+        let trimmedEntry = entry.trimmingCharacters(in: .newlines)
+        guard !trimmedEntry.isEmpty else { return nil }
+
+        let lines = trimmedEntry.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        var header = lines.first ?? trimmedEntry
+        let continuation = lines.dropFirst().joined(separator: "\n")
+
+        // Timestamp = first token
+        let tokens = header.split(separator: " ", maxSplits: 1, omittingEmptySubsequences: true)
+        let rawTs = tokens.first.map(String.init)
+        let dt = rawTs.flatMap(normalizeTimestamp)
+
+        // Extract optional [b:BUILD] token and strip from header before category parsing
+        var extractedBuild: String?
+        if let buildRange = header.range(of: #"\[b:([^\]]+)\]"#, options: .regularExpression) {
+            let token = String(header[buildRange])
+            extractedBuild = token.trimmingCharacters(in: CharacterSet(charactersIn: "[]")).replacingOccurrences(of: "b:", with: "")
+            header = header.replacingCharacters(in: buildRange, with: "").replacingOccurrences(of: "  ", with: " ")
+        }
+
+        // Category = first [...] after timestamp
+        var category: String?
+        if let range = header.range(of: #"^\S+\s+\[([^\]]+)\]"#, options: [.regularExpression]) {
+            // Extract using a second regex capture to keep code simple.
+            if let match = header[range].range(of: #"\[([^\]]+)\]"#, options: .regularExpression) {
+                let bracketed = String(header[match])
+                category = bracketed.trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
+            }
+        }
+
+        // Extract file, method, and line number
+        // Format: [CATEGORY] <File.swift> - <function> - <line> - <LEVEL>:
+        // Example: [Nightscout] NightscoutManager.swift - uploadNonCoreDataTreatments(_:) - 999 - DEV:
+        var file: String?
+        var method: String?
+        var lineNumber: String?
+
+        // Pattern: \] (.+\.swift) - (.+?) - (\d+) - (<LEVEL>):
+        // Method name can contain special chars like (_:), so we match everything between the delimiters.
+        // Level can vary depending on logger implementation ("DEV", "DEBUG", "WARN", "WARNING", ...),
+        // so keep it permissive to avoid losing file/method/line parsing.
+        let fileMethodLineRegex = #"\]\s+([^\s]+\.swift)\s+-\s+(.+?)\s+-\s+(\d+)\s+-\s+([A-Z]+):"#
+        if let regex = try? NSRegularExpression(pattern: fileMethodLineRegex) {
+            let nsHeader = header as NSString
+            let range = NSRange(location: 0, length: nsHeader.length)
+            if let regexMatch = regex.firstMatch(in: header, range: range), regexMatch.numberOfRanges >= 5 {
+                // Group 1: file, Group 2: method, Group 3: line number
+                let fileRange = regexMatch.range(at: 1)
+                let methodRange = regexMatch.range(at: 2)
+                let lineRange = regexMatch.range(at: 3)
+
+                if fileRange.location != NSNotFound {
+                    file = nsHeader.substring(with: fileRange)
+                }
+                if methodRange.location != NSNotFound {
+                    method = nsHeader.substring(with: methodRange)
+                }
+                if lineRange.location != NSNotFound {
+                    lineNumber = nsHeader.substring(with: lineRange)
+                }
+            }
+        }
+
+        // Level = delimiter-aware: " - (DEV|INFO|WARN|ERR):"
+        let levelRegex = #"\s-\s([A-Z]+):\s"#
+        guard let levelMatch = header.range(of: levelRegex, options: .regularExpression) else {
+            // If we can't confidently parse, still return the original line as message.
+            let msg = continuation.isEmpty ? header : "\(header)\n\(continuation)"
+            return CloudParsedLogLine(dt: dt, category: category, level: nil, message: msg, file: file, method: method, lineNumber: lineNumber, source: nil, build: extractedBuild)
+        }
+
+        // Extract the actual level token and normalize
+        let levelToken = String(header[levelMatch])
+            .replacingOccurrences(of: " - ", with: "")
+            .replacingOccurrences(of: ":", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let normalizedLevel: String?
+        switch levelToken {
+        case "DEV", "DEBUG": normalizedLevel = "debug"
+        case "INFO": normalizedLevel = "info"
+        case "WARN", "WARNING": normalizedLevel = "warn"
+        case "ERR", "ERROR": normalizedLevel = "error"
+        default: normalizedLevel = nil
+        }
+
+        // Message = everything after "<LEVEL>: "
+        let messageStart = header.index(levelMatch.upperBound, offsetBy: 0)
+        let parsedFirstLineMessage = String(header[messageStart...]).trimmingCharacters(in: .newlines)
+        let firstLineMessage = parsedFirstLineMessage.isEmpty ? header : parsedFirstLineMessage
+        let fullMessage = continuation.isEmpty ? firstLineMessage : "\(firstLineMessage)\n\(continuation)"
+
+        // Apply message-based level detection to upgrade levels when appropriate
+        let finalLevel = detectLevelFromMessage(fullMessage, originalLevel: normalizedLevel)
+
+        return CloudParsedLogLine(
+            dt: dt,
+            category: category,
+            level: finalLevel,
+            message: fullMessage,
+            file: file,
+            method: method,
+            lineNumber: lineNumber,
+            source: nil,
+            build: extractedBuild
+        )
+    }
+
+    // Watch format:
+    // [<TIMESTAMP>] [b:<BUILD>] [<File.swift>:<line>] <function>() → <message>
+    // (the [b:BUILD] token is optional for backward compatibility)
+    static func parseWatch(_ entry: String) -> CloudParsedLogLine? {
+        let trimmedEntry = entry.trimmingCharacters(in: .newlines)
+        guard !trimmedEntry.isEmpty else { return nil }
+
+        let lines = trimmedEntry.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        var header = lines.first ?? trimmedEntry
+        let continuation = lines.dropFirst().joined(separator: "\n")
+
+        // Timestamp = first [...] token
+        var dt: String?
+        if let tsRange = header.range(of: #"^\[([^\]]+)\]"#, options: [.regularExpression]) {
+            let bracketed = String(header[tsRange])
+            let raw = bracketed.trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
+            dt = normalizeTimestamp(raw)
+        }
+
+        // Extract optional [b:BUILD] token and strip it from the header before further parsing
+        var extractedBuild: String?
+        if let buildRange = header.range(of: #"\[b:([^\]]+)\]"#, options: .regularExpression) {
+            let token = String(header[buildRange])
+            extractedBuild = token.trimmingCharacters(in: CharacterSet(charactersIn: "[]")).replacingOccurrences(of: "b:", with: "")
+            header = header.replacingCharacters(in: buildRange, with: "").replacingOccurrences(of: "  ", with: " ")
+        }
+
+        // Category = filename from "[File.swift:line]" (without .swift extension)
+        var category: String?
+        category = extractWatchCategory(from: header)
+
+        // Extract file, line number, and function name
+        // Format: [TIMESTAMP] [File.swift:line] function() → message
+        var file: String?
+        var lineNumber: String?
+        var method: String?
+
+        // Extract file + line independent of method parsing, since watch log methods can be:
+        // - finalizePendingData()            (trailing "()")
+        // - scheduleUIUpdate(with:)         (no trailing "()", includes signature)
+        // - session(_:didReceiveUserInfo:)  (no trailing "()", includes signature)
+        let fileLineRegex = #"\[[^\]]+\]\s+\[([^\]:]+\.swift):(\d+)\]"#
+        if let regex = try? NSRegularExpression(pattern: fileLineRegex) {
+            let nsHeader = header as NSString
+            let range = NSRange(location: 0, length: nsHeader.length)
+            if let regexMatch = regex.firstMatch(in: header, range: range), regexMatch.numberOfRanges >= 3 {
+                let fileRange = regexMatch.range(at: 1)
+                let lineRange = regexMatch.range(at: 2)
+                if fileRange.location != NSNotFound {
+                    file = nsHeader.substring(with: fileRange)
+                }
+                if lineRange.location != NSNotFound {
+                    lineNumber = nsHeader.substring(with: lineRange)
+                }
+            }
+        }
+
+        let arrowRange = header.range(of: "→") ?? header.range(of: "->")
+        if let arrowRange {
+            // Method = substring between the second closing bracket and the arrow
+            if let firstClose = header.firstIndex(of: "]") {
+                let afterFirst = header.index(after: firstClose)
+                if let secondClose = header[afterFirst...].firstIndex(of: "]") {
+                    var start = header.index(after: secondClose)
+                    while start < header.endIndex, header[start].isWhitespace {
+                        start = header.index(after: start)
+                    }
+                    let candidate = String(header[start..<arrowRange.lowerBound]).trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !candidate.isEmpty {
+                        method = candidate.hasSuffix("()") ? String(candidate.dropLast(2)) : candidate
+                    }
+                }
+            }
+        }
+
+        // Message = everything after the arrow
+        let fullMessage: String
+        if let arrowRange {
+            let msg = header[arrowRange.upperBound...].trimmingCharacters(in: .whitespacesAndNewlines)
+            let firstLineMessage = msg.isEmpty ? header : String(msg)
+            fullMessage = continuation.isEmpty ? firstLineMessage : "\(firstLineMessage)\n\(continuation)"
+        } else {
+            fullMessage = continuation.isEmpty ? header : "\(header)\n\(continuation)"
+        }
+
+        // Apply message-based level detection to upgrade levels when appropriate
+        let finalLevel = detectLevelFromMessage(fullMessage, originalLevel: nil)
+
+        let source: String? = (file == "ComplicationLogBuffer.swift" || file == "TrioComplicationDataStore.swift") ? "complication" : nil
+
+        return CloudParsedLogLine(dt: dt, category: category, level: finalLevel, message: fullMessage, file: file, method: method, lineNumber: lineNumber, source: source, build: extractedBuild)
+    }
+
+    /// Normalizes "yyyy-MM-dd'T'HH:mm:ssZ" like "...+0100" into "...+01:00" if possible.
+    /// Returns nil if normalization is not possible.
+    static func normalizeTimestamp(_ raw: String) -> String? {
+        // Only normalize if it ends with "+HHMM" or "-HHMM"
+        let tzRegex = #"([+-]\d{2})(\d{2})$"#
+        guard let tzRange = raw.range(of: tzRegex, options: .regularExpression) else {
+            return nil
+        }
+
+        let tz = raw[tzRange]
+        let tzStr = String(tz)
+        guard tzStr.count == 5 else { return nil }
+
+        let hh = tzStr.prefix(3) // +01
+        let mm = tzStr.suffix(2) // 00
+        let normalized = raw.replacingCharacters(in: tzRange, with: "\(hh):\(mm)")
+        return normalized
+    }
+
+    private static func extractWatchCategory(from line: String) -> String? {
+        let pattern = #"^\[[^\]]+\]\s+\[([^\]:]+)\.swift:\d+\]"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        let nsLine = line as NSString
+        let range = NSRange(location: 0, length: nsLine.length)
+        guard let match = regex.firstMatch(in: line, range: range), match.numberOfRanges >= 2 else { return nil }
+        let capture = match.range(at: 1)
+        guard capture.location != NSNotFound else { return nil }
+        return nsLine.substring(with: capture)
+    }
+
+    /// Detects log level from message content, upgrading the level when error/warning patterns are detected.
+    /// This helps classify logs that were incorrectly logged with `debug()` but contain error/warning indicators.
+    ///
+    /// - Parameters:
+    ///   - message: The log message to analyze
+    ///   - originalLevel: The level parsed from the log prefix (e.g., "debug", "info", "warn", "error")
+    /// - Returns: The detected level, or the original level if no patterns match
+    private static func detectLevelFromMessage(_ message: String, originalLevel: String?) -> String? {
+        let lowercased = message.lowercased()
+
+        // Error patterns (critical failures) - check first
+        if lowercased.contains("failed to retrieve file") ||
+           lowercased.contains("error domain=diskerrordomain") ||
+           lowercased.contains("could not find an existing file") ||
+           lowercased.contains("unable to") && (lowercased.contains("file") || lowercased.contains("disk")) {
+            return "error"
+        }
+
+        // Warning patterns (issues needing attention, not critical)
+        if message.contains("❌ Error sending watch state") ||
+           lowercased.contains("error domain=wcerrordomain") ||
+           lowercased.contains("warning:") {
+            return "warn"
+        }
+
+        // Info patterns (informational, expected conditions)
+        if lowercased.contains("error domain=cberrordomain") ||
+           lowercased.contains("pod disconnected") ||
+           lowercased.contains("sensor disconnected") ||
+           lowercased.contains("skipping") ||
+           lowercased.contains("device message:") ||
+           lowercased.contains("device manager for") ||
+           lowercased.contains("not reachable") ||
+           lowercased.contains("failed to send") {
+            return "info"
+        }
+
+        // If no pattern matches, return the original level
+        return originalLevel
+    }
+}

--- a/Trio/Sources/Logger/CloudLogging/CloudLogProvider.swift
+++ b/Trio/Sources/Logger/CloudLogging/CloudLogProvider.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+protocol CloudLogProvider {
+    /// Uploads a batch of events.
+    ///
+    /// - Important: Must only treat HTTP 202 as success.
+    func upload(events: [CloudLogEvent]) async -> Result<Void, CloudLogUploadError>
+}
+
+enum CloudLogUploadError: Error, CustomStringConvertible {
+    case notConfigured
+    case invalidURL
+    case transport(Error)
+    case invalidResponse
+    case unexpectedStatus(code: Int, bodyPreview: String?)
+    case encoding(Error)
+
+    var description: String {
+        switch self {
+        case .notConfigured:
+            return "Cloud logging not configured"
+        case .invalidURL:
+            return "Invalid cloud logging URL"
+        case let .transport(error):
+            return "Transport error: \(error)"
+        case .invalidResponse:
+            return "Invalid HTTP response"
+        case let .unexpectedStatus(code, bodyPreview):
+            return "Unexpected HTTP status: \(code) body: \(bodyPreview ?? "<nil>")"
+        case let .encoding(error):
+            return "Encoding error: \(error)"
+        }
+    }
+}
+
+struct CloudLogEvent: Encodable {
+    let message: String
+    let dt: String?
+    let attributes: [String: String]?
+    let raw: String?
+
+    // Custom encoding to flatten attributes to top-level fields
+    enum CodingKeys: String, CodingKey {
+        case message
+        case dt
+        case platform
+        case build
+        case category
+        case appVersion
+        case env
+        case level
+        case file
+        case method
+        case lineNumber
+        case source
+        case raw
+        case event
+        case windowId = "window_id"
+        case taskType = "task_type"
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(message, forKey: .message)
+        if let dt = dt {
+            try container.encode(dt, forKey: .dt)
+        }
+        if let raw = raw {
+            try container.encode(raw, forKey: .raw)
+        }
+
+        // Flatten attributes to top-level fields
+        if let attrs = attributes {
+            if let platform = attrs["platform"] {
+                try container.encode(platform, forKey: .platform)
+            }
+            if let build = attrs["build"] {
+                try container.encode(build, forKey: .build)
+            }
+            if let category = attrs["category"] {
+                try container.encode(category, forKey: .category)
+            }
+            if let appVersion = attrs["appVersion"] {
+                try container.encode(appVersion, forKey: .appVersion)
+            }
+            if let env = attrs["env"] {
+                try container.encode(env, forKey: .env)
+            }
+            if let level = attrs["level"] {
+                try container.encode(level, forKey: .level)
+            }
+            if let file = attrs["file"] {
+                try container.encode(file, forKey: .file)
+            }
+            if let method = attrs["method"] {
+                try container.encode(method, forKey: .method)
+            }
+            if let lineNumber = attrs["lineNumber"] {
+                try container.encode(lineNumber, forKey: .lineNumber)
+            }
+            if let source = attrs["source"] {
+                try container.encode(source, forKey: .source)
+            }
+        }
+
+        if let value = Self.extractToken(from: message, pattern: #"\bevent=([^ ]+)"#) {
+            try container.encode(value, forKey: .event)
+        }
+        if let value = Self.extractToken(from: message, pattern: #"\bwindow_id=(-?[0-9]+)"#),
+           let intValue = Int(value)
+        {
+            try container.encode(intValue, forKey: .windowId)
+        }
+        if let value = Self.extractToken(from: message, pattern: #"\btask_type=([^ ]+)"#) {
+            try container.encode(value, forKey: .taskType)
+        }
+    }
+
+    private static func extractToken(from string: String, pattern: String) -> String? {
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let match = regex.firstMatch(in: string, range: NSRange(string.startIndex..., in: string)),
+              match.numberOfRanges > 1,
+              let range = Range(match.range(at: 1), in: string)
+        else { return nil }
+        return String(string[range])
+    }
+}

--- a/Trio/Sources/Logger/CloudLogging/CloudLogUploadService.swift
+++ b/Trio/Sources/Logger/CloudLogging/CloudLogUploadService.swift
@@ -1,0 +1,194 @@
+import Foundation
+import UIKit
+
+extension Notification.Name {
+    static let trioWatchLogsAppended = Notification.Name("trioWatchLogsAppended")
+}
+
+/// App lifecycle + periodic trigger wrapper.
+///
+/// - Manual trigger: `uploadNow()`
+/// - Lifecycle triggers: foreground/background
+/// - Periodic trigger: every 30 seconds while app is running
+/// - Watch log nudge: immediate upload + timer reset when watch logs arrive
+final class CloudLogUploadService {
+    // Settings UI (first-choice config)
+    static let userDefaultsEnabledKey = "cloudLogging.enabled"
+    static let userDefaultsTokenKey = "cloudLogging.token"
+    static let userDefaultsIngestionURLKey = "cloudLogging.ingestionUrl"
+
+    // Legacy key (kept for backwards compatibility)
+    static let legacyUserDefaultsTokenKey = "cloudLogging.betterStackSourceToken"
+
+    private let uploader: CloudLogUploader
+    private var timer: Timer?
+    private var observers: [NSObjectProtocol] = []
+    private let tokenProvider: () -> String?
+    private let ingestionURLProvider: () -> URL?
+
+    init() {
+        tokenProvider = {
+            let ud = UserDefaults.standard
+
+            // If the user explicitly disabled cloud logging, do not fall back to file/env.
+            if let enabled = ud.object(forKey: Self.userDefaultsEnabledKey) as? Bool, enabled == false {
+                return nil
+            }
+
+            // Priority: Settings UI (UserDefaults) → app group settings/BetterStack.json → Info.plist → env.
+            if let enabled = ud.object(forKey: Self.userDefaultsEnabledKey) as? Bool, enabled == true {
+                if let t = ud.string(forKey: Self.userDefaultsTokenKey), !t.isEmpty { return t }
+                if let t = ud.string(forKey: Self.legacyUserDefaultsTokenKey), !t.isEmpty { return t }
+                // If enabled but no token set in UI, allow file-based config.
+            } else {
+                // No explicit enable flag; still allow legacy token key.
+                if let t = ud.string(forKey: Self.legacyUserDefaultsTokenKey), !t.isEmpty { return t }
+            }
+
+            if let settings = BetterStackSettingsStore.load(),
+               let t = settings.BetterStackSourceToken,
+               !t.isEmpty
+            {
+                return t
+            }
+
+            if let t = Bundle.main.object(forInfoDictionaryKey: "BetterStackSourceToken") as? String, !t.isEmpty { return t }
+            return ProcessInfo.processInfo.environment["BETTERSTACK_SOURCE_TOKEN"]
+        }
+
+        ingestionURLProvider = {
+            let ud = UserDefaults.standard
+
+            if let enabled = ud.object(forKey: Self.userDefaultsEnabledKey) as? Bool, enabled == false {
+                return nil
+            }
+
+            if let enabled = ud.object(forKey: Self.userDefaultsEnabledKey) as? Bool, enabled == true {
+                if let raw = ud.string(forKey: Self.userDefaultsIngestionURLKey), !raw.isEmpty {
+                    return URL(string: raw)
+                }
+            }
+
+            if let settings = BetterStackSettingsStore.load(),
+               let raw = settings.BetterStackIngestionUrl,
+               let url = URL(string: raw)
+            {
+                return url
+            }
+            return URL(string: "https://in.logs.betterstack.com/")
+        }
+
+        let provider = BetterStackLogtailProvider(
+            tokenProvider: tokenProvider,
+            ingestionURLProvider: ingestionURLProvider
+        )
+
+        let pairs: [CloudLogUploader.RotatingPair] = [
+            .init(
+                currentPath: SimpleLogReporter.logFile,
+                previousPath: SimpleLogReporter.logFilePrev,
+                platform: .ios,
+                parser: CloudLogLineParser.parseIOS
+            ),
+            .init(
+                currentPath: SimpleLogReporter.watchLogFile,
+                previousPath: SimpleLogReporter.watchLogFilePrev,
+                platform: .watchos,
+                parser: CloudLogLineParser.parseWatch
+            )
+        ]
+
+        uploader = CloudLogUploader(provider: provider, pairs: pairs)
+
+        start()
+    }
+
+    deinit {
+        stop()
+    }
+
+    func uploadNow() {
+        // Only run when configured (no privacy gating in this repo).
+        guard let token = tokenProvider(), !token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return
+        }
+        guard ingestionURLProvider() != nil else {
+            return
+        }
+
+        Task {
+            _ = await uploader.uploadNow()
+        }
+    }
+
+    // MARK: - Scheduling
+
+    private func start() {
+        let center = Foundation.NotificationCenter.default
+
+        observers.append(
+            center.addObserver(
+                forName: UIApplication.willEnterForegroundNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                self?.uploadNow()
+                self?.resetUploadTimer()
+            }
+        )
+
+        observers.append(
+            center.addObserver(
+                forName: UIApplication.didEnterBackgroundNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                self?.uploadNow()
+                self?.resetUploadTimer()
+            }
+        )
+
+        // Watch log nudge: immediate upload + timer reset.
+        // queue: .main ensures resetUploadTimer() runs on the main thread
+        // regardless of which thread the notification was posted from.
+        observers.append(
+            center.addObserver(
+                forName: .trioWatchLogsAppended,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                self?.uploadNow()
+                self?.resetUploadTimer()
+            }
+        )
+
+        resetUploadTimer()
+
+        // Detect build change and flush immediately so backlogged lines carry the old build
+        let lastKnownBuildKey = "cloudLogUploadService.lastKnownBuild"
+        let currentBuild = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown"
+        let lastKnownBuild = UserDefaults.standard.string(forKey: lastKnownBuildKey)
+        if lastKnownBuild != currentBuild {
+            uploadNow()
+            UserDefaults.standard.set(currentBuild, forKey: lastKnownBuildKey)
+        }
+    }
+
+    private func resetUploadTimer() {
+        timer?.invalidate()
+        timer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
+            self?.uploadNow()
+        }
+    }
+
+    private func stop() {
+        timer?.invalidate()
+        timer = nil
+
+        let center = Foundation.NotificationCenter.default
+        for o in observers {
+            center.removeObserver(o)
+        }
+        observers.removeAll()
+    }
+}

--- a/Trio/Sources/Logger/CloudLogging/CloudLogUploader.swift
+++ b/Trio/Sources/Logger/CloudLogging/CloudLogUploader.swift
@@ -1,0 +1,430 @@
+import Foundation
+
+/// iPhone-only log tailer/uploader.
+///
+/// - Keeps file-based logs as the source of truth.
+/// - Tails files using byte offsets (no buffering).
+/// - Handles daily rotation where `*_log.txt` is moved to `*_log_prev.txt`.
+actor CloudLogUploader {
+    struct RotatingPair {
+        let currentPath: String
+        let previousPath: String
+        let platform: CloudLogPlatform
+        let parser: (String) -> CloudParsedLogLine?
+    }
+
+    private struct TailState: Codable {
+        var offset: UInt64
+    }
+
+    private let provider: CloudLogProvider
+    private let pairs: [RotatingPair]
+    private let userDefaults: UserDefaults
+    private let stateKey = "cloudLogUploader.tailState.v1"
+
+    private var isUploading = false
+
+    // MARK: - Better Stack ingestion filter (reduce volume; local logs unchanged)
+
+    private var ingestionThrottleLastSent: [String: Date] = [:]
+    private let ingestionThrottleInterval: TimeInterval = 60
+    private let ingestionStorageErrorMaxChars = 300
+    private let ingestionAutosensShortMaxChars = 15
+
+    init(
+        provider: CloudLogProvider,
+        pairs: [RotatingPair],
+        userDefaults: UserDefaults = .standard
+    ) {
+        self.provider = provider
+        self.pairs = pairs
+        self.userDefaults = userDefaults
+    }
+
+    /// Returns true if this run completed without provider failures.
+    @discardableResult
+    func uploadNow() async -> Bool {
+        guard !isUploading else { return true }
+        isUploading = true
+        defer { isUploading = false }
+
+        var allSucceeded = true
+        for pair in pairs {
+            let ok = await uploadRotatingPair(pair)
+            if !ok { allSucceeded = false }
+        }
+        return allSucceeded
+    }
+
+    // MARK: - Rotation + tail logic
+
+    private func uploadRotatingPair(_ pair: RotatingPair) async -> Bool {
+        let currentURL = URL(fileURLWithPath: pair.currentPath)
+        let prevURL = URL(fileURLWithPath: pair.previousPath)
+
+        var currentState = loadState(for: pair.currentPath)
+        var prevState = loadState(for: pair.previousPath)
+        var succeeded = true
+
+        // Reset offsets if file shrank (rotation or truncation).
+        if let currentSize = fileSize(currentURL), currentSize < currentState.offset {
+            currentState.offset = 0
+            saveState(currentState, for: pair.currentPath)
+        }
+        if let prevSize = fileSize(prevURL), prevSize < prevState.offset {
+            prevState.offset = 0
+            saveState(prevState, for: pair.previousPath)
+        }
+
+        // Upload current tail.
+        let okCurrent = await uploadNewContent(
+            fileURL: currentURL,
+            filePathKey: pair.currentPath,
+            startOffset: currentState.offset,
+            platform: pair.platform,
+            parser: pair.parser
+        )
+        if !okCurrent { succeeded = false }
+
+        // Upload previous tail as well (best-effort for late rotation or missed uploads).
+        let okPrev = await uploadNewContent(
+            fileURL: prevURL,
+            filePathKey: pair.previousPath,
+            startOffset: prevState.offset,
+            platform: pair.platform,
+            parser: pair.parser
+        )
+        if !okPrev { succeeded = false }
+
+        return succeeded
+    }
+
+    private func uploadNewContent(
+        fileURL: URL,
+        filePathKey: String,
+        startOffset: UInt64,
+        platform: CloudLogPlatform,
+        parser: (String) -> CloudParsedLogLine?
+    ) async -> Bool {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { return true }
+        guard let size = fileSize(fileURL), size > startOffset else { return true }
+
+        guard let (lines, nextOffset) = readCompleteLines(fileURL: fileURL, startOffset: startOffset) else {
+            return true
+        }
+        guard !lines.isEmpty else {
+            saveState(TailState(offset: nextOffset), for: filePathKey)
+            return true
+        }
+
+        let entries = aggregateEntries(physicalLines: lines, platform: platform)
+        guard !entries.isEmpty else {
+            saveState(TailState(offset: nextOffset), for: filePathKey)
+            return true
+        }
+
+        let commonAttributes = buildCommonAttributes(platform: platform)
+
+        // Build events (best-effort parsing; always upload the line).
+        let events: [CloudLogEvent] = entries.compactMap { entry in
+            let parsed = parser(entry)
+            var attrs = commonAttributes
+            if let parsed {
+                if let c = parsed.category { attrs["category"] = c }
+                if let l = parsed.level { attrs["level"] = l }
+                if let f = parsed.file { attrs["file"] = f }
+                if let m = parsed.method { attrs["method"] = m }
+                if let ln = parsed.lineNumber { attrs["lineNumber"] = ln }
+                if let s = parsed.source { attrs["source"] = s }
+                if let b = parsed.build { attrs["build"] = b }
+                let msg = truncateMessage(parsed.message)
+                return CloudLogEvent(message: msg, dt: parsed.dt, attributes: attrs, raw: entry)
+            } else {
+                let msg = truncateMessage(entry)
+                return CloudLogEvent(message: msg, dt: nil, attributes: attrs, raw: entry)
+            }
+        }
+
+        // Apply ingestion filter: drop/throttle/trim for Better Stack volume reduction (local logs unchanged).
+        let eventsToUpload = applyIngestionFilter(events, now: Date())
+
+        // Upload in batches with both count and byte-budget caps.
+        // This helps avoid 413 errors regardless of log verbosity.
+        let batches = buildBatches(events: eventsToUpload)
+        for batch in batches {
+            switch await provider.upload(events: batch) {
+            case .success:
+                continue
+            case .failure:
+                // Critical: do NOT advance offsets.
+                debug(.service, "CloudLogUploader: upload failed for \(filePathKey), offset not advanced")
+                return false
+            }
+        }
+
+        // Only advance the file offset after the final batch succeeds.
+        var state = loadState(for: filePathKey)
+        state.offset = nextOffset
+        saveState(state, for: filePathKey)
+        return true
+    }
+
+    /// Reads from startOffset to EOF and returns only complete lines (ending with '\n').
+    /// The returned `nextOffset` is the byte offset right after the last complete newline.
+    private func readCompleteLines(fileURL: URL, startOffset: UInt64) -> ([String], UInt64)? {
+        guard let handle = try? FileHandle(forReadingFrom: fileURL) else { return nil }
+        defer { try? handle.close() }
+
+        do {
+            try handle.seek(toOffset: startOffset)
+            let data = try handle.readToEnd() ?? Data()
+            guard !data.isEmpty else { return ([], startOffset) }
+
+            // Only advance to the last newline to avoid uploading a partial final line.
+            guard let lastNewlineIdx = data.lastIndex(of: 0x0A) else {
+                return ([], startOffset)
+            }
+
+            let completeData = data.prefix(upTo: data.index(after: lastNewlineIdx))
+            let text = String(decoding: completeData, as: UTF8.self)
+
+            var lines = text
+                .split(separator: "\n", omittingEmptySubsequences: false)
+                .map(String.init)
+            // Because `text` ends with '\n', split(...) includes a final empty element; drop it.
+            if lines.last == "" {
+                lines.removeLast()
+            }
+
+            let nextOffset = startOffset + UInt64(completeData.count)
+            return (lines, nextOffset)
+        } catch {
+            return nil
+        }
+    }
+
+    private func aggregateEntries(physicalLines: [String], platform: CloudLogPlatform) -> [String] {
+        let pattern: String
+        switch platform {
+        case .ios:
+            pattern = #"^\d{4}-\d{2}-\d{2}T"#
+        case .watchos:
+            pattern = #"^\[\d{4}-\d{2}-\d{2}T"#
+        }
+
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            // Fallback to line-by-line if regex compilation fails (shouldn't happen).
+            return physicalLines
+        }
+
+        return CloudLogEntryAggregator.aggregate(lines: physicalLines, startPattern: regex)
+    }
+
+    // MARK: - Attributes
+
+    private func buildCommonAttributes(platform: CloudLogPlatform) -> [String: String] {
+        var attrs: [String: String] = [:]
+        attrs["platform"] = platform.rawValue
+
+        let env: String
+        if BuildDetails.shared.isTestFlightBuild() {
+            env = "testflight"
+        } else {
+            #if DEBUG
+                env = "debug"
+            #else
+                env = "release"
+            #endif
+        }
+        attrs["env"] = env
+
+        if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+            attrs["appVersion"] = version
+        }
+        if let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String {
+            attrs["build"] = build
+        }
+
+        return attrs
+    }
+
+    // MARK: - Ingestion filter (Better Stack volume reduction)
+
+    /// Drops or trims events before upload. Local log files are unchanged.
+    private func applyIngestionFilter(_ events: [CloudLogEvent], now: Date) -> [CloudLogEvent] {
+        var result: [CloudLogEvent] = []
+        for event in events {
+            // Rule 2: Drop all PersistedProperty "Saved value successfully".
+            if event.message.contains("[PersistedProperty:") && event.message.contains("Saved value successfully.") {
+                continue
+            }
+
+            // Rule 1: Throttle OpenAPS Dynamic ISF prediction lines (1 per 60s per subtype).
+            if event.message.contains("Dynamic ISF (Logarithmic Formula)") {
+                let key: String?
+                if event.message.contains("adjusted predictions for IOB and ZT") { key = "openaps:IOB_ZT" }
+                else if event.message.contains("adjusted prediction for UAM") { key = "openaps:UAM" }
+                else { key = nil }
+                if let key = key {
+                    if let last = ingestionThrottleLastSent[key], now.timeIntervalSince(last) < ingestionThrottleInterval {
+                        continue
+                    }
+                    ingestionThrottleLastSent[key] = now
+                }
+            }
+
+            // Rule 5: Throttle short autosens.js lines (e.g. "autosens.js: 2g").
+            if let autosensRange = event.message.range(of: "autosens.js:") {
+                let rest = event.message[autosensRange.upperBound...].trimmingCharacters(in: .whitespaces)
+                if rest.count <= ingestionAutosensShortMaxChars {
+                    let key = "autosens:short"
+                    if let last = ingestionThrottleLastSent[key], now.timeIntervalSince(last) < ingestionThrottleInterval {
+                        continue
+                    }
+                    ingestionThrottleLastSent[key] = now
+                }
+            }
+
+            // Rule 3: Trim "Watch received data" — drop from "glucoseValues = (" onward in message and raw.
+            var message = event.message
+            var raw = event.raw
+            if message.contains("Watch received data") {
+                message = trimWatchReceivedDataMessage(message)
+                if let r = raw, r.contains("Watch received data") {
+                    raw = trimWatchReceivedDataMessage(r)
+                }
+            }
+
+            // Rule 4: Trim long storage/error messages (e.g. "Failed to retrieve file").
+            if message.contains("Failed to retrieve file") && message.count > ingestionStorageErrorMaxChars {
+                message = String(message.prefix(ingestionStorageErrorMaxChars)) + "…"
+                raw = nil
+            }
+
+            if message != event.message || raw != event.raw {
+                result.append(CloudLogEvent(message: message, dt: event.dt, attributes: event.attributes, raw: raw))
+            } else {
+                result.append(event)
+            }
+        }
+        return result
+    }
+
+    /// Keeps content before `glucoseValues = (` (or `glucoseValues =     (` etc.); drops the rest to reduce Better Stack payload size.
+    private func trimWatchReceivedDataMessage(_ text: String) -> String {
+        // Match "glucoseValues =" followed by optional whitespace and "(" (watch state uses variable spacing).
+        guard let keyRange = text.range(of: "glucoseValues =") else { return text }
+        let afterKey = text[keyRange.upperBound...]
+        guard afterKey.firstIndex(where: { $0 == "(" }) != nil else { return text }
+        return String(text[..<keyRange.lowerBound]).trimmingCharacters(in: .whitespaces)
+    }
+
+    // MARK: - State store
+
+    private func loadState(for path: String) -> TailState {
+        guard let data = userDefaults.data(forKey: stateKey),
+              let dict = try? JSONDecoder().decode([String: TailState].self, from: data),
+              let state = dict[path]
+        else {
+            return TailState(offset: 0)
+        }
+        return state
+    }
+
+    private func saveState(_ state: TailState, for path: String) {
+        var dict: [String: TailState] = [:]
+        if let data = userDefaults.data(forKey: stateKey),
+           let decoded = try? JSONDecoder().decode([String: TailState].self, from: data)
+        {
+            dict = decoded
+        }
+        dict[path] = state
+        if let encoded = try? JSONEncoder().encode(dict) {
+            userDefaults.set(encoded, forKey: stateKey)
+        }
+    }
+
+    // MARK: - File helpers
+
+    private func fileSize(_ url: URL) -> UInt64? {
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+              let size = attrs[.size] as? NSNumber
+        else { return nil }
+        return size.uint64Value
+    }
+
+    // MARK: - Request sizing helpers
+
+    private let maxMessageBytes = 256 * 1024
+    private let maxRequestBytes = 8 * 1024 * 1024
+    private let maxEventsPerRequest = 250
+
+    private func truncateMessage(_ message: String) -> String {
+        guard message.utf8.count > maxMessageBytes else { return message }
+        let data = message.data(using: .utf8) ?? Data()
+        return truncateUTF8(data: data, maxBytes: maxMessageBytes)
+    }
+
+    private func buildBatches(events: [CloudLogEvent]) -> [[CloudLogEvent]] {
+        guard !events.isEmpty else { return [] }
+
+        var result: [[CloudLogEvent]] = []
+        var current: [CloudLogEvent] = []
+        var currentBytes = 2 // "[]"
+        let encoder = JSONEncoder()
+
+        for event in events {
+            let eventBytes = (try? encoder.encode(event).count) ?? Int.max
+            let additionalBytes = current.isEmpty ? eventBytes : (1 + eventBytes) // comma for non-first
+
+            let wouldExceedCount = current.count >= maxEventsPerRequest
+            let wouldExceedBytes = (currentBytes + additionalBytes) > maxRequestBytes
+
+            if wouldExceedCount || wouldExceedBytes {
+                if !current.isEmpty {
+                    result.append(current)
+                }
+                current = [event]
+                currentBytes = 2 + eventBytes
+
+                // If a single event still exceeds the request budget (should be rare due to truncation),
+                // upload it alone to avoid an infinite loop.
+                if currentBytes > maxRequestBytes {
+                    result.append(current)
+                    current.removeAll(keepingCapacity: true)
+                    currentBytes = 2
+                }
+            } else {
+                current.append(event)
+                currentBytes += additionalBytes
+            }
+        }
+
+        if !current.isEmpty {
+            result.append(current)
+        }
+
+        return result
+    }
+
+    /// Truncate UTF-8 data without emitting replacement characters.
+    private func truncateUTF8(data: Data, maxBytes: Int) -> String {
+        guard data.count > maxBytes else {
+            return String(data: data, encoding: .utf8) ?? String(decoding: data, as: UTF8.self)
+        }
+
+        var truncated = data.prefix(maxBytes)
+
+        // If we're mid-codepoint, drop trailing bytes until valid UTF-8.
+        // Worst-case UTF-8 sequence length is 4, so this loop should be short,
+        // but we keep it safe for malformed input.
+        while !truncated.isEmpty {
+            if let s = String(data: truncated, encoding: .utf8) {
+                return s
+            }
+            truncated = truncated.dropLast(1)
+        }
+
+        return ""
+    }
+}

--- a/Trio/Sources/Logger/IssueReporter/SimpleLogReporter.swift
+++ b/Trio/Sources/Logger/IssueReporter/SimpleLogReporter.swift
@@ -3,12 +3,13 @@ import SwiftDate
 
 final class SimpleLogReporter: IssueReporter {
     private let fileManager = FileManager.default
+    private let build: String = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown"
 
-    private var dateFormatter: DateFormatter {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
-        return dateFormatter
-    }
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
+        return formatter
+    }()
 
     func setup() {}
 
@@ -42,7 +43,7 @@ final class SimpleLogReporter: IssueReporter {
             }
         }
 
-        let logEntry = "\(dateFormatter.string(from: now)) [\(category)] \(file.file) - \(function) - \(line) - \(message)\n"
+        let logEntry = "\(SimpleLogReporter.dateFormatter.string(from: now)) [b:\(build)] [\(category)] \(file.file) - \(function) - \(line) - \(message)\n"
         let data = logEntry.data(using: .utf8)!
         try? data.append(fileURL: URL(fileURLWithPath: SimpleLogReporter.logFile))
     }

--- a/Trio/Sources/Models/NightscoutAlgorithmSettings.swift
+++ b/Trio/Sources/Models/NightscoutAlgorithmSettings.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+struct NightscoutAlgorithmSettings: Codable {
+    // Meta
+    let schemaVersion: Int? // = 1
+    let algorithmVersion: String?
+    let units: String? // "mg/dL" or "mmol/L"
+    let preferencesTimestamp: Date?
+
+    // Loop & SMB/UAM
+    let closedLoop: Bool?
+    let enableUAM: Bool?
+    let enableSMBAlways: Bool?
+    let enableSMBWithCOB: Bool?
+    let enableSMBAfterCarbs: Bool?
+    let enableSMBWithTemptarget: Bool?
+    let allowSMBWithHighTemptarget: Bool?
+    let smbDeliveryRatio: Decimal?
+    let smbInterval: Decimal?
+    let maxSMBBasalMinutes: Decimal?
+    let maxUAMSMBBasalMinutes: Decimal?
+
+    // Sensitivity / targets
+    let autosensMax: Decimal?
+    let autosensMin: Decimal?
+    let rewindResetsAutosens: Bool?
+    let highTemptargetRaisesSensitivity: Bool?
+    let lowTemptargetLowersSensitivity: Bool?
+    let sensitivityRaisesTarget: Bool?
+    let resistanceLowersTarget: Bool?
+    let advTargetAdjustments: Bool?
+
+    // Safety rails
+    let maxIOB: Decimal?
+    let maxCOB: Decimal?
+    let maxDailySafetyMultiplier: Decimal?
+    let currentBasalSafetyMultiplier: Decimal?
+
+    // Insulin model
+    let curve: String? // Preferences.InsulinCurve rawValue
+    let useCustomPeakTime: Bool?
+    let insulinPeakTime: Decimal?
+    let insulinActionCurve: Decimal? // Pump reality
+
+    // Exercise / temp targets
+    let exerciseMode: Bool?
+    let halfBasalExerciseTarget: Decimal?
+
+    // Carb absorption / UAM
+    let maxMealAbsorptionTime: Decimal?
+    let min5mCarbimpact: Decimal?
+    let remainingCarbsFraction: Decimal?
+    let remainingCarbsCap: Decimal?
+
+    // Heuristics & advanced math
+    let adjustmentFactor: Decimal?
+    let adjustmentFactorSigmoid: Decimal?
+    let sigmoid: Bool?
+    let useNewFormula: Bool?
+    let useWeightedAverage: Bool?
+    let weightPercentage: Decimal?
+    let tddAdjBasal: Bool?
+    let updateInterval: Decimal?
+    let maxDeltaBGthreshold: Decimal?
+    let noisyCGMTargetMultiplier: Decimal?
+    let carbsReqThreshold: Decimal?
+    let threshold_setting: Decimal?
+    let suspendZerosIOB: Bool?
+    let unsuspendIfNoTemp: Bool?
+    let skipNeutralTemps: Bool?
+
+    // Food processing helpers
+    let useFPUconversion: Bool?
+    let fattyMeals: Bool?
+    let fattyMealFactor: Decimal?
+    let sweetMeals: Bool?
+    let sweetMealFactor: Decimal?
+    let overrideFactor: Decimal?
+    let individualAdjustmentFactor: Decimal?
+    let timeCap: Decimal?
+    let minuteInterval: Decimal?
+    let delay: Decimal?
+
+    // Pump hard limits
+    let maxBolus: Decimal?
+    let maxBasal: Decimal?
+}

--- a/Trio/Sources/Models/NightscoutStatus.swift
+++ b/Trio/Sources/Models/NightscoutStatus.swift
@@ -5,6 +5,8 @@ struct NightscoutStatus: JSON {
     let openaps: OpenAPSStatus
     let pump: NSPumpStatus
     let uploader: Uploader
+    /// Trio‑specific advanced algorithm settings (optional).
+    let trioSettings: NightscoutAlgorithmSettings?
 }
 
 struct OpenAPSStatus: JSON {

--- a/Trio/Sources/Models/WatchMessageKeys.swift
+++ b/Trio/Sources/Models/WatchMessageKeys.swift
@@ -1,6 +1,6 @@
 enum WatchMessageKeys {
     // Request/Response Keys
-    static let date = "date"
+    static let date = "date" // ⚠️ BUILD TIME, not CGM reading time — use readingEpoch for CGM timestamp
     static let units = "units"
     static let requestWatchUpdate = "requestWatchUpdate"
     static let watchState = "watchState"
@@ -43,6 +43,10 @@ enum WatchMessageKeys {
     static let maxYAxisValue = "maxYAxisValue"
     static let overridePresets = "overridePresets"
     static let tempTargetPresets = "tempTargetPresets"
+
+    // Transfer Metadata Keys
+    static let readingEpoch = "reading_epoch"
+    static let transferEnqueuedAt = "transfer_enqueued_at"
 
     // Limits and Settings Keys
     static let maxBolus = "maxBolus"

--- a/Trio/Sources/Modules/AppDiagnostics/View/AppDiagnosticsRootView.swift
+++ b/Trio/Sources/Modules/AppDiagnostics/View/AppDiagnosticsRootView.swift
@@ -1,3 +1,4 @@
+import FirebaseCrashlytics
 import SwiftUI
 import Swinject
 
@@ -6,6 +7,7 @@ extension AppDiagnostics {
         let resolver: Resolver
 
         @State var state = StateModel()
+        @State private var showCrashConfirmation = false
 
         @Environment(\.colorScheme) var colorScheme
         @Environment(AppState.self) var appState
@@ -46,6 +48,47 @@ extension AppDiagnostics {
                         }
                     }
                 ).listRowBackground(Color.chart)
+
+                Section(
+                    header: Text("Developer Tools"),
+                    footer: Text(
+                        "Use Test Crash to verify Crashlytics is receiving crash reports correctly."
+                    )
+                ) {
+                    Button(role: .destructive) {
+                        showCrashConfirmation = true
+                    } label: {
+                        HStack {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .foregroundColor(.red)
+                            Text("Test Crash")
+                                .foregroundColor(.primary)
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                    .confirmationDialog(
+                        "Force a Test Crash?",
+                        isPresented: $showCrashConfirmation,
+                        titleVisibility: .visible
+                    ) {
+                        Button("Crash Now", role: .destructive) {
+                            // Log a breadcrumb to confirm Crashlytics is connected
+                            Crashlytics.crashlytics().log("Test crash initiated from App Diagnostics")
+                            // Force a crash - this will crash the app
+                            fatalError("Test crash triggered from App Diagnostics")
+                        }
+                        Button("Cancel", role: .cancel) {}
+                    } message: {
+                        Text(
+                            """
+                            This will immediately crash the app to verify Crashlytics \
+                            is working. Relaunch the app after the crash.
+                            """
+                        )
+                    }
+                }.listRowBackground(Color.chart)
 
                 Section {
                     VStack(alignment: .leading, spacing: 8) {

--- a/Trio/Sources/Modules/Home/View/Chart/ChartElements/BasalChart.swift
+++ b/Trio/Sources/Modules/Home/View/Chart/ChartElements/BasalChart.swift
@@ -17,29 +17,28 @@ struct BasalProfile: Hashable {
 
 extension MainChartView {
     var basalChart: some View {
-        VStack {
-            Chart {
-                drawStartRuleMark()
-                drawEndRuleMark()
-                drawCurrentTimeMarker()
-                drawTempBasals(dummy: false)
-                drawBasalProfile()
-                drawSuspensions()
-            }.onChange(of: state.tempBasals) {
-                calculateBasals()
-                calculateTempBasalsInBackground()
-            }
-            .onChange(of: state.maxBasal) {
-                calculateBasals()
-            }
-            .frame(minHeight: geo.size.height * 0.05)
-            .frame(width: fullWidth(viewWidth: screenSize.width))
-            .chartXScale(domain: state.startMarker ... state.endMarker)
-            .chartXAxis { basalChartXAxis }
-            .chartXAxis(.hidden)
-            .chartYAxis(.hidden)
-            .chartPlotStyle { basalChartPlotStyle($0) }
+        Chart {
+            drawStartRuleMark()
+            drawEndRuleMark()
+            drawCurrentTimeMarker()
+            drawTempBasals(dummy: false)
+            drawBasalProfile()
+            drawSuspensions()
         }
+        .onChange(of: state.tempBasals) {
+            calculateBasals()
+            calculateTempBasalsInBackground()
+        }
+        .onChange(of: state.maxBasal) {
+            calculateBasals()
+        }
+        .frame(height: basalChartHeight)
+        .frame(width: fullWidth(viewWidth: geo.size.width))
+        .chartXScale(domain: state.startMarker ... state.endMarker)
+        .chartXAxis { basalChartXAxis }
+        .chartXAxis(.hidden)
+        .chartYAxis(.hidden)
+        .chartPlotStyle { basalChartPlotStyle($0) }
     }
 }
 
@@ -177,7 +176,6 @@ extension MainChartView {
         let startOfDay = Calendar.current.startOfDay(for: beginDate)
         let profile = state.basalProfile
         var basalPoints: [BasalProfile] = []
-        var lastEntryBeforeRange: (amount: Double, date: Date)?
 
         // Iterate over the next three days, multiplying the time intervals
         for dayOffset in 0 ..< 3 {
@@ -186,12 +184,8 @@ extension MainChartView {
                 let basalTime = startOfDay.addingTimeInterval(entry.minutes.minutes.timeInterval + dayTimeOffset)
                 let basalTimeInterval = basalTime.timeIntervalSince1970
 
-                if basalTimeInterval < timeBegin {
-                    // Track the last profile entry before the visible range
-                    if lastEntryBeforeRange == nil || basalTime > lastEntryBeforeRange!.date {
-                        lastEntryBeforeRange = (amount: Double(entry.rate), date: basalTime)
-                    }
-                } else if basalTimeInterval < timeEnd {
+                // Only append points within the timeBegin and timeEnd range
+                if basalTimeInterval >= timeBegin, basalTimeInterval < timeEnd {
                     basalPoints.append(BasalProfile(
                         amount: Double(entry.rate),
                         isOverwritten: false,
@@ -199,15 +193,6 @@ extension MainChartView {
                     ))
                 }
             }
-        }
-
-        // Include the active profile entry at timeBegin so the line starts at the chart's left edge
-        if let lastBefore = lastEntryBeforeRange {
-            basalPoints.append(BasalProfile(
-                amount: lastBefore.amount,
-                isOverwritten: false,
-                startDate: beginDate
-            ))
         }
 
         return basalPoints

--- a/Trio/Sources/Modules/Home/View/Chart/ChartElements/CobIobChart.swift
+++ b/Trio/Sources/Modules/Home/View/Chart/ChartElements/CobIobChart.swift
@@ -44,8 +44,8 @@ extension MainChartView {
             "IOB": Color.darkerBlue
         ])
         .chartLegend(.hidden)
-        .frame(minHeight: geo.size.height * 0.12)
-        .frame(width: fullWidth(viewWidth: screenSize.width))
+        .frame(height: cobChartHeight)
+        .frame(width: fullWidth(viewWidth: geo.size.width))
         .chartXScale(domain: state.startMarker ... state.endMarker)
         .chartXSelection(value: $selection)
         .chartXAxis { basalChartXAxis }

--- a/Trio/Sources/Modules/Home/View/Chart/ChartElements/DummyCharts.swift
+++ b/Trio/Sources/Modules/Home/View/Chart/ChartElements/DummyCharts.swift
@@ -38,10 +38,8 @@ extension MainChartView {
             }
         }
         .id("DummyMainChart")
-        .frame(
-            minHeight: geo.size.height * (0.28 - safeAreaSize)
-        )
-        .frame(width: screenSize.width - 10)
+        .frame(height: mainChartHeight)
+        .frame(width: geo.size.width - 10)
         .chartXAxis { mainChartXAxis }
         .chartXScale(domain: state.startMarker ... state.endMarker)
         .chartXAxis(.hidden)
@@ -56,8 +54,8 @@ extension MainChartView {
     var dummyBasalChart: some View {
         Chart {}
             .id("DummyBasalChart")
-            .frame(minHeight: geo.size.height * 0.05)
-            .frame(width: screenSize.width - 10)
+            .frame(height: basalChartHeight)
+            .frame(width: geo.size.width - 10)
             .chartXAxis { basalChartXAxis }
             .chartXAxis(.hidden)
             .chartYAxis(.hidden)
@@ -67,8 +65,8 @@ extension MainChartView {
     var dummyCobChart: some View {
         Chart {}
             .id("DummyCobChart")
-            .frame(minHeight: geo.size.height * 0.12)
-            .frame(width: screenSize.width - 10)
+            .frame(height: cobChartHeight)
+            .frame(width: geo.size.width - 10)
             .chartXScale(domain: state.startMarker ... state.endMarker)
             .chartXAxis { basalChartXAxis }
             .chartXAxis(.hidden)

--- a/Trio/Sources/Modules/Home/View/Chart/MainChartView.swift
+++ b/Trio/Sources/Modules/Home/View/Chart/MainChartView.swift
@@ -2,7 +2,6 @@ import Charts
 import CoreData
 import SwiftUI
 
-let screenSize: CGRect = UIScreen.main.bounds
 let calendar = Calendar.current
 
 struct MainChartView: View {
@@ -33,6 +32,45 @@ struct MainChartView: View {
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.calendar) var calendar
 
+    // Scaled spacer height for accessibility support - scales with dynamic type.
+    @ScaledMetric(relativeTo: .footnote) private var axisSpacerHeight: CGFloat = 16
+
+    private let chartSpacing: CGFloat = 5
+
+    /// Use the current chart container height as the layout reference, then
+    /// bound it to avoid pathological values during transient layout passes.
+    private var chartLayoutReferenceHeight: CGFloat {
+        max(geo.size.height, 0).clamped(320 ... 980)
+    }
+    // NOTE:
+    // Historically these charts used `minHeight` to allow them to stretch if the
+    // surrounding layout provided extra vertical space. The flexible sizing also
+    // meant that a spacer recalculation or an unexpected safe-area change could
+    // cause the charts to over-expand. We now use fixed heights to keep the
+    // overlaid chart stack aligned. If future layouts need flexibility again,
+    // prefer a bounded range (`minHeight` + `maxHeight`) instead of a single
+    // unconstrained `minHeight`.
+    var mainChartHeight: CGFloat {
+        let rawHeight = chartLayoutReferenceHeight * (0.28 - safeAreaSize)
+        return rawHeight.clamped(110 ... 320)
+    }
+
+    var basalChartHeight: CGFloat {
+        let rawHeight = chartLayoutReferenceHeight * 0.05
+        return rawHeight.clamped(24 ... 64)
+    }
+
+    var cobChartHeight: CGFloat {
+        let rawHeight = chartLayoutReferenceHeight * 0.12
+        return rawHeight.clamped(56 ... 150)
+    }
+
+    // Computed chart stack height to constrain the overall chart region.
+    // Layout inside each VStack: basalChart, mainChart, axisSpacer, cobChart = 4 items with 3 gaps.
+    private var chartStackHeight: CGFloat {
+        basalChartHeight + mainChartHeight + cobChartHeight + axisSpacerHeight + (chartSpacing * 3)
+    }
+
     var upperLimit: Decimal {
         units == .mgdL ? 400 : 22.2
     }
@@ -62,21 +100,21 @@ struct MainChartView: View {
     }
 
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
             ZStack {
-                VStack(spacing: 5) {
+                VStack(spacing: chartSpacing) {
                     dummyBasalChart
                     staticYAxisChart
-                    Spacer()
+                    Color.clear.frame(height: axisSpacerHeight)
                     dummyCobChart
                 }
 
                 ScrollViewReader { scroller in
                     ScrollView(.horizontal, showsIndicators: false) {
-                        VStack(spacing: 5) {
+                        VStack(spacing: chartSpacing) {
                             basalChart
                             mainChart
-                            Spacer()
+                            Color.clear.frame(height: axisSpacerHeight)
                             cobIobChart
                         }.onChange(of: screenHours) {
                             scroller.scrollTo("MainChart", anchor: .trailing)
@@ -103,6 +141,7 @@ struct MainChartView: View {
                     }
                 }
             }
+            .frame(height: chartStackHeight)
         }
     }
 }
@@ -111,103 +150,98 @@ struct MainChartView: View {
 
 extension MainChartView {
     private var mainChart: some View {
-        VStack {
-            Chart {
-                drawStartRuleMark()
-                drawEndRuleMark()
-                drawCurrentTimeMarker()
+        Chart {
+            drawStartRuleMark()
+            drawEndRuleMark()
+            drawCurrentTimeMarker()
 
-                GlucoseTargetsView(
-                    targetProfiles: state.targetProfiles
+            GlucoseTargetsView(
+                targetProfiles: state.targetProfiles
+            )
+
+            OverrideView(
+                state: state,
+                overrides: state.overrides,
+                overrideRunStored: state.overrideRunStored,
+                units: state.units,
+                viewContext: context
+            )
+
+            TempTargetView(
+                tempTargetStored: state.tempTargetStored,
+                tempTargetRunStored: state.tempTargetRunStored,
+                units: state.units,
+                viewContext: context
+            )
+
+            GlucoseChartView(
+                glucoseData: state.glucoseFromPersistence,
+                units: state.units,
+                highGlucose: state.highGlucose,
+                lowGlucose: state.lowGlucose,
+                currentGlucoseTarget: state.currentGlucoseTarget,
+                isSmoothingEnabled: state.isSmoothingEnabled,
+                glucoseColorScheme: state.glucoseColorScheme
+            )
+
+            InsulinView(
+                glucoseData: state.glucoseFromPersistence,
+                insulinData: state.insulinFromPersistence,
+                units: state.units,
+                bolusDisplayThreshold: state.bolusDisplayThreshold
+            )
+
+            CarbView(
+                glucoseData: state.glucoseFromPersistence,
+                units: state.units,
+                carbData: state.carbsFromPersistence,
+                fpuData: state.fpusFromPersistence,
+                minValue: units == .mgdL ? state.minYAxisValue : state.minYAxisValue
+                    .asMmolL
+            )
+
+            ForecastView(
+                preprocessedData: state.preprocessedData,
+                minForecast: state.minForecast,
+                maxForecast: state.maxForecast,
+                units: state.units,
+                maxValue: state.maxYAxisValue,
+                forecastDisplayType: state.forecastDisplayType,
+                lastDeterminationDate: state.determinationsFromPersistence.first?.deliverAt ?? .distantPast
+            )
+
+            if let selectedGlucose {
+                SelectionPopoverView(
+                    selectedGlucose: selectedGlucose,
+                    selectedIOBValue: selectedIOBValue,
+                    selectedCOBValue: selectedCOBValue,
+                    units: units,
+                    highGlucose: highGlucose,
+                    lowGlucose: lowGlucose,
+                    currentGlucoseTarget: currentGlucoseTarget,
+                    glucoseColorScheme: glucoseColorScheme,
+                    isSmoothingEnabled: state.settingsManager.settings.smoothGlucose
                 )
-
-                OverrideView(
-                    state: state,
-                    overrides: state.overrides,
-                    overrideRunStored: state.overrideRunStored,
-                    units: state.units,
-                    viewContext: context
-                )
-
-                TempTargetView(
-                    tempTargetStored: state.tempTargetStored,
-                    tempTargetRunStored: state.tempTargetRunStored,
-                    units: state.units,
-                    viewContext: context
-                )
-
-                GlucoseChartView(
-                    glucoseData: state.glucoseFromPersistence,
-                    units: state.units,
-                    highGlucose: state.highGlucose,
-                    lowGlucose: state.lowGlucose,
-                    currentGlucoseTarget: state.currentGlucoseTarget,
-                    isSmoothingEnabled: state.isSmoothingEnabled,
-                    glucoseColorScheme: state.glucoseColorScheme
-                )
-
-                InsulinView(
-                    glucoseData: state.glucoseFromPersistence,
-                    insulinData: state.insulinFromPersistence,
-                    units: state.units,
-                    bolusDisplayThreshold: state.bolusDisplayThreshold
-                )
-
-                CarbView(
-                    glucoseData: state.glucoseFromPersistence,
-                    units: state.units,
-                    carbData: state.carbsFromPersistence,
-                    fpuData: state.fpusFromPersistence,
-                    minValue: units == .mgdL ? state.minYAxisValue : state.minYAxisValue
-                        .asMmolL
-                )
-
-                ForecastView(
-                    preprocessedData: state.preprocessedData,
-                    minForecast: state.minForecast,
-                    maxForecast: state.maxForecast,
-                    units: state.units,
-                    maxValue: state.maxYAxisValue,
-                    forecastDisplayType: state.forecastDisplayType,
-                    lastDeterminationDate: state.determinationsFromPersistence.first?.deliverAt ?? .distantPast
-                )
-
-                /// show glucose value when hovering over it
-                if let selectedGlucose {
-                    SelectionPopoverView(
-                        selectedGlucose: selectedGlucose,
-                        selectedIOBValue: selectedIOBValue,
-                        selectedCOBValue: selectedCOBValue,
-                        units: units,
-                        highGlucose: highGlucose,
-                        lowGlucose: lowGlucose,
-                        currentGlucoseTarget: currentGlucoseTarget,
-                        glucoseColorScheme: glucoseColorScheme,
-                        isSmoothingEnabled: state.settingsManager.settings.smoothGlucose
-                    )
-                }
             }
-            .id("MainChart")
-            .frame(
-                minHeight: geo.size.height * (0.28 - safeAreaSize)
-            )
-            .frame(width: fullWidth(viewWidth: screenSize.width))
-            .chartXScale(domain: state.startMarker ... state.endMarker)
-            .chartXAxis { mainChartXAxis }
-            .chartYAxis { mainChartYAxis }
-            .chartYAxis(.hidden)
-            .chartXSelection(value: $selection)
-            .chartYScale(
-                domain: units == .mgdL ? state.minYAxisValue ... state.maxYAxisValue : state.minYAxisValue
-                    .asMmolL ... state.maxYAxisValue.asMmolL
-            )
-            .chartLegend(.hidden)
-            .chartForegroundStyleScale([
-                "iob": Color.insulin,
-                "uam": Color.uam,
-                "zt": Color.zt,
-                "cob": Color.orange
-            ])
         }
+        .id("MainChart")
+        .frame(height: mainChartHeight)
+        .frame(width: fullWidth(viewWidth: geo.size.width))
+        .chartXScale(domain: state.startMarker ... state.endMarker)
+        .chartXAxis { mainChartXAxis }
+        .chartYAxis { mainChartYAxis }
+        .chartYAxis(.hidden)
+        .chartXSelection(value: $selection)
+        .chartYScale(
+            domain: units == .mgdL ? state.minYAxisValue ... state.maxYAxisValue : state.minYAxisValue
+                .asMmolL ... state.maxYAxisValue.asMmolL
+        )
+        .chartLegend(.hidden)
+        .chartForegroundStyleScale([
+            "iob": Color.insulin,
+            "uam": Color.uam,
+            "zt": Color.zt,
+            "cob": Color.orange
+        ])
     }
 }

--- a/Trio/Sources/Modules/Settings/SettingItems.swift
+++ b/Trio/Sources/Modules/Settings/SettingItems.swift
@@ -325,6 +325,17 @@ enum SettingItems {
             ],
             path: ["Services", "Nightscout", "Fetch and Remote Control"]
         ),
+        SettingItem(
+            title: "Cloud Logging",
+            view: .cloudLogging,
+            searchContents: [
+                "Enable Cloud Logging",
+                "Source token",
+                "Ingestion URL",
+                "Test Connection"
+            ],
+            path: ["Services", "Cloud Logging"]
+        ),
         SettingItem(title: "Tidepool", view: .serviceSettings, path: ["Services"]),
         SettingItem(title: "Apple Health", view: .healthkit, path: ["Services"])
     ]

--- a/Trio/Sources/Modules/Settings/View/CloudLoggingSettingsView.swift
+++ b/Trio/Sources/Modules/Settings/View/CloudLoggingSettingsView.swift
@@ -1,0 +1,150 @@
+import SwiftUI
+
+struct CloudLoggingSettingsView: View {
+    @State private var enabled: Bool = false
+    @State private var token: String = ""
+    @State private var ingestionURL: String = ""
+
+    @State private var showResult = false
+    @State private var resultTitle = ""
+    @State private var resultMessage = ""
+
+    private var effectiveToken: String? {
+        let t = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        return t.isEmpty ? nil : t
+    }
+
+    private var effectiveURL: URL? {
+        let raw = ingestionURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        if raw.isEmpty {
+            return URL(string: "https://in.logs.betterstack.com/")
+        }
+        return URL(string: raw)
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle("Enable Cloud Logging", isOn: $enabled)
+                    .onChange(of: enabled) { _, newValue in
+                        UserDefaults.standard.set(newValue, forKey: CloudLogUploadService.userDefaultsEnabledKey)
+                    }
+            }
+
+            Section("Better Stack") {
+                SecureField("Source token", text: $token)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled(true)
+                    .disabled(!enabled)
+                    .onChange(of: token) { _, newValue in
+                        let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if trimmed.isEmpty {
+                            UserDefaults.standard.removeObject(forKey: CloudLogUploadService.userDefaultsTokenKey)
+                        } else {
+                            UserDefaults.standard.set(trimmed, forKey: CloudLogUploadService.userDefaultsTokenKey)
+                        }
+                    }
+
+                TextField("Ingestion URL", text: $ingestionURL)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled(true)
+                    .keyboardType(.URL)
+                    .disabled(!enabled)
+                    .onChange(of: ingestionURL) { _, newValue in
+                        let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if trimmed.isEmpty {
+                            UserDefaults.standard.removeObject(forKey: CloudLogUploadService.userDefaultsIngestionURLKey)
+                        } else {
+                            UserDefaults.standard.set(trimmed, forKey: CloudLogUploadService.userDefaultsIngestionURLKey)
+                        }
+                    }
+
+                Button("Test Connection") {
+                    Task { await testConnection() }
+                }
+                .disabled(!enabled || effectiveToken == nil || effectiveURL == nil)
+
+                Button(role: .destructive) {
+                    token = ""
+                    ingestionURL = ""
+                    UserDefaults.standard.removeObject(forKey: CloudLogUploadService.userDefaultsTokenKey)
+                    UserDefaults.standard.removeObject(forKey: CloudLogUploadService.userDefaultsIngestionURLKey)
+                } label: {
+                    Text("Remove Token & URL")
+                }
+                .disabled(!enabled)
+            }
+
+            Section {
+                Text("These settings override on-device settings files (e.g. settings/BetterStack.json) when enabled.")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .navigationTitle("Cloud Logging")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear(perform: loadFromDefaults)
+        .alert(resultTitle, isPresented: $showResult) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(resultMessage)
+        }
+    }
+
+    private func loadFromDefaults() {
+        let ud = UserDefaults.standard
+
+        // Respect explicit enabled flag if present; otherwise default to false.
+        if let enabledObj = ud.object(forKey: CloudLogUploadService.userDefaultsEnabledKey) as? Bool {
+            enabled = enabledObj
+        } else {
+            enabled = false
+        }
+
+        token = ud.string(forKey: CloudLogUploadService.userDefaultsTokenKey) ?? ""
+        ingestionURL = ud.string(forKey: CloudLogUploadService.userDefaultsIngestionURLKey) ?? ""
+    }
+
+    private func testConnection() async {
+        guard let token = effectiveToken else {
+            presentResult(title: "Missing token", message: "Enter a Better Stack source token first.")
+            return
+        }
+        guard let url = effectiveURL else {
+            presentResult(title: "Invalid URL", message: "Enter a valid ingestion URL.")
+            return
+        }
+
+        let provider = BetterStackLogtailProvider(
+            tokenProvider: { token },
+            ingestionURLProvider: { url }
+        )
+
+        let events = [
+            CloudLogEvent(
+                message: "Trio cloud logging test event",
+                dt: nil,
+                attributes: [
+                    "platform": "ios",
+                    "category": "CloudLogging",
+                    "level": "info"
+                ],
+                raw: "Trio cloud logging test event"
+            )
+        ]
+
+        switch await provider.upload(events: events) {
+        case .success:
+            presentResult(title: "Success", message: "Test event ingested successfully.")
+        case let .failure(error):
+            presentResult(title: "Failed", message: error.description)
+        }
+    }
+
+    @MainActor
+    private func presentResult(title: String, message: String) {
+        resultTitle = title
+        resultMessage = message
+        showResult = true
+    }
+}

--- a/Trio/Sources/Modules/Settings/View/Subviews/ServicesView.swift
+++ b/Trio/Sources/Modules/Settings/View/Subviews/ServicesView.swift
@@ -24,6 +24,7 @@ struct ServicesView: BaseView {
                 content: {
                     Text("Nightscout").navigationLink(to: .nighscoutConfig, from: self)
                     Text("Tidepool").navigationLink(to: .tidepoolConfig, from: self)
+                    Text("Cloud Logging").navigationLink(to: .cloudLogging, from: self)
                     if HKHealthStore.isHealthDataAvailable() {
                         Text("Apple Health").navigationLink(to: .healthkit, from: self)
                     }

--- a/Trio/Sources/Modules/Settings/View/Subviews/SubmodulesView.swift
+++ b/Trio/Sources/Modules/Settings/View/Subviews/SubmodulesView.swift
@@ -13,6 +13,18 @@ struct SubmodulesView: View {
                     KeyValueRow(key: name, value: info.commitSHA)
                 }
             }
+            if !buildDetails.patches.isEmpty {
+                Section(header: Text("Patches")) {
+                    ForEach(Array(buildDetails.patches.enumerated()), id: \.offset) { _, patch in
+                        PatchRow(
+                            name: patch.name,
+                            subject: patch.subject,
+                            sha: patch.fromSHA,
+                            date: patch.date
+                        )
+                    }
+                }
+            }
         }
         .listStyle(.insetGrouped)
         .navigationTitle("Submodules")
@@ -32,6 +44,37 @@ struct KeyValueRow: View {
             Text(value)
                 .foregroundColor(.secondary)
                 .multilineTextAlignment(.trailing)
+        }
+    }
+}
+
+struct PatchRow: View {
+    let name: String
+    let subject: String
+    let sha: String
+    let date: String
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(name)
+                    .foregroundColor(.primary)
+                if !subject.isEmpty {
+                    Text(subject)
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
+                }
+            }
+            Spacer()
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(sha)
+                    .foregroundColor(.secondary)
+                if !date.isEmpty {
+                    Text(date)
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
+                }
+            }
         }
     }
 }

--- a/Trio/Sources/Modules/Treatments/View/TreatmentsRootView.swift
+++ b/Trio/Sources/Modules/Treatments/View/TreatmentsRootView.swift
@@ -365,8 +365,6 @@ extension Treatments {
                                 Toggle("", isOn: $state.externalInsulin).toggleStyle(CheckboxToggleStyle())
                             }
                         }.listRowBackground(Color.chart)
-
-                        treatmentButton
                     }
                     .listSectionSpacing(sectionSpacing)
                 }
@@ -379,6 +377,10 @@ extension Treatments {
             .padding(.top)
             .ignoresSafeArea(edges: .top)
             .scrollContentBackground(.hidden).background(appState.trioBackgroundColor(for: colorScheme))
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                treatmentActionBar
+                    .blur(radius: state.isAwaitingDeterminationResult ? 5 : 0)
+            }
             .blur(radius: state.showInfo ? 3 : 0)
             .navigationTitle("Treatments")
             .navigationBarTitleDisplayMode(.inline)
@@ -474,60 +476,65 @@ extension Treatments {
             return (shouldConfirm, warningMessage, warningColor)
         }
 
-        var treatmentButton: some View {
-            var treatmentButtonBackground = Color(.systemBlue)
-            if limitExceeded {
-                treatmentButtonBackground = Color(.systemRed)
-            } else if disableTaskButton {
-                treatmentButtonBackground = Color(.systemGray)
-            }
-
-            return Section {
-                Button {
-                    if bolusWarning.shouldConfirm {
-                        showConfirmDialogForBolusing = true
-                    } else {
-                        state.invokeTreatmentsTask()
-                    }
-                } label: {
-                    HStack {
-                        if state.isBolusInProgress && state.amount > 0 &&
-                            !state.externalInsulin && (state.carbs == 0 || state.fat == 0 || state.protein == 0)
-                        {
-                            ProgressView()
-                        }
-                        taskButtonLabel
-                    }
-                    .font(.headline)
-                    .foregroundStyle(Color.white)
-                    .frame(maxWidth: .infinity, alignment: .center)
-                    .frame(height: 35)
-                }
-                .disabled(disableTaskButton)
-                .listRowBackground(treatmentButtonBackground)
-                .shadow(radius: 3)
-                .clipShape(RoundedRectangle(cornerRadius: 8))
-                .confirmationDialog(
-                    bolusWarning.warningMessage + " Bolus \(state.amount.description) U?",
-                    isPresented: $showConfirmDialogForBolusing,
-                    titleVisibility: .visible
-                ) {
-                    Button("Cancel", role: .cancel) {}
-                    Button(
-                        bolusWarning.warningMessage.isEmpty ? "Enact Bolus" : "Ignore Warning and Enact Bolus",
-                        role: bolusWarning.warningMessage.isEmpty ? nil : .destructive
-                    ) {
-                        state.invokeTreatmentsTask()
-                    }
-                }
-            } header: {
+        var treatmentActionBar: some View {
+            VStack(spacing: 10) {
                 if !bolusWarning.warningMessage.isEmpty {
                     Text(bolusWarning.warningMessage)
-                        .textCase(nil)
                         .font(.subheadline)
                         .foregroundColor(bolusWarning.color)
                         .frame(maxWidth: .infinity, alignment: .center)
-                        .padding(.top, -22)
+                }
+
+                treatmentButton
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, bolusWarning.warningMessage.isEmpty ? 10 : 14)
+            .padding(.bottom, 10)
+            .background {
+                VStack(spacing: 0) {
+                    Divider()
+                    appState.trioBackgroundColor(for: colorScheme)
+                }
+                .ignoresSafeArea(edges: .bottom)
+            }
+        }
+
+        private var treatmentButton: some View {
+            Button {
+                if bolusWarning.shouldConfirm {
+                    showConfirmDialogForBolusing = true
+                } else {
+                    state.invokeTreatmentsTask()
+                }
+            } label: {
+                HStack {
+                    if state.isBolusInProgress && state.amount > 0 &&
+                        !state.externalInsulin && (state.carbs == 0 || state.fat == 0 || state.protein == 0)
+                    {
+                        ProgressView()
+                    }
+                    taskButtonLabel
+                }
+                .font(.headline)
+                .foregroundStyle(Color.white)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .frame(height: 35)
+            }
+            .disabled(disableTaskButton)
+            .background(treatmentButtonBackground)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .shadow(radius: 3)
+            .confirmationDialog(
+                bolusWarning.warningMessage + " Bolus \(state.amount.description) U?",
+                isPresented: $showConfirmDialogForBolusing,
+                titleVisibility: .visible
+            ) {
+                Button("Cancel", role: .cancel) {}
+                Button(
+                    bolusWarning.warningMessage.isEmpty ? "Enact Bolus" : "Ignore Warning and Enact Bolus",
+                    role: bolusWarning.warningMessage.isEmpty ? nil : .destructive
+                ) {
+                    state.invokeTreatmentsTask()
                 }
             }
         }
@@ -596,6 +603,16 @@ extension Treatments {
 
         private var limitExceeded: Bool {
             pumpBolusLimitExceeded || externalBolusLimitExceeded || carbLimitExceeded || fatLimitExceeded || proteinLimitExceeded
+        }
+
+        private var treatmentButtonBackground: Color {
+            if limitExceeded {
+                return Color(.systemRed)
+            } else if disableTaskButton {
+                return Color(.systemGray)
+            } else {
+                return Color(.systemBlue)
+            }
         }
 
         private var disableTaskButton: Bool {

--- a/Trio/Sources/Router/Screen.swift
+++ b/Trio/Sources/Router/Screen.swift
@@ -42,6 +42,7 @@ enum Screen: Identifiable, Hashable {
     case calendarEventSettings
     case contactImage
     case serviceSettings
+    case cloudLogging
     case remoteControlConfig
     case autosensSettings
     case smbSettings
@@ -151,6 +152,8 @@ extension Screen {
             ContactImage.RootView(resolver: resolver)
         case .serviceSettings:
             ServicesView(resolver: resolver, state: Settings.StateModel())
+        case .cloudLogging:
+            CloudLoggingSettingsView()
         case .autosensSettings:
             AutosensSettings.RootView(resolver: resolver)
         case .smbSettings:

--- a/Trio/Sources/Services/Network/Nightscout/NightscoutManager.swift
+++ b/Trio/Sources/Services/Network/Nightscout/NightscoutManager.swift
@@ -551,11 +551,94 @@ final class BaseNightscoutManager: NightscoutManager, Injectable {
             battery: Int(batteryLevel * 100),
             isCharging: batteryState == .charging || batteryState == .full
         )
+
+        let s = settingsManager.settings
+        let p = settingsManager.preferences
+        let ps = settingsManager.pumpSettings
+
+        let trioSettings = NightscoutAlgorithmSettings(
+            schemaVersion: 1,
+            algorithmVersion: Bundle.main.releaseVersionNumber,
+            units: s.units.rawValue,
+            preferencesTimestamp: p.timestamp,
+
+            closedLoop: s.closedLoop,
+            enableUAM: p.enableUAM,
+            enableSMBAlways: p.enableSMBAlways,
+            enableSMBWithCOB: p.enableSMBWithCOB,
+            enableSMBAfterCarbs: p.enableSMBAfterCarbs,
+            enableSMBWithTemptarget: p.enableSMBWithTemptarget,
+            allowSMBWithHighTemptarget: p.allowSMBWithHighTemptarget,
+            smbDeliveryRatio: p.smbDeliveryRatio,
+            smbInterval: p.smbInterval,
+            maxSMBBasalMinutes: p.maxSMBBasalMinutes,
+            maxUAMSMBBasalMinutes: p.maxUAMSMBBasalMinutes,
+
+            autosensMax: p.autosensMax,
+            autosensMin: p.autosensMin,
+            rewindResetsAutosens: p.rewindResetsAutosens,
+            highTemptargetRaisesSensitivity: p.highTemptargetRaisesSensitivity,
+            lowTemptargetLowersSensitivity: p.lowTemptargetLowersSensitivity,
+            sensitivityRaisesTarget: p.sensitivityRaisesTarget,
+            resistanceLowersTarget: p.resistanceLowersTarget,
+            advTargetAdjustments: p.advTargetAdjustments,
+
+            maxIOB: p.maxIOB,
+            maxCOB: p.maxCOB,
+            maxDailySafetyMultiplier: p.maxDailySafetyMultiplier,
+            currentBasalSafetyMultiplier: p.currentBasalSafetyMultiplier,
+
+            curve: p.curve.rawValue,
+            useCustomPeakTime: p.useCustomPeakTime,
+            insulinPeakTime: p.insulinPeakTime,
+            insulinActionCurve: ps.insulinActionCurve,
+
+            exerciseMode: p.exerciseMode,
+            halfBasalExerciseTarget: p.halfBasalExerciseTarget,
+
+            maxMealAbsorptionTime: p.maxMealAbsorptionTime,
+            min5mCarbimpact: p.min5mCarbimpact,
+            remainingCarbsFraction: p.remainingCarbsFraction,
+            remainingCarbsCap: p.remainingCarbsCap,
+
+            adjustmentFactor: p.adjustmentFactor,
+            adjustmentFactorSigmoid: p.adjustmentFactorSigmoid,
+            sigmoid: p.sigmoid,
+            useNewFormula: p.useNewFormula,
+            useWeightedAverage: p.useWeightedAverage,
+            weightPercentage: p.weightPercentage,
+            tddAdjBasal: p.tddAdjBasal,
+            updateInterval: p.updateInterval,
+            maxDeltaBGthreshold: p.maxDeltaBGthreshold,
+            noisyCGMTargetMultiplier: p.noisyCGMTargetMultiplier,
+            carbsReqThreshold: p.carbsReqThreshold,
+            threshold_setting: p.threshold_setting,
+            suspendZerosIOB: p.suspendZerosIOB,
+            unsuspendIfNoTemp: p.unsuspendIfNoTemp,
+            skipNeutralTemps: p.skipNeutralTemps,
+
+            useFPUconversion: s.useFPUconversion,
+            fattyMeals: s.fattyMeals,
+            fattyMealFactor: s.fattyMealFactor,
+            sweetMeals: s.sweetMeals,
+            sweetMealFactor: s.sweetMealFactor,
+            overrideFactor: s.overrideFactor,
+            individualAdjustmentFactor: s.individualAdjustmentFactor,
+            timeCap: nil,
+            minuteInterval: s.minuteInterval,
+            delay: s.delay,
+
+            maxBolus: ps.maxBolus,
+            maxBasal: ps.maxBasal
+        )
+        // pass trioSettings when building NightscoutStatus(...)
+
         let status = NightscoutStatus(
             device: NightscoutTreatment.local,
             openaps: openapsStatus,
             pump: pump,
-            uploader: uploader
+            uploader: uploader,
+            trioSettings: trioSettings
         )
 
         do {

--- a/Trio/Sources/Services/WatchManager/AppleWatchManager.swift
+++ b/Trio/Sources/Services/WatchManager/AppleWatchManager.swift
@@ -16,6 +16,8 @@ protocol WatchManager {
 final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchManager {
     private var session: WCSession?
 
+    private static var hasLoggedAppGroupDiagnostics = false
+
     @Injected() var broadcaster: Broadcaster!
     @Injected() private var apsManager: APSManager!
     @Injected() private var settingsManager: SettingsManager!
@@ -39,6 +41,28 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
     private let queue = DispatchQueue(label: "BaseWatchManagerManager.queue", qos: .utility)
     private var coreDataPublisher: AnyPublisher<Set<NSManagedObjectID>, Never>?
     private var subscriptions = Set<AnyCancellable>()
+
+    private var pendingSendWorkItem: DispatchWorkItem?
+    private var coalescerFirstScheduledAt: Date?
+
+    // R1b: queue drain state
+    private var hasPerformedStartupQueueDrain = false
+    private var lastQueueDeepDrainAt: TimeInterval = 0
+
+    // R2a: coalescer attribution
+    private var coalescerTriggerCount = 0
+    private var coalescerSources: [String] = []
+    private var lastEligibleSourceAt: TimeInterval = 0
+    private let complicationEligibleSources: Set<String> = ["glucoseStored", "glucoseUpdate"]
+
+    // R2b: per-reading-epoch dispatch gate (App Group-backed to survive restarts)
+    private var lastDispatchedGateKey: String {
+        get { appGroupIDCandidate().value.flatMap { UserDefaults(suiteName: $0)?.string(forKey: "lastDispatchedGateKey") } ?? "" }
+        set { appGroupIDCandidate().value.flatMap { UserDefaults(suiteName: $0) }?.set(newValue, forKey: "lastDispatchedGateKey") }
+    }
+
+    // Step 3b: complication-age stale-first gate threshold (seconds)
+    private static let complicationAgeGateThresholdSeconds: TimeInterval = 600
 
     // Processed payload IDs for deduplication (LRU with TTL)
     private let processedIdsKey = "watchProcessedIds"
@@ -75,27 +99,16 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
 
         // Observer for glucose and manual glucose
         glucoseStorage.updatePublisher
-            .receive(on: DispatchQueue.global(qos: .background))
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                guard let self = self else { return }
-                // Skip if no watch is paired or app not installed
-                guard let session = self.session, session.isPaired, session.isReachable,
-                      session.isWatchAppInstalled else { return }
-                Task {
-                    let state = await self.setupWatchState()
-                    await self.sendDataToWatch(state)
-                }
+                self?.scheduleWatchStateUpdate(source: "glucoseUpdate")
             }
             .store(in: &subscriptions)
 
         iobService.iobPublisher
-            .receive(on: DispatchQueue.global(qos: .background))
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                guard let self = self else { return }
-                Task {
-                    let state = await self.setupWatchState()
-                    await self.sendDataToWatch(state)
-                }
+                self?.scheduleWatchStateUpdate(source: "iobUpdate")
             }
             .store(in: &subscriptions)
 
@@ -103,26 +116,18 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
     }
 
     private func registerHandlers() {
-        coreDataPublisher?.filteredByEntityName("OrefDetermination").sink { [weak self] _ in
-            guard let self = self else { return }
-            // Skip if no watch is paired or app not installed
-            guard let session = self.session, session.isPaired, session.isReachable, session.isWatchAppInstalled else { return }
-            Task {
-                let state = await self.setupWatchState()
-                await self.sendDataToWatch(state)
-            }
-        }.store(in: &subscriptions)
+        coreDataPublisher?.filteredByEntityName("OrefDetermination")
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.scheduleWatchStateUpdate(source: "orefDetermination")
+            }.store(in: &subscriptions)
 
         // Due to the Batch insert this only is used for observing Deletion of Glucose entries
-        coreDataPublisher?.filteredByEntityName("GlucoseStored").sink { [weak self] _ in
-            guard let self = self else { return }
-            // Skip if no watch is paired or app not installed
-            guard let session = self.session, session.isPaired, session.isReachable, session.isWatchAppInstalled else { return }
-            Task {
-                let state = await self.setupWatchState()
-                await self.sendDataToWatch(state)
-            }
-        }.store(in: &subscriptions)
+        coreDataPublisher?.filteredByEntityName("GlucoseStored")
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.scheduleWatchStateUpdate(source: "glucoseStored")
+            }.store(in: &subscriptions)
 
         coreDataPublisher?.filteredByEntityName("PumpEventStored").sink { [weak self] _ in
             guard let self = self else { return }
@@ -131,25 +136,17 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
             }
         }.store(in: &subscriptions)
 
-        coreDataPublisher?.filteredByEntityName("OverrideStored").sink { [weak self] _ in
-            guard let self = self else { return }
-            // Skip if no watch is paired or app not installed
-            guard let session = self.session, session.isPaired, session.isReachable, session.isWatchAppInstalled else { return }
-            Task {
-                let state = await self.setupWatchState()
-                await self.sendDataToWatch(state)
-            }
-        }.store(in: &subscriptions)
+        coreDataPublisher?.filteredByEntityName("OverrideStored")
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.scheduleWatchStateUpdate(source: "overrideStored")
+            }.store(in: &subscriptions)
 
-        coreDataPublisher?.filteredByEntityName("TempTargetStored").sink { [weak self] _ in
-            guard let self = self else { return }
-            // Skip if no watch is paired or app not installed
-            guard let session = self.session, session.isPaired, session.isReachable, session.isWatchAppInstalled else { return }
-            Task {
-                let state = await self.setupWatchState()
-                await self.sendDataToWatch(state)
-            }
-        }.store(in: &subscriptions)
+        coreDataPublisher?.filteredByEntityName("TempTargetStored")
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.scheduleWatchStateUpdate(source: "tempTargetStored")
+            }.store(in: &subscriptions)
     }
 
     /// Sets up the WatchConnectivity session if the device supports it
@@ -161,9 +158,48 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
             self.session = session
 
             debug(.watchManager, "📱 Phone session setup - isPaired: \(session.isPaired)")
+            logAppGroupDiagnosticsOnce(context: "setupWatchSession")
         } else {
             debug(.watchManager, "📱 WCSession is not supported on this device")
         }
+    }
+
+    private static func extractTeamID(fromNightscoutBundleIdentifier bundleIdentifier: String?) -> String? {
+        guard let bundleIdentifier, !bundleIdentifier.isEmpty else { return nil }
+        let prefix = "org.nightscout."
+        guard let prefixRange = bundleIdentifier.range(of: prefix) else { return nil }
+        let afterPrefix = bundleIdentifier[prefixRange.upperBound...]
+        guard let trioRange = afterPrefix.range(of: ".trio") else { return nil }
+        let teamID = String(afterPrefix[..<trioRange.lowerBound])
+        return teamID.isEmpty ? nil : teamID
+    }
+
+    private func appGroupIDCandidate() -> (value: String?, source: String) {
+        if let value = Bundle.main.object(forInfoDictionaryKey: "AppGroupID") as? String, !value.isEmpty {
+            return (value, "Info.plist(AppGroupID)")
+        }
+
+        let bundleID = Bundle.main.bundleIdentifier
+        if let teamID = Self.extractTeamID(fromNightscoutBundleIdentifier: bundleID) {
+            return ("group.org.nightscout.\(teamID).trio.trio-app-group", "Derived(bundleIdentifier)")
+        }
+
+        return (nil, "Unavailable")
+    }
+
+    private func logAppGroupDiagnosticsOnce(context: String) {
+        guard !Self.hasLoggedAppGroupDiagnostics else { return }
+        Self.hasLoggedAppGroupDiagnostics = true
+
+        let bundleID = Bundle.main.bundleIdentifier ?? "unknown"
+        let (suiteName, source) = appGroupIDCandidate()
+        let defaultsOK = suiteName.flatMap { UserDefaults(suiteName: $0) } != nil
+        let containerURL = suiteName.flatMap { FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: $0) }
+
+        debug(
+            .watchManager,
+            "📦 AppGroupDiagnostics(\(context)): bundleID=\(bundleID) AppGroupID=\(suiteName ?? "nil") source=\(source) defaults=\(defaultsOK) container=\(containerURL?.path ?? "nil")"
+        )
     }
 
     /// Attempts to reestablish the Watch connection if it becomes unreachable
@@ -180,9 +216,26 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
     /// - Returns: WatchState containing current glucose readings and trends and determination infos for displaying cob and iob in the view
     func setupWatchState() async -> WatchState {
         // Check if a watch is paired and reachable before doing expensive calculations
-        guard let session = session, session.isPaired, session.isReachable, session.isWatchAppInstalled else {
-            debug(.watchManager, "⌚️❌ Skipping setupWatchState - No Watch is paired or app not installed")
+        guard let session else {
+            debug(.watchManager, "⌚️❌ Skipping setupWatchState - WCSession not available")
             return WatchState(date: Date())
+        }
+
+        if !session.isPaired {
+            debug(.watchManager, "⌚️❌ Skipping setupWatchState - No Watch is paired")
+            return WatchState(date: Date())
+        }
+
+        if !session.isWatchAppInstalled {
+            debug(.watchManager, "⌚️❌ Skipping setupWatchState - Trio Watch app is not installed")
+            return WatchState(date: Date())
+        }
+
+        if !session.isReachable {
+            debug(
+                .watchManager,
+                "⌚️⚠️ Watch is not reachable (activationState: \(session.activationState.rawValue)); continuing to build WatchState for background delivery"
+            )
         }
 
         // Skip if watch session is not activated
@@ -278,6 +331,8 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
 
                 // Map glucose values
                 watchState.glucoseValues = glucoseObjects.compactMap { glucose in
+                    guard let date = glucose.date else { return nil }
+
                     let glucoseValue = self.units == .mgdL
                         ? Double(glucose.glucose)
                         : Double(truncating: Decimal(glucose.glucose).asMmolL as NSNumber)
@@ -291,7 +346,7 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
                     )
 
                     return WatchGlucoseObject(
-                        date: glucose.date ?? Date(),
+                        date: date,
                         glucose: glucoseValue,
                         color: glucoseColor.toHexString()
                     )
@@ -328,12 +383,14 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
 
                 // Calculate delta if we have at least 2 readings
                 if glucoseObjects.count >= 2 {
-                    var deltaValue = Decimal(glucoseObjects[0].glucose - glucoseObjects[1].glucose)
-
+                    var glucoseLast = Decimal(glucoseObjects[0].glucose)
+                    var glucoseSecondLast = Decimal(glucoseObjects[1].glucose)
                     if self.units == .mmolL {
-                        deltaValue = Double(truncating: deltaValue as NSNumber).asMmolL
+                        glucoseLast = glucoseLast.asMmolL
+                        glucoseSecondLast = glucoseSecondLast.asMmolL
                     }
 
+                    let deltaValue = glucoseLast - glucoseSecondLast
                     let formattedDelta = Formatter.glucoseFormatter(for: self.units)
                         .string(from: deltaValue as NSNumber) ?? "0"
                     watchState.delta = deltaValue < 0 ? "\(formattedDelta)" : "+\(formattedDelta)"
@@ -438,8 +495,8 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
     // MARK: - Send to Watch
 
     func watchStateToDictionary(from state: WatchState) -> [String: Any] {
-        [
-            WatchMessageKeys.date: state.date.timeIntervalSince1970,
+        var dict: [String: Any] = [
+            WatchMessageKeys.date: state.date,
             WatchMessageKeys.currentGlucose: state.currentGlucose ?? "--",
             WatchMessageKeys.currentGlucoseColorString: state.currentGlucoseColorString ?? "#ffffff",
             WatchMessageKeys.trend: state.trend ?? "",
@@ -450,7 +507,7 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
             WatchMessageKeys.glucoseValues: state.glucoseValues.map { value in
                 [
                     "glucose": value.glucose,
-                    "date": value.date.timeIntervalSince1970,
+                    "date": value.date,
                     "color": value.color
                 ]
             },
@@ -476,11 +533,197 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
             WatchMessageKeys.confirmBolusFaster: state.confirmBolusFaster,
             WatchMessageKeys.units: state.units.rawValue
         ]
+
+        // R1a: Use max(by: date) rather than .first/.last to avoid sorted-order assumption.
+        if let newestReading = state.glucoseValues.max(by: { $0.date < $1.date }) {
+            dict[WatchMessageKeys.readingEpoch] = newestReading.date.timeIntervalSince1970
+        }
+
+        return dict
+    }
+
+    // MARK: - Session Readiness & Queue Management (R1b)
+
+    /// Shared session readiness helper — used by cancelStaleQueuedTransfers and sendDataToWatch.
+    private func sessionIsReadyForTransfer() -> Bool {
+        guard let session = self.session else { return false }
+        return session.activationState == .activated
+            && session.isPaired
+            && session.isWatchAppInstalled
+    }
+
+    /// Cancels stale queued transfers, keeping only the newest transfer within the latest reading epoch.
+    private func cancelStaleQueuedTransfers() {
+        guard sessionIsReadyForTransfer() else {
+            if let session = self.session {
+                debug(
+                    .watchManager,
+                    "🗑️ queue_drain_skipped session_not_ready activation=\(session.activationState.rawValue) paired=\(session.isPaired) installed=\(session.isWatchAppInstalled)"
+                )
+            }
+            return
+        }
+        guard let session = self.session else { return }
+        let allTransfers = session.outstandingUserInfoTransfers
+        guard allTransfers.count > 1 else { return }
+
+        let latestEpoch = allTransfers
+            .compactMap { $0.userInfo[WatchMessageKeys.readingEpoch] as? TimeInterval }
+            .max()
+
+        let transfersToKeep: Set<ObjectIdentifier>
+        if let latest = latestEpoch {
+            let latestEpochTransfers = allTransfers.filter {
+                ($0.userInfo[WatchMessageKeys.readingEpoch] as? TimeInterval) == latest
+            }
+            let keeper = latestEpochTransfers
+                .max(by: {
+                    let a = $0.userInfo[WatchMessageKeys.transferEnqueuedAt] as? TimeInterval ?? 0
+                    let b = $1.userInfo[WatchMessageKeys.transferEnqueuedAt] as? TimeInterval ?? 0
+                    return a < b
+                })
+            transfersToKeep = keeper.map { Set([ObjectIdentifier($0)]) } ?? []
+        } else {
+            transfersToKeep = allTransfers.last.map { Set([ObjectIdentifier($0)]) } ?? []
+        }
+
+        let depthBefore = allTransfers.count
+        let toCancel = allTransfers.filter { !transfersToKeep.contains(ObjectIdentifier($0)) }
+        toCancel.forEach { $0.cancel() }
+
+        let depthAfter = session.outstandingUserInfoTransfers.count
+
+        let keptTransfer = allTransfers.first { transfersToKeep.contains(ObjectIdentifier($0)) }
+        let keptEpoch = keptTransfer?.userInfo[WatchMessageKeys.readingEpoch] as? TimeInterval ?? 0
+        let keptEnqueuedAt = keptTransfer?.userInfo[WatchMessageKeys.transferEnqueuedAt] as? TimeInterval ?? 0
+
+        debug(
+            .watchManager,
+            "🗑️ queue_drain cancel_requested=\(toCancel.count) depth_before=\(depthBefore) depth_after=\(depthAfter) kept_epoch=\(Int(keptEpoch)) kept_enqueued_at=\(Int(keptEnqueuedAt))"
+        )
+
+        if depthAfter > 5 {
+            debug(
+                .watchManager,
+                "⚠️ queue_drain_incomplete depth_after=\(depthAfter) cancel_requested=\(toCancel.count) — session may not have shrunk yet; advisory only"
+            )
+        }
+    }
+
+    /// R2b: Builds a gate key from the complication-visible fields of a WatchState.
+    /// Matches the watch-side ComplicationSnapshotFingerprint for consistent dual-layer dedup.
+    /// Format: "epoch|glucose|trend|delta" — currentComplicationAgeSeconds() parses the epoch
+    /// from the first pipe-delimited component. Do not change the format without updating that function.
+    private func computeDispatchGateKey(state: WatchState) -> String {
+        let epoch = state.glucoseValues.max(by: { $0.date < $1.date })
+            .map { String(Int($0.date.timeIntervalSince1970)) } ?? "nil"
+        let display = "\(state.currentGlucose ?? "nil")|\(state.trend ?? "nil")|\(state.delta ?? "nil")"
+        return "\(epoch)|\(display)"
+    }
+
+    /// Step 3b: Complication age from the best available source.
+    /// Prefers ground-truth timestamp from the watch (reported via updateApplicationContext
+    /// after each successful complication save). Falls back to the reading epoch in
+    /// lastDispatchedGateKey (iOS-side proxy) when the watch hasn't reported yet.
+    /// Returns .infinity if neither source has data (first transfer always goes through).
+    private func currentComplicationAgeSeconds() -> TimeInterval {
+        // Watch writes Swift Double; WCSession bridges it as NSNumber across the process boundary.
+        // The NSNumber path is the one that actually succeeds; TimeInterval cast is kept for safety.
+        let rawTimestamp = WCSession.default.receivedApplicationContext["complicationLastValidTimestamp"]
+        let watchTimestamp = (rawTimestamp as? TimeInterval) ?? (rawTimestamp as? NSNumber)?.doubleValue ?? 0
+        if watchTimestamp > 0 {
+            let age = max(0, Date().timeIntervalSince(Date(timeIntervalSince1970: watchTimestamp)))
+            debug(.watchManager, "🔍 complication_age_check age_seconds=\(Int(age)) threshold=\(Int(Self.complicationAgeGateThresholdSeconds)) gate_passes=\(age > Self.complicationAgeGateThresholdSeconds) source=watchApplicationContext")
+            return age
+        }
+
+        let gateKey = lastDispatchedGateKey
+        guard !gateKey.isEmpty else {
+            debug(.watchManager, "🔍 complication_age_check gate_key_empty returning=infinity")
+            return .infinity
+        }
+        guard let epochString = gateKey.split(separator: "|").first,
+              let epoch = TimeInterval(epochString), epoch > 0 else {
+            debug(.watchManager, "⚠️ complication_age_check gate_key_parse_failed key=\(gateKey) returning=infinity")
+            return .infinity
+        }
+        let readingDate = Date(timeIntervalSince1970: epoch)
+        let age = max(0, Date().timeIntervalSince(readingDate))
+        debug(.watchManager, "🔍 complication_age_check age_seconds=\(Int(age)) threshold=\(Int(Self.complicationAgeGateThresholdSeconds)) gate_passes=\(age > Self.complicationAgeGateThresholdSeconds) source=lastDispatchedGateKey")
+        return age
+    }
+
+    /// Coalesces multiple publisher-driven WatchState updates into a single send.
+    /// Uses a 2s trailing debounce with 5s max-wait cap. Main-thread confined.
+    private func scheduleWatchStateUpdate(source: String = "unknown") {
+        assert(Thread.isMainThread, "scheduleWatchStateUpdate must be called on main queue")
+        guard let session = self.session, session.isPaired, session.isWatchAppInstalled else { return }
+
+        coalescerTriggerCount += 1
+        coalescerSources.append(source)
+        if complicationEligibleSources.contains(source) {
+            lastEligibleSourceAt = Date().timeIntervalSince1970
+        }
+        debug(.watchManager, "⏱️ coalescer_trigger source=\(source) eligible=\(complicationEligibleSources.contains(source)) pending=\(pendingSendWorkItem != nil)")
+
+        let now = Date()
+        if coalescerFirstScheduledAt == nil {
+            coalescerFirstScheduledAt = now
+        }
+
+        pendingSendWorkItem?.cancel()
+
+        let elapsed = now.timeIntervalSince(coalescerFirstScheduledAt ?? now)
+        let delay = max(0.0, min(2.0, 5.0 - elapsed))
+
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+
+            let sourcesSnapshot = self.coalescerSources
+            let triggerCountSnapshot = self.coalescerTriggerCount
+            let lastEligibleSnapshot = self.lastEligibleSourceAt
+
+            let windowStartEpoch: TimeInterval?
+            if let scheduled = self.coalescerFirstScheduledAt {
+                windowStartEpoch = scheduled.timeIntervalSince1970
+            } else {
+                windowStartEpoch = nil
+                debug(.watchManager, "⚠️ coalescer_window_start_nil — invariant violated; mode will use eligible-source fallback")
+            }
+
+            self.coalescerTriggerCount = 0
+            self.coalescerSources = []
+            self.lastEligibleSourceAt = 0
+            self.coalescerFirstScheduledAt = nil
+
+            debug(.watchManager, "📡 coalescer_fired trigger_count=\(triggerCountSnapshot) sources=\(sourcesSnapshot.joined(separator: ",")) last_eligible_at=\(Int(lastEligibleSnapshot))")
+
+            Task {
+                let state = await self.setupWatchState()
+                await self.sendDataToWatch(
+                    state,
+                    sourcesSnapshot: sourcesSnapshot,
+                    lastEligibleSourceAt: lastEligibleSnapshot,
+                    windowStartEpoch: windowStartEpoch
+                )
+            }
+        }
+        pendingSendWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
     }
 
     /// Sends the state of type WatchState to the connected Watch
-    /// - Parameter state: Current WatchState containing glucose data to be sent
-    @MainActor func sendDataToWatch(_ state: WatchState) async {
+    /// - Parameters:
+    ///   - state: Current WatchState containing glucose data to be sent
+    ///   - sourcesSnapshot: Coalescer source tags from this window (empty for non-coalescer call sites)
+    ///   - lastEligibleSourceAt: Epoch of last complication-eligible source in this window
+    ///   - windowStartEpoch: Epoch when the coalescer window opened (nil if not from coalescer)
+    @MainActor func sendDataToWatch(
+        _ state: WatchState,
+        sourcesSnapshot: [String] = [],
+        lastEligibleSourceAt: TimeInterval = 0,
+        windowStartEpoch: TimeInterval? = nil
+    ) async {
         guard let session = session else { return }
 
         guard session.isPaired else {
@@ -489,7 +732,7 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
         }
 
         guard session.isWatchAppInstalled else {
-            debug(.watchManager, "⌚️❌ Trio Watch app is")
+            debug(.watchManager, "⌚️❌ Trio Watch app is not installed")
             return
         }
 
@@ -507,19 +750,140 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
             return
         }
 
-        let message: [String: Any] = watchStateToDictionary(from: state)
+        var fullMessage: [String: Any] = watchStateToDictionary(from: state)
+        let readingEpoch = state.glucoseValues.max(by: { $0.date < $1.date })
+            .map { Int($0.date.timeIntervalSince1970) } ?? -1
 
-        // if session is reachable, it means watch App is in the foreground -> send watchState as message
-        // if session is not reachable, it means it's in background -> send watchState as userInfo
+        // R1a: stamp enqueue time immediately before transfer calls
+        fullMessage[WatchMessageKeys.transferEnqueuedAt] = Date().timeIntervalSince1970
+
+        // R3: Build complication payload from explicit allowlist.
+        // Uses safe if-let inserts to avoid Optional-as-Any bridging issues.
+        var complicationMessage: [String: Any] = [:]
+        let complicationAllowlist: [(String, String)] = [
+            (WatchMessageKeys.currentGlucose, "currentGlucose"),
+            (WatchMessageKeys.currentGlucoseColorString, "currentGlucoseColorString"),
+            (WatchMessageKeys.trend, "trend"),
+            (WatchMessageKeys.delta, "delta"),
+            (WatchMessageKeys.readingEpoch, "readingEpoch"),
+            (WatchMessageKeys.transferEnqueuedAt, "transferEnqueuedAt"),
+            (WatchMessageKeys.date, "date"),
+        ]
+        for (key, name) in complicationAllowlist {
+            if let value = fullMessage[key] {
+                complicationMessage[key] = value
+            } else {
+                if key == WatchMessageKeys.readingEpoch {
+                    debug(.watchManager, "⚠️ complication_payload missing key=\(name) — load-bearing field absent")
+                } else {
+                    debug(.watchManager, "complication_payload missing key=\(name) — non-load-bearing, continuing")
+                }
+            }
+        }
+
+        let readingEpochPresent = complicationMessage[WatchMessageKeys.readingEpoch] != nil
+        if !readingEpochPresent {
+            debug(.watchManager, "⚠️ complication_transfer_skipped missing readingEpoch — R1a may not have shipped; sendMessage still firing")
+        }
+
+        WatchStateSnapshot.saveLatestDateToDisk(state.date)
+
+        // R2b: per-reading-epoch dispatch gate — suppresses duplicate complication transfers only.
+        // Gate key is computed unconditionally for logging, but only persisted when a complication
+        // transfer is actually enqueued (not on sendMessage-only paths).
+        let gateKey = computeDispatchGateKey(state: state)
+        let isDuplicateDispatch = gateKey == lastDispatchedGateKey
+        // Only log duplicate skip when we're in conditions where a complication transfer would otherwise be considered
+        // (avoids implying "duplicate blocked us" when we wouldn't have tried due to reachable / missing epoch).
+        if isDuplicateDispatch, !session.isReachable, readingEpochPresent {
+            debug(.watchManager, "⏭️ complication_transfer_gate_skipped skip_reason=duplicate_gate gate_key=\(gateKey) reading_date_epoch_seconds=\(readingEpoch)")
+        }
+
+        let budgetSnapshot = session.remainingComplicationUserInfoTransfers
+        debug(.watchManager, "🔍 complication_budget_check remaining=\(budgetSnapshot) isReachable=\(session.isReachable) readingEpochPresent=\(readingEpochPresent) isDuplicate=\(isDuplicateDispatch) queue_depth=\(session.outstandingUserInfoTransfers.count)")
+
+        // sendMessage (budget-free watch UI path) — always fires with fullMessage
         if session.isReachable {
-            session.sendMessage([WatchMessageKeys.watchState: message], replyHandler: nil) { error in
+            session.sendMessage([WatchMessageKeys.watchState: fullMessage], replyHandler: nil) { error in
                 debug(.watchManager, "❌ Error sending watch state: \(error)")
             }
-            WatchStateSnapshot.saveLatestDateToDisk(state.date)
-        } else {
-            WatchStateSnapshot.saveLatestDateToDisk(state.date)
-            session.transferUserInfo([WatchMessageKeys.watchState: message])
-            debug(.watchManager, "📤 Transferred new WatchState snapshot via userInfo")
+            debug(.watchManager, "📨 sendMessage_sent reading_epoch=\(readingEpoch) send_wall=\(Date().timeIntervalSince1970)")
+            debug(.watchManager, "📤 Transferred new WatchState snapshot via=sendMessage reading_date_epoch_seconds=\(readingEpoch)")
+            if readingEpochPresent, !isDuplicateDispatch {
+                if budgetSnapshot > 0 {
+                    debug(.watchManager, "ℹ️ complication_transfer_skipped_reachable remaining=\(budgetSnapshot)")
+                } else {
+                    debug(.watchManager, "ℹ️ complication_budget_exhausted_reachable remaining=0 - userInfo fallback will enqueue")
+                }
+            }
+        }
+
+        // Budgeted complication transfer — only when unreachable. When reachable,
+        // sendMessage already updates the foreground watch app, so we conserve the
+        // complication transfer budget.
+        // Complication age is derived from the watch-reported timestamp (receivedApplicationContext)
+        // or the reading epoch in lastDispatchedGateKey (iOS-side proxy).
+        if !session.isReachable, readingEpochPresent, !isDuplicateDispatch, budgetSnapshot > 0 {
+            let complicationAgeSeconds = currentComplicationAgeSeconds()
+            let ageGatePassed = complicationAgeSeconds > Self.complicationAgeGateThresholdSeconds
+            if ageGatePassed {
+                session.transferCurrentComplicationUserInfo([WatchMessageKeys.watchState: complicationMessage])
+                lastDispatchedGateKey = gateKey
+                let remaining = session.remainingComplicationUserInfoTransfers
+                let queueDepth = session.outstandingUserInfoTransfers.count
+                debug(.watchManager, "📤 Transferred new WatchState snapshot via=transferCurrentComplicationUserInfo remaining_budget=\(remaining) queue_depth=\(queueDepth) reading_date_epoch_seconds=\(readingEpoch) complication_age_seconds=\(Int(complicationAgeSeconds)) complication_age_gate_threshold_seconds=\(Int(Self.complicationAgeGateThresholdSeconds))")
+            } else {
+                debug(.watchManager, "⏭️ complication_transfer_age_gate_skipped skip_reason=age_gate age_seconds=\(Int(complicationAgeSeconds)) threshold_seconds=\(Int(Self.complicationAgeGateThresholdSeconds)) gate_key=\(gateKey) reading_date_epoch_seconds=\(readingEpoch)")
+            }
+        }
+
+        // Budget-exhausted fallback — runs regardless of reachability. When reachable,
+        // sendMessage already fired above; this enqueues a background userInfo delivery
+        // for complication refresh. No age gate (budget is already zero).
+        if budgetSnapshot == 0, readingEpochPresent, !isDuplicateDispatch {
+            cancelStaleQueuedTransfers()
+            session.transferUserInfo([WatchMessageKeys.watchState: complicationMessage])
+            lastDispatchedGateKey = gateKey
+            let queueDepth = session.outstandingUserInfoTransfers.count
+            debug(.watchManager, "📤 Transferred new WatchState snapshot via=userInfo budget_exhausted=true queue_depth=\(queueDepth) reading_date_epoch_seconds=\(readingEpoch)")
+        }
+
+        // R1b: queue-deep observation — runs after all transfer paths regardless of reachability.
+        // sessionIsReadyForTransfer() and cooldown are sufficient guards.
+        let queueDeepCooldown: TimeInterval = 60
+        if sessionIsReadyForTransfer() {
+            let queueDepthNow = session.outstandingUserInfoTransfers.count
+            if queueDepthNow > 5,
+               (Date().timeIntervalSince1970 - lastQueueDeepDrainAt) > queueDeepCooldown
+            {
+                debug(.watchManager, "🧹 queue_deep_drain triggered depth=\(queueDepthNow)")
+                lastQueueDeepDrainAt = Date().timeIntervalSince1970
+                cancelStaleQueuedTransfers()
+            }
+        }
+
+        // R4: applicationContext safety net — budget-free parallel delivery channel.
+        // Fires only during budget exhaustion or deep queue; dormant during normal operation.
+        guard sessionIsReadyForTransfer() else {
+            debug(.watchManager, "📦 context_skipped activation_state=\(session.activationState.rawValue) paired=\(session.isPaired) installed=\(session.isWatchAppInstalled)")
+            return
+        }
+
+        let budgetExhausted = session.remainingComplicationUserInfoTransfers == 0
+        let queueDeep = session.outstandingUserInfoTransfers.count > 5
+        guard budgetExhausted || queueDeep else { return }
+
+        let ctx: [String: Any] = [
+            WatchMessageKeys.watchState: complicationMessage,
+            "context_updated_at": Date().timeIntervalSince1970
+        ]
+        debug(.watchManager, "📦 context_attempted budget_exhausted=\(budgetExhausted) queue_depth=\(session.outstandingUserInfoTransfers.count)")
+        do {
+            try session.updateApplicationContext(ctx)
+            debug(.watchManager, "📦 context_succeeded reading_epoch=\(readingEpoch)")
+            debug(.watchManager, "📤 Transferred new WatchState snapshot via=updateApplicationContext reading_date_epoch_seconds=\(readingEpoch) userinfo_budget_exhausted=\(budgetExhausted) queue_depth=\(session.outstandingUserInfoTransfers.count)")
+        } catch {
+            debug(.watchManager, "📦 context_failed context_update_failed=true error=\(error)")
         }
     }
 
@@ -548,10 +912,21 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
             return
         }
 
-        debug(.watchManager, "📱 Phone session activated with state: \(activationState.rawValue)")
-        debug(.watchManager, "📱 Phone isReachable after activation: \(session.isReachable)")
+        debug(.watchManager, "📱 Phone session activated state=\(activationState.rawValue) isReachable=\(session.isReachable) isPaired=\(session.isPaired) isWatchAppInstalled=\(session.isWatchAppInstalled) remaining_budget=\(session.remainingComplicationUserInfoTransfers)")
 
-        // Try to send initial data after activation
+        // R2b: clear dispatch gate on activation so the first post-launch transfer always fires
+        lastDispatchedGateKey = ""
+
+        // R1b: one-time startup drain of the frozen transfer queue
+        if !hasPerformedStartupQueueDrain {
+            hasPerformedStartupQueueDrain = true
+            cancelStaleQueuedTransfers()
+        }
+
+        DispatchQueue.main.async {
+            self.pendingSendWorkItem?.cancel()
+            self.coalescerFirstScheduledAt = nil
+        }
         Task {
             let state = await self.setupWatchState()
             await self.sendDataToWatch(state)
@@ -676,14 +1051,16 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
 
     /// Implements the replyHandler version of didReceiveMessage for ACK support.
     func session(_ session: WCSession, didReceiveMessage message: [String: Any], replyHandler: @escaping ([String: Any]) -> Void) {
-        // Validate envelope structure — check type first so queryAcks (no payloadId) isn't rejected
-        guard let type = message["type"] as? String else {
+        // Validate envelope structure
+        guard let type = message["type"] as? String,
+              let payloadId = message["payloadId"] as? String else {
+            // Not an envelope message - delegate to legacy handler
             self.session(session, didReceiveMessage: message)
             replyHandler([:])
             return
         }
 
-        // Handle ACK query (no payloadId required)
+        // Handle ACK query
         if type == "queryAcks" {
             if let pendingIds = message["pendingIds"] as? [String] {
                 let ackIds = getAcknowledgedIds(from: pendingIds)
@@ -692,16 +1069,8 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
                     "ackIds": ackIds
                 ]
                 replyHandler(batchAck)
-            } else {
-                replyHandler([:])
+                return
             }
-            return
-        }
-
-        guard let payloadId = message["payloadId"] as? String else {
-            self.session(session, didReceiveMessage: message)
-            replyHandler([:])
-            return
         }
 
         // Deduplicate BEFORE any Crashlytics calls
@@ -723,6 +1092,7 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
             if type == "watchLogs" {
                 if let logData = message["data"] as? String {
                     SimpleLogReporter.appendToWatchLog(logData)
+                    Foundation.NotificationCenter.default.post(name: .trioWatchLogsAppended, object: nil)
                 }
             } else if type == "watchError" {
                 if let errorData = message["data"] as? [String: Any] {
@@ -730,6 +1100,10 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
                 }
             }
         }
+
+        // Do not send reverse transferUserInfo confirms for watchLogs here.
+        // Watch-side cleanup is covered by the immediate ACK reply plus later batchAck/queryAcks,
+        // and the extra userInfo confirm can create avoidable connectivity background wakes.
 
         // Reply ACK immediately (even if Crashlytics fails) - ACK means "received and queued"
         let ack: [String: Any] = [
@@ -744,10 +1118,13 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
             // Check if this is an envelope message
             if let type = message["type"] as? String,
                let payloadId = message["payloadId"] as? String {
-                // This is an envelope message but no replyHandler - handle it
+                if self?.isProcessed(payloadId) == true { return }
+                self?.recordProcessed(payloadId)
+
                 if type == "watchLogs" {
                     if let logData = message["data"] as? String {
                         SimpleLogReporter.appendToWatchLog(logData)
+                        Foundation.NotificationCenter.default.post(name: .trioWatchLogsAppended, object: nil)
                     }
                 } else if type == "watchError" {
                     if let errorData = message["data"] as? [String: Any] {
@@ -760,6 +1137,7 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
             // Legacy message format
             if let logs = message["watchLogs"] as? String {
                 SimpleLogReporter.appendToWatchLog(logs)
+                Foundation.NotificationCenter.default.post(name: .trioWatchLogsAppended, object: nil)
             }
 
             // Handle watch errors forwarded for Crashlytics logging
@@ -772,9 +1150,9 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
             {
                 debug(.watchManager, "📱 Watch requested watch state data update.")
                 guard let self = self else { return }
-                // Skip if no watch is paired or app not installed
-                guard let session = self.session, session.isPaired, session.isReachable,
-                      session.isWatchAppInstalled else { return }
+                guard let session = self.session, session.isPaired, session.isWatchAppInstalled else { return }
+                self.pendingSendWorkItem?.cancel()
+                self.coalescerFirstScheduledAt = nil
                 Task {
                     let state = await self.setupWatchState()
                     await self.sendDataToWatch(state)
@@ -896,6 +1274,14 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
         }
     }
 
+    func session(_: WCSession, didReceiveApplicationContext applicationContext: [String: Any]) {
+        let raw = applicationContext["complicationLastValidTimestamp"]
+        let timestamp = (raw as? TimeInterval) ?? (raw as? NSNumber)?.doubleValue
+        if let timestamp {
+            debug(.watchManager, "📱 complication_age_received_from_watch epoch=\(Int(timestamp)) age_seconds=\(Int(Date().timeIntervalSince(Date(timeIntervalSince1970: timestamp))))")
+        }
+    }
+
     func session(_: WCSession, didReceiveUserInfo userInfo: [String: Any] = [:]) {
         // Check if this is an envelope message
         if let type = userInfo["type"] as? String,
@@ -915,6 +1301,7 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
             if type == "watchLogs" {
                 if let logData = userInfo["data"] as? String {
                     SimpleLogReporter.appendToWatchLog(logData)
+                    Foundation.NotificationCenter.default.post(name: .trioWatchLogsAppended, object: nil)
                 }
             } else if type == "watchError" {
                 if let errorData = userInfo["data"] as? [String: Any] {
@@ -965,10 +1352,13 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
     #endif
 
     func sessionReachabilityDidChange(_ session: WCSession) {
-        debug(.watchManager, "📱 Phone reachability changed: \(session.isReachable)")
+        debug(.watchManager, "📱 Phone reachability changed: isReachable=\(session.isReachable) remaining_budget=\(session.remainingComplicationUserInfoTransfers)")
 
         if session.isReachable {
-            // Try to send data when connection is established
+            DispatchQueue.main.async {
+                self.pendingSendWorkItem?.cancel()
+                self.coalescerFirstScheduledAt = nil
+            }
             Task {
                 let state = await self.setupWatchState()
                 await self.sendDataToWatch(state)
@@ -1016,6 +1406,8 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
                 carbEntry.note = String(localized: "Via Watch", comment: "Note added to carb entry when entered via watch")
                 carbEntry.isFPU = false // set this to false to ensure watch-entered carbs are displayed in main chart
                 carbEntry.isUploadedToNS = false
+                carbEntry.isUploadedToHealth = false
+                carbEntry.isUploadedToTidepool = false
 
                 do {
                     guard context.hasChanges else {
@@ -1078,6 +1470,8 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
                     carbEntry.note = String(localized: "Via Watch", comment: "Note added to carb entry when entered via watch")
                     carbEntry.isFPU = false // set this to false to ensure watch-entered carbs are displayed in main chart
                     carbEntry.isUploadedToNS = false
+                    carbEntry.isUploadedToHealth = false
+                    carbEntry.isUploadedToTidepool = false
 
                     guard context.hasChanges else {
                         // Acknowledge failure
@@ -1449,11 +1843,8 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
 extension BaseWatchManager: SettingsObserver, PumpSettingsObserver {
     // to update maxBolus
     func pumpSettingsDidChange(_: PumpSettings) {
-        // Skip if no watch is paired or app not installed
-        guard let session = self.session, session.isPaired, session.isReachable, session.isWatchAppInstalled else { return }
-        Task {
-            let state = await self.setupWatchState()
-            await self.sendDataToWatch(state)
+        DispatchQueue.main.async {
+            self.scheduleWatchStateUpdate(source: "pumpSettings")
         }
     }
 
@@ -1464,12 +1855,8 @@ extension BaseWatchManager: SettingsObserver, PumpSettingsObserver {
         lowGlucose = settingsManager.settings.low
         highGlucose = settingsManager.settings.high
 
-        // Skip if no watch is paired or app not installed
-        guard let session = self.session, session.isPaired, session.isReachable, session.isWatchAppInstalled else { return }
-
-        Task {
-            let state = await self.setupWatchState()
-            await self.sendDataToWatch(state)
+        DispatchQueue.main.async {
+            self.scheduleWatchStateUpdate(source: "settingsChanged")
         }
     }
 }

--- a/Trio/Sources/Services/WatchManager/AppleWatchManager.swift
+++ b/Trio/Sources/Services/WatchManager/AppleWatchManager.swift
@@ -70,6 +70,10 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
     private let processedIdsTTL: TimeInterval = 7 * 24 * 60 * 60 // 7 days
     private let pendingAcksKey = "watchPendingAcks"
 
+    // Delegate-triggered state push debounce (crash guard — absorbs rapid WCSession delegate storms)
+    private var pendingDelegateWorkItem: DispatchWorkItem?
+    private var delegateCoalesceCount = 0
+
     typealias PumpEvent = PumpEventStored.EventType
 
     let backgroundContext = CoreDataStack.shared.newTaskContext()
@@ -202,13 +206,26 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
         )
     }
 
-    /// Attempts to reestablish the Watch connection if it becomes unreachable
-    private func retryConnection() {
-        guard let session = session else { return }
+    /// Cancel-and-replace debounce for delegate-triggered state pushes.
+    /// Collapses N rapid callbacks (e.g. watch reboot storm) into one push after a 0.5s quiet window.
+    private func scheduleDelegateTriggeredUpdate(source: String) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.pendingDelegateWorkItem?.cancel()
+            self.delegateCoalesceCount += 1
 
-        if !session.isReachable {
-            debug(.watchManager, "📱 Attempting to reactivate session...")
-            session.activate()
+            let count = self.delegateCoalesceCount
+            let workItem = DispatchWorkItem { [weak self] in
+                guard let self else { return }
+                debug(.watchManager, "📡 delegate_coalescer_fired source=\(source) coalesced=\(count)")
+                self.delegateCoalesceCount = 0
+                Task {
+                    let state = await self.setupWatchState()
+                    await self.sendDataToWatch(state)
+                }
+            }
+            self.pendingDelegateWorkItem = workItem
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: workItem)
         }
     }
 
@@ -383,14 +400,12 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
 
                 // Calculate delta if we have at least 2 readings
                 if glucoseObjects.count >= 2 {
-                    var glucoseLast = Decimal(glucoseObjects[0].glucose)
-                    var glucoseSecondLast = Decimal(glucoseObjects[1].glucose)
+                    var deltaValue = Decimal(glucoseObjects[0].glucose - glucoseObjects[1].glucose)
+
                     if self.units == .mmolL {
-                        glucoseLast = glucoseLast.asMmolL
-                        glucoseSecondLast = glucoseSecondLast.asMmolL
+                        deltaValue = Double(truncating: deltaValue as NSNumber).asMmolL
                     }
 
-                    let deltaValue = glucoseLast - glucoseSecondLast
                     let formattedDelta = Formatter.glucoseFormatter(for: self.units)
                         .string(from: deltaValue as NSNumber) ?? "0"
                     watchState.delta = deltaValue < 0 ? "\(formattedDelta)" : "+\(formattedDelta)"
@@ -800,7 +815,7 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
         }
 
         let budgetSnapshot = session.remainingComplicationUserInfoTransfers
-        debug(.watchManager, "🔍 complication_budget_check remaining=\(budgetSnapshot) isReachable=\(session.isReachable) readingEpochPresent=\(readingEpochPresent) isDuplicate=\(isDuplicateDispatch) queue_depth=\(session.outstandingUserInfoTransfers.count)")
+        debug(.watchManager, "🔍 complication_budget_check remaining=\(budgetSnapshot) isReachable=\(session.isReachable) readingEpochPresent=\(readingEpochPresent) isDuplicate=\(isDuplicateDispatch)")
 
         // sendMessage (budget-free watch UI path) — always fires with fullMessage
         if session.isReachable {
@@ -881,7 +896,6 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
         do {
             try session.updateApplicationContext(ctx)
             debug(.watchManager, "📦 context_succeeded reading_epoch=\(readingEpoch)")
-            debug(.watchManager, "📤 Transferred new WatchState snapshot via=updateApplicationContext reading_date_epoch_seconds=\(readingEpoch) userinfo_budget_exhausted=\(budgetExhausted) queue_depth=\(session.outstandingUserInfoTransfers.count)")
         } catch {
             debug(.watchManager, "📦 context_failed context_update_failed=true error=\(error)")
         }
@@ -912,6 +926,11 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
             return
         }
 
+        guard activationState == .activated else {
+            debug(.watchManager, "📱 Ignoring activation callback — state is \(activationState.rawValue), not .activated")
+            return
+        }
+
         debug(.watchManager, "📱 Phone session activated state=\(activationState.rawValue) isReachable=\(session.isReachable) isPaired=\(session.isPaired) isWatchAppInstalled=\(session.isWatchAppInstalled) remaining_budget=\(session.remainingComplicationUserInfoTransfers)")
 
         // R2b: clear dispatch gate on activation so the first post-launch transfer always fires
@@ -923,14 +942,7 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
             cancelStaleQueuedTransfers()
         }
 
-        DispatchQueue.main.async {
-            self.pendingSendWorkItem?.cancel()
-            self.coalescerFirstScheduledAt = nil
-        }
-        Task {
-            let state = await self.setupWatchState()
-            await self.sendDataToWatch(state)
-        }
+        scheduleDelegateTriggeredUpdate(source: "activationCompleted")
     }
 
     // MARK: - Processed IDs Management
@@ -1051,16 +1063,14 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
 
     /// Implements the replyHandler version of didReceiveMessage for ACK support.
     func session(_ session: WCSession, didReceiveMessage message: [String: Any], replyHandler: @escaping ([String: Any]) -> Void) {
-        // Validate envelope structure
-        guard let type = message["type"] as? String,
-              let payloadId = message["payloadId"] as? String else {
-            // Not an envelope message - delegate to legacy handler
+        // Validate envelope structure — check type first so queryAcks (no payloadId) isn't rejected
+        guard let type = message["type"] as? String else {
             self.session(session, didReceiveMessage: message)
             replyHandler([:])
             return
         }
 
-        // Handle ACK query
+        // Handle ACK query (no payloadId required)
         if type == "queryAcks" {
             if let pendingIds = message["pendingIds"] as? [String] {
                 let ackIds = getAcknowledgedIds(from: pendingIds)
@@ -1069,8 +1079,16 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
                     "ackIds": ackIds
                 ]
                 replyHandler(batchAck)
-                return
+            } else {
+                replyHandler([:])
             }
+            return
+        }
+
+        guard let payloadId = message["payloadId"] as? String else {
+            self.session(session, didReceiveMessage: message)
+            replyHandler([:])
+            return
         }
 
         // Deduplicate BEFORE any Crashlytics calls
@@ -1101,10 +1119,6 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
             }
         }
 
-        // Do not send reverse transferUserInfo confirms for watchLogs here.
-        // Watch-side cleanup is covered by the immediate ACK reply plus later batchAck/queryAcks,
-        // and the extra userInfo confirm can create avoidable connectivity background wakes.
-
         // Reply ACK immediately (even if Crashlytics fails) - ACK means "received and queued"
         let ack: [String: Any] = [
             "type": "ack",
@@ -1118,9 +1132,7 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
             // Check if this is an envelope message
             if let type = message["type"] as? String,
                let payloadId = message["payloadId"] as? String {
-                if self?.isProcessed(payloadId) == true { return }
-                self?.recordProcessed(payloadId)
-
+                // This is an envelope message but no replyHandler - handle it
                 if type == "watchLogs" {
                     if let logData = message["data"] as? String {
                         SimpleLogReporter.appendToWatchLog(logData)
@@ -1355,22 +1367,11 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
         debug(.watchManager, "📱 Phone reachability changed: isReachable=\(session.isReachable) remaining_budget=\(session.remainingComplicationUserInfoTransfers)")
 
         if session.isReachable {
-            DispatchQueue.main.async {
-                self.pendingSendWorkItem?.cancel()
-                self.coalescerFirstScheduledAt = nil
-            }
-            Task {
-                let state = await self.setupWatchState()
-                await self.sendDataToWatch(state)
-            }
+            scheduleDelegateTriggeredUpdate(source: "reachabilityChanged")
 
-            // Send pending ACKs when watch becomes reachable
             sendPendingAcksIfReachable()
         } else {
-            // Try to reconnect after a short delay
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
-                self?.retryConnection()
-            }
+            debug(.watchManager, "📱 Watch became unreachable — waiting for system reconnection")
         }
     }
 
@@ -1406,8 +1407,6 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
                 carbEntry.note = String(localized: "Via Watch", comment: "Note added to carb entry when entered via watch")
                 carbEntry.isFPU = false // set this to false to ensure watch-entered carbs are displayed in main chart
                 carbEntry.isUploadedToNS = false
-                carbEntry.isUploadedToHealth = false
-                carbEntry.isUploadedToTidepool = false
 
                 do {
                     guard context.hasChanges else {
@@ -1470,8 +1469,6 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
                     carbEntry.note = String(localized: "Via Watch", comment: "Note added to carb entry when entered via watch")
                     carbEntry.isFPU = false // set this to false to ensure watch-entered carbs are displayed in main chart
                     carbEntry.isUploadedToNS = false
-                    carbEntry.isUploadedToHealth = false
-                    carbEntry.isUploadedToTidepool = false
 
                     guard context.hasChanges else {
                         // Acknowledge failure

--- a/Trio/Sources/Services/WatchManager/AppleWatchManager.swift
+++ b/Trio/Sources/Services/WatchManager/AppleWatchManager.swift
@@ -1,5 +1,6 @@
 import Combine
 import CoreData
+import FirebaseCrashlytics
 import Foundation
 import Swinject
 import UIKit
@@ -38,6 +39,12 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
     private let queue = DispatchQueue(label: "BaseWatchManagerManager.queue", qos: .utility)
     private var coreDataPublisher: AnyPublisher<Set<NSManagedObjectID>, Never>?
     private var subscriptions = Set<AnyCancellable>()
+
+    // Processed payload IDs for deduplication (LRU with TTL)
+    private let processedIdsKey = "watchProcessedIds"
+    private let processedIdsMaxCount = 100
+    private let processedIdsTTL: TimeInterval = 7 * 24 * 60 * 60 // 7 days
+    private let pendingAcksKey = "watchPendingAcks"
 
     typealias PumpEvent = PumpEventStored.EventType
 
@@ -321,14 +328,12 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
 
                 // Calculate delta if we have at least 2 readings
                 if glucoseObjects.count >= 2 {
-                    var glucoseLast = Decimal(glucoseObjects[0].glucose)
-                    var glucoseSecondLast = Decimal(glucoseObjects[1].glucose)
+                    var deltaValue = Decimal(glucoseObjects[0].glucose - glucoseObjects[1].glucose)
+
                     if self.units == .mmolL {
-                        glucoseLast = glucoseLast.asMmolL
-                        glucoseSecondLast = glucoseSecondLast.asMmolL
+                        deltaValue = Double(truncating: deltaValue as NSNumber).asMmolL
                     }
 
-                    let deltaValue = glucoseLast - glucoseSecondLast
                     let formattedDelta = Formatter.glucoseFormatter(for: self.units)
                         .string(from: deltaValue as NSNumber) ?? "0"
                     watchState.delta = deltaValue < 0 ? "\(formattedDelta)" : "+\(formattedDelta)"
@@ -353,11 +358,11 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
                 watchState.bolusIncrement = self.settingsManager.preferences.bolusIncrement
                 watchState.confirmBolusFaster = self.settingsManager.settings.confirmBolusFaster
 
-                debug(
-                    .watchManager,
-
-                    "📱 Setup WatchState - currentGlucose: \(watchState.currentGlucose ?? "nil"), trend: \(watchState.trend ?? "nil"), delta: \(watchState.delta ?? "nil"), values: \(watchState.glucoseValues.count)"
-                )
+                let glucoseInfo = "currentGlucose: \(watchState.currentGlucose ?? "nil"), " +
+                    "trend: \(watchState.trend ?? "nil"), " +
+                    "delta: \(watchState.delta ?? "nil"), " +
+                    "values: \(watchState.glucoseValues.count)"
+                debug(.watchManager, "📱 Setup WatchState - \(glucoseInfo)")
 
                 return watchState
             }
@@ -553,19 +558,220 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
         }
     }
 
-    func session(_: WCSession, didReceiveMessage message: [String: Any]) {
-        // Handle logs first - doesn't need self, so it can run even during teardown
-        if let logs = message["watchLogs"] as? String {
-            SimpleLogReporter.appendToWatchLog(logs)
+    // MARK: - Processed IDs Management
+
+    /// Checks if a payloadId has been processed (deduplication).
+    private func isProcessed(_ payloadId: String) -> Bool {
+        guard let processedIds = UserDefaults.standard.dictionary(forKey: processedIdsKey) as? [String: TimeInterval] else {
+            return false
         }
 
-        Task { @MainActor [weak self] in
-            guard let self else { return }
+        guard let timestamp = processedIds[payloadId] else {
+            return false
+        }
+
+        // Check TTL
+        let now = Date().timeIntervalSince1970
+        if (now - timestamp) > processedIdsTTL {
+            // Expired - remove it
+            var updatedIds = processedIds
+            updatedIds.removeValue(forKey: payloadId)
+            UserDefaults.standard.set(updatedIds, forKey: processedIdsKey)
+            return false
+        }
+
+        return true
+    }
+
+    /// Records a payloadId as processed (durable storage).
+    private func recordProcessed(_ payloadId: String) {
+        var processedIds = UserDefaults.standard.dictionary(forKey: processedIdsKey) as? [String: TimeInterval] ?? [:]
+        let now = Date().timeIntervalSince1970
+
+        // Add new ID
+        processedIds[payloadId] = now
+
+        // Clean up expired entries
+        processedIds = processedIds.filter { (_, timestamp) in
+            (now - timestamp) <= processedIdsTTL
+        }
+
+        // Enforce LRU (keep most recent N)
+        if processedIds.count > processedIdsMaxCount {
+            let sorted = processedIds.sorted { $0.value > $1.value }
+            let toKeep = Dictionary(uniqueKeysWithValues: Array(sorted.prefix(processedIdsMaxCount)))
+            processedIds = toKeep
+        }
+
+        UserDefaults.standard.set(processedIds, forKey: processedIdsKey)
+    }
+
+    /// Gets acknowledged payloadIds from processedIds for a list of pending IDs.
+    private func getAcknowledgedIds(from pendingIds: [String]) -> [String] {
+        guard let processedIds = UserDefaults.standard.dictionary(forKey: processedIdsKey) as? [String: TimeInterval] else {
+            return []
+        }
+
+        let now = Date().timeIntervalSince1970
+        return pendingIds.filter { payloadId in
+            if let timestamp = processedIds[payloadId] {
+                return (now - timestamp) <= processedIdsTTL
+            }
+            return false
+        }
+    }
+
+    /// Stores a pending ACK for later delivery when watch becomes reachable.
+    private func storePendingAck(_ payloadId: String) {
+        var pendingAcks = UserDefaults.standard.array(forKey: pendingAcksKey) as? [[String: Any]] ?? []
+
+        let record: [String: Any] = [
+            "payloadId": payloadId,
+            "timestamp": Date().timeIntervalSince1970
+        ]
+
+        pendingAcks.append(record)
+
+        // Clean up old records (older than 7 days)
+        let now = Date().timeIntervalSince1970
+        pendingAcks = pendingAcks.filter { record in
+            if let timestamp = record["timestamp"] as? TimeInterval {
+                return (now - timestamp) < (7 * 24 * 60 * 60)
+            }
+            return true
+        }
+
+        UserDefaults.standard.set(pendingAcks, forKey: pendingAcksKey)
+    }
+
+    /// Sends pending ACKs when watch becomes reachable.
+    private func sendPendingAcksIfReachable() {
+        guard let session = session, session.isReachable else {
+            return
+        }
+
+        guard let pendingAcks = UserDefaults.standard.array(forKey: pendingAcksKey) as? [[String: Any]],
+              !pendingAcks.isEmpty else {
+            return
+        }
+
+        let ackIds = pendingAcks.compactMap { $0["payloadId"] as? String }
+
+        if !ackIds.isEmpty {
+            let batchAck: [String: Any] = [
+                "type": "batchAck",
+                "ackIds": ackIds
+            ]
+
+            session.sendMessage(batchAck, replyHandler: nil) { error in
+                debug(.watchManager, "📱 Failed to send batchAck: \(error.localizedDescription)")
+            }
+
+            // Clear pending ACKs after sending
+            UserDefaults.standard.removeObject(forKey: pendingAcksKey)
+        }
+    }
+
+    // MARK: - WCSessionDelegate Methods
+
+    /// Implements the replyHandler version of didReceiveMessage for ACK support.
+    func session(_ session: WCSession, didReceiveMessage message: [String: Any], replyHandler: @escaping ([String: Any]) -> Void) {
+        // Validate envelope structure — check type first so queryAcks (no payloadId) isn't rejected
+        guard let type = message["type"] as? String else {
+            self.session(session, didReceiveMessage: message)
+            replyHandler([:])
+            return
+        }
+
+        // Handle ACK query (no payloadId required)
+        if type == "queryAcks" {
+            if let pendingIds = message["pendingIds"] as? [String] {
+                let ackIds = getAcknowledgedIds(from: pendingIds)
+                let batchAck: [String: Any] = [
+                    "type": "batchAck",
+                    "ackIds": ackIds
+                ]
+                replyHandler(batchAck)
+            } else {
+                replyHandler([:])
+            }
+            return
+        }
+
+        guard let payloadId = message["payloadId"] as? String else {
+            self.session(session, didReceiveMessage: message)
+            replyHandler([:])
+            return
+        }
+
+        // Deduplicate BEFORE any Crashlytics calls
+        if isProcessed(payloadId) {
+            // Duplicate - send ACK immediately but skip processing
+            let ack: [String: Any] = [
+                "type": "ack",
+                "payloadId": payloadId
+            ]
+            replyHandler(ack)
+            return
+        }
+
+        // New payload - record as processed (durable) BEFORE processing
+        recordProcessed(payloadId)
+
+        // Enqueue payload handling (durable enqueue)
+        DispatchQueue.main.async { [weak self] in
+            if type == "watchLogs" {
+                if let logData = message["data"] as? String {
+                    SimpleLogReporter.appendToWatchLog(logData)
+                }
+            } else if type == "watchError" {
+                if let errorData = message["data"] as? [String: Any] {
+                    self?.handleWatchError(errorData)
+                }
+            }
+        }
+
+        // Reply ACK immediately (even if Crashlytics fails) - ACK means "received and queued"
+        let ack: [String: Any] = [
+            "type": "ack",
+            "payloadId": payloadId
+        ]
+        replyHandler(ack)
+    }
+
+    func session(_: WCSession, didReceiveMessage message: [String: Any]) {
+        DispatchQueue.main.async { [weak self] in
+            // Check if this is an envelope message
+            if let type = message["type"] as? String,
+               let payloadId = message["payloadId"] as? String {
+                // This is an envelope message but no replyHandler - handle it
+                if type == "watchLogs" {
+                    if let logData = message["data"] as? String {
+                        SimpleLogReporter.appendToWatchLog(logData)
+                    }
+                } else if type == "watchError" {
+                    if let errorData = message["data"] as? [String: Any] {
+                        self?.handleWatchError(errorData)
+                    }
+                }
+                return
+            }
+
+            // Legacy message format
+            if let logs = message["watchLogs"] as? String {
+                SimpleLogReporter.appendToWatchLog(logs)
+            }
+
+            // Handle watch errors forwarded for Crashlytics logging
+            if let errorInfo = message["watchError"] as? [String: Any] {
+                self?.handleWatchError(errorInfo)
+            }
 
             if let requestWatchUpdate = message[WatchMessageKeys.requestWatchUpdate] as? String,
                requestWatchUpdate == WatchMessageKeys.watchState
             {
                 debug(.watchManager, "📱 Watch requested watch state data update.")
+                guard let self = self else { return }
                 // Skip if no watch is paired or app not installed
                 guard let session = self.session, session.isPaired, session.isReachable,
                       session.isWatchAppInstalled else { return }
@@ -578,21 +784,24 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
 
             if let snoozeMinutes = message[WatchMessageKeys.snoozeDuration] as? Int {
                 debug(.watchManager, "📱 Received snooze request from watch: \(snoozeMinutes) minutes")
-                await self.notificationsManager.applySnooze(for: TimeInterval(snoozeMinutes * 60))
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    await self.notificationsManager.applySnooze(for: TimeInterval(snoozeMinutes * 60))
+                }
                 return
             } else if let bolusAmount = message[WatchMessageKeys.bolus] as? Double,
                       message[WatchMessageKeys.carbs] == nil,
                       message[WatchMessageKeys.date] == nil
             {
                 debug(.watchManager, "📱 Received bolus request from watch: \(bolusAmount)U")
-                self.handleBolusRequest(Decimal(bolusAmount))
+                self?.handleBolusRequest(Decimal(bolusAmount))
             } else if let carbsAmount = message[WatchMessageKeys.carbs] as? Int,
                       let timestamp = message[WatchMessageKeys.date] as? TimeInterval,
                       message[WatchMessageKeys.bolus] == nil
             {
                 let date = Date(timeIntervalSince1970: timestamp)
                 debug(.watchManager, "📱 Received carbs request from watch: \(carbsAmount)g at \(date)")
-                self.handleCarbsRequest(carbsAmount, date)
+                self?.handleCarbsRequest(carbsAmount, date)
             } else if let bolusAmount = message[WatchMessageKeys.bolus] as? Double,
                       let carbsAmount = message[WatchMessageKeys.carbs] as? Int,
                       let timestamp = message[WatchMessageKeys.date] as? TimeInterval
@@ -602,11 +811,11 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
                     .watchManager,
                     "📱 Received meal bolus combo request from watch: \(bolusAmount)U, \(carbsAmount)g at \(date)"
                 )
-                self.handleCombinedRequest(bolusAmount: Decimal(bolusAmount), carbsAmount: Decimal(carbsAmount), date: date)
+                self?.handleCombinedRequest(bolusAmount: Decimal(bolusAmount), carbsAmount: Decimal(carbsAmount), date: date)
             } else {
                 debug(.watchManager, "📱 Invalid or incomplete data received from watch. Received:  \(message)")
                 // Acknowledge failure
-                self.sendAcknowledgment(
+                self?.sendAcknowledgment(
                     toWatch: false,
                     message: "Error! Invalid or incomplete data received from watch.",
                     ackCode: .genericFailure
@@ -615,22 +824,22 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
 
             if message[WatchMessageKeys.cancelOverride] as? Bool == true {
                 debug(.watchManager, "📱 Received cancel override request from watch")
-                self.handleCancelOverride()
+                self?.handleCancelOverride()
             }
 
             if let presetName = message[WatchMessageKeys.activateOverride] as? String {
                 debug(.watchManager, "📱 Received activate override request from watch for preset: \(presetName)")
-                self.handleActivateOverride(presetName)
+                self?.handleActivateOverride(presetName)
             }
 
             if let presetName = message[WatchMessageKeys.activateTempTarget] as? String {
                 debug(.watchManager, "📱 Received activate temp target request from watch for preset: \(presetName)")
-                self.handleActivateTempTarget(presetName)
+                self?.handleActivateTempTarget(presetName)
             }
 
             if message[WatchMessageKeys.cancelTempTarget] as? Bool == true {
                 debug(.watchManager, "📱 Received cancel temp target request from watch")
-                self.handleCancelTempTarget()
+                self?.handleCancelTempTarget()
             }
 
             if message[WatchMessageKeys.requestBolusRecommendation] as? Bool == true {
@@ -688,14 +897,61 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
     }
 
     func session(_: WCSession, didReceiveUserInfo userInfo: [String: Any] = [:]) {
+        // Check if this is an envelope message
+        if let type = userInfo["type"] as? String,
+           let payloadId = userInfo["payloadId"] as? String {
+            // Validate envelope structure
+            // Deduplicate
+            if isProcessed(payloadId) {
+                // Duplicate - skip processing but store for ACK later
+                storePendingAck(payloadId)
+                return
+            }
+
+            // New payload - record as processed (durable)
+            recordProcessed(payloadId)
+
+            // Handle payload
+            if type == "watchLogs" {
+                if let logData = userInfo["data"] as? String {
+                    SimpleLogReporter.appendToWatchLog(logData)
+                }
+            } else if type == "watchError" {
+                if let errorData = userInfo["data"] as? [String: Any] {
+                    handleWatchError(errorData)
+                }
+            }
+
+            // Store pending ACK for later delivery when watch becomes reachable
+            storePendingAck(payloadId)
+
+            // Try to send ACK immediately if reachable (best-effort)
+            if let session = session, session.isReachable {
+                let ack: [String: Any] = [
+                    "type": "ack",
+                    "payloadId": payloadId
+                ]
+                session.sendMessage(ack, replyHandler: nil) { error in
+                    debug(.watchManager, "📱 Failed to send ACK for userInfo payloadId \(payloadId): \(error.localizedDescription)")
+                }
+            }
+
+            return
+        }
+
+        // Legacy message format
         if let logs = userInfo["watchLogs"] as? String {
             SimpleLogReporter.appendToWatchLog(logs)
         }
 
+        // Handle watch errors forwarded for Crashlytics logging
+        if let errorInfo = userInfo["watchError"] as? [String: Any] {
+            handleWatchError(errorInfo)
+        }
+
         if let snoozeMinutes = userInfo[WatchMessageKeys.snoozeDuration] as? Int {
             debug(.watchManager, "📱 Received snooze userInfo from watch: \(snoozeMinutes) minutes")
-            Task { @MainActor [weak self] in
-                guard let self else { return }
+            Task { @MainActor in
                 await self.notificationsManager.applySnooze(for: TimeInterval(snoozeMinutes * 60))
             }
         }
@@ -717,6 +973,9 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
                 let state = await self.setupWatchState()
                 await self.sendDataToWatch(state)
             }
+
+            // Send pending ACKs when watch becomes reachable
+            sendPendingAcksIfReachable()
         } else {
             // Try to reconnect after a short delay
             DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
@@ -757,8 +1016,6 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
                 carbEntry.note = String(localized: "Via Watch", comment: "Note added to carb entry when entered via watch")
                 carbEntry.isFPU = false // set this to false to ensure watch-entered carbs are displayed in main chart
                 carbEntry.isUploadedToNS = false
-                carbEntry.isUploadedToHealth = false
-                carbEntry.isUploadedToTidepool = false
 
                 do {
                     guard context.hasChanges else {
@@ -821,8 +1078,6 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
                     carbEntry.note = String(localized: "Via Watch", comment: "Note added to carb entry when entered via watch")
                     carbEntry.isFPU = false // set this to false to ensure watch-entered carbs are displayed in main chart
                     carbEntry.isUploadedToNS = false
-                    carbEntry.isUploadedToHealth = false
-                    carbEntry.isUploadedToTidepool = false
 
                     guard context.hasChanges else {
                         // Acknowledge failure
@@ -1265,6 +1520,91 @@ extension BaseWatchManager {
         }
 
         return nil
+    }
+
+    /// Handles errors forwarded from the watch app and logs them to Crashlytics.
+    /// - Parameter errorInfo: Dictionary containing error information from watchOS
+    private func handleWatchError(_ errorInfo: [String: Any]) {
+        // Set custom keys for watch errors
+        Crashlytics.crashlytics().setCustomValue("watchOS", forKey: "platform")
+
+        if let appVersion = errorInfo["appVersion"] as? String {
+            Crashlytics.crashlytics().setCustomValue(appVersion, forKey: "watch_app_version")
+        }
+
+        // Add context if available (limit to first 10 keys, truncate values to 256-512 chars)
+        if let context = errorInfo["context"] as? [String: String] {
+            let limitedContext = context.prefix(10)
+            for (key, value) in limitedContext {
+                let truncatedValue = String(value.prefix(512))
+                Crashlytics.crashlytics().setCustomValue(truncatedValue, forKey: "watch_\(key)")
+            }
+        }
+
+        // Handle saved context from crash recovery (limit and truncate)
+        if let savedContext = errorInfo["savedContext"] as? [String: String] {
+            let limitedContext = savedContext.prefix(10)
+            for (key, value) in limitedContext {
+                let truncatedValue = String(value.prefix(512))
+                Crashlytics.crashlytics().setCustomValue(truncatedValue, forKey: "watch_crash_\(key)")
+            }
+        }
+
+        // Handle different error types
+        let errorType = errorInfo["type"] as? String
+
+        if errorType == "potentialCrash" {
+            // Handle crash detection from previous session
+            let crashMessage = "Watch app detected potential crash from previous session"
+
+            Crashlytics.crashlytics().log("Watch crash detected: \(crashMessage)")
+
+            // Log recent logs if available
+            if let recentLogs = errorInfo["recentLogs"] as? String {
+                Crashlytics.crashlytics().log("Watch recent logs before crash:\n\(recentLogs)")
+            }
+
+            // Create a non-fatal error to represent the crash
+            let crashError = NSError(
+                domain: "watchOS",
+                code: -1,
+                userInfo: [
+                    NSLocalizedDescriptionKey: crashMessage,
+                    "source": "watchOS",
+                    "errorType": "potentialCrash"
+                ]
+            )
+            Crashlytics.crashlytics().record(error: crashError)
+            debug(.watchManager, "📱 Recorded watch crash detection to Crashlytics: \(crashMessage)")
+        } else if let errorDomain = errorInfo["errorDomain"] as? String,
+                  let errorCode = errorInfo["errorCode"] as? Int,
+                  let errorDescription = errorInfo["errorDescription"] as? String {
+            // Create an NSError from the watch error info
+            let error = NSError(
+                domain: errorDomain,
+                code: errorCode,
+                userInfo: [
+                    NSLocalizedDescriptionKey: errorDescription,
+                    "source": "watchOS"
+                ]
+            )
+            Crashlytics.crashlytics().record(error: error)
+            debug(.watchManager, "📱 Recorded watch error to Crashlytics: \(errorDescription)")
+        } else if let message = errorInfo["message"] as? String {
+            // Non-fatal issue with custom message
+            Crashlytics.crashlytics().log("Watch non-fatal issue: \(message)")
+            debug(.watchManager, "📱 Logged watch non-fatal issue to Crashlytics: \(message)")
+        }
+
+        // Log stack trace if available (use reportingStackTrace, fallback to stackTrace)
+        if let reportingStackTrace = errorInfo["reportingStackTrace"] as? [String] {
+            let stackTraceString = reportingStackTrace.joined(separator: "\n")
+            Crashlytics.crashlytics().log("Watch reporting stack trace:\n\(stackTraceString)")
+        } else if let stackTrace = errorInfo["stackTrace"] as? [String] {
+            // Fallback to legacy field name
+            let stackTraceString = stackTrace.joined(separator: "\n")
+            Crashlytics.crashlytics().log("Watch stack trace:\n\(stackTraceString)")
+        }
     }
 }
 

--- a/TrioTests/CloudLogEntryAggregatorTests.swift
+++ b/TrioTests/CloudLogEntryAggregatorTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+
+@testable import Trio
+
+@Suite("Cloud Log Entry Aggregation Tests") struct CloudLogEntryAggregatorTests {
+    @Test("iOS multi-line entry aggregation groups by timestamp start") func testIOSAggregation() throws {
+        let start = try NSRegularExpression(pattern: #"^\d{4}-\d{2}-\d{2}T"#)
+
+        let lines: [String] = [
+            "2026-01-01T08:32:30+0100 [DeviceManager] Foo.swift - bar() - 1 - INFO: Starting request",
+            "{",
+            "  \"a\": 1,",
+            "  \"b\": 2",
+            "}",
+            "2026-01-01T08:32:31+0100 [DeviceManager] Foo.swift - bar() - 2 - INFO: Done"
+        ]
+
+        let entries = CloudLogEntryAggregator.aggregate(lines: lines, startPattern: start)
+        #expect(entries.count == 2)
+        #expect(entries[0].contains("\n{\n  \"a\": 1,"))
+        #expect(entries[0].hasPrefix("2026-01-01T08:32:30+0100"))
+        #expect(entries[1].hasPrefix("2026-01-01T08:32:31+0100"))
+    }
+
+    @Test("watch multi-line entry aggregation groups by bracketed timestamp start") func testWatchAggregation() throws {
+        let start = try NSRegularExpression(pattern: #"^\[\d{4}-\d{2}-\d{2}T"#)
+
+        let lines: [String] = [
+            "[2026-01-01T08:35:51+0100] [WatchLogger.swift:169] flushToPhone() → ⌚️ Something happened",
+            "stacktrace line 1",
+            "stacktrace line 2",
+            "[2026-01-01T08:35:52+0100] [WatchState.swift:1] tick() → Next entry"
+        ]
+
+        let entries = CloudLogEntryAggregator.aggregate(lines: lines, startPattern: start)
+        #expect(entries.count == 2)
+        #expect(entries[0].contains("stacktrace line 1\nstacktrace line 2"))
+        #expect(entries[0].hasPrefix("[2026-01-01T08:35:51+0100]"))
+        #expect(entries[1].hasPrefix("[2026-01-01T08:35:52+0100]"))
+    }
+}

--- a/docs/in-progress/watch-g7-direct-ble-observer/01-design.md
+++ b/docs/in-progress/watch-g7-direct-ble-observer/01-design.md
@@ -1,0 +1,72 @@
+# Watch G7 direct BLE observer — design
+
+**Version:** v2  
+**Status:** Draft (device validation pending)  
+**Created:** 2026-04-24 16:02 CEST  
+**Last updated:** 2026-04-24 17:24 CEST  
+
+---
+
+## Mission
+
+Trio’s watch app extension **eavesdrops** on the Dexcom G7 session that the **official Dexcom G7 watch app** already holds in direct-to-watch mode, using **same-device CoreBluetooth**: Trio’s `CBCentralManager` gets its own GATT view, subscribes to auth/control notifications, and **writes the EGV-request opcode** on the control characteristic. The goal is **sustained delivery of many EGV readings over time**, not a one-shot read.
+
+Trio does **not** own authentication (no J-PAKE, no app-key auth, no `sendAuthRequest`); it only **observes** auth traffic and **requests data** once the session is ready per the advance condition below.
+
+**References (read-only, not copied into the tree):** G7SensorKit `G7BluetoothManager.swift`, `G7Sensor.swift`, `G7GlucoseMessage.swift`, `AuthChallengeRxMessage.swift`, `BluetoothServices.swift`; DiaBLE `BluetoothDelegate.swift`, `DexcomG7.swift`.
+
+## Baseline: `dev` + patches 01–10
+
+The implementation is integrated on **`dev` with `patches/01-*.patch` … `patches/10-*.patch` applied** (watch complication data store, session/telemetry, etc.). The G7 observer **extends** the existing `Trio Watch Shared/TrioComplicationDataStore` (optional `TrioComplicationDataSource` on `TrioComplicationSnapshot`); it does **not** replace that store with a duplicate.
+
+---
+
+## Protocol sequence (high fidelity)
+
+1. `CBCentralManager` with **restore identifier** (G7SensorKit, DiaBLE pattern).
+2. **Attach ladder:** `retrievePeripherals(withIdentifiers:)` (last good UUID) → `retrieveConnectedPeripherals` with `FEBC` then cgm service → **scan** `FEBC` with allow-duplicates and `registerForConnectionEvents`.
+3. `connect` with `CBConnectPeripheralOptionNotifyOnConnectionKey` + `NotifyOnDisconnectionKey`.
+4. **Services:** `discoverServices` for cgm + serviceB (J-PAKE service for **discovery-only** logging; **no notify** on J-PAKE).
+5. **Characteristics:** `discoverCharacteristics(nil, for: cgm)`.
+6. Enable **auth** notify first; on **AuthChallengeRx** `0x05` with `isAuthenticated && isBonded`, enable **control** notify, then **write** `0x4E` to control **withResponse**.
+7. Parse EGV with **G7GlucoseMessage** field layout; activation: `Date() - messageTimestamp` on first EGV.
+8. **Backfill:** log only; does not gate.
+
+**Safety:** no auth writes; no J-PAKE subscription.
+
+---
+
+## Dedup / source (DQ 16, post-patch integration)
+
+- **Newer `readingDate` wins.**
+- **Within ±1s** with same glucose/trend/delta: **higher** `TrioComplicationDataSource` priority can replace (`g7DirectBLE` > `watchConnectivityPhone` > `healthKit` > unknown).
+- Saves use `TrioComplicationDataStore.save(..., minInterval: 5)`.
+
+## Source attribution (pipeline)
+
+- `TrioComplicationSnapshot.dataSource` (optional) + `WatchState.displayedComplicationDataSource` for the main view.
+
+## UI (DQ 17)
+
+- G7 status on `WatchState` + `GlucoseTrendView` recency line (`src:`, `G7:` line).
+
+## Observability
+
+- `event=g7_ble_*` via `G7BLELog` → `WatchLogger`.
+
+## Known risks
+
+- Device / Xcode: add new G7 `*.swift` files to the Watch App Extension target.
+- Fingerprint in App Group: new optional `dataSource` field; older fingerprints decode with `dataSource: nil` (treated as unknown).
+
+---
+
+## Changelog
+
+### v2 (2026-04-24 17:24 CEST)
+
+- Documented integration on **dev + patches 01–10** and use of **shared** `TrioComplicationDataStore` + `dataSource` (no duplicate G7 store).
+
+### v1 (2026-04-24 16:02 CEST)
+
+- Initial design: eavesdrop sequence, DQs, pipeline, UI, and risks for watch-only G7 observer POC.

--- a/docs/in-progress/watch-g7-direct-ble-observer/02-implementation-plan.md
+++ b/docs/in-progress/watch-g7-direct-ble-observer/02-implementation-plan.md
@@ -1,0 +1,38 @@
+# Watch G7 direct BLE observer — implementation plan
+
+**Version:** v2  
+**Status:** In progress (Xcode wiring on patched baseline)  
+**Created:** 2026-04-24 16:02 CEST  
+**Last updated:** 2026-04-24 17:24 CEST  
+
+---
+
+## New / modified (patched baseline)
+
+| Location | Change |
+|----------|--------|
+| `Trio Watch App Extension/G7/*.swift` | G7 protocol + `G7DirectBLEManager` (no duplicate `TrioComplicationDataStore`) |
+| `Trio Watch Shared/TrioComplicationDataSource.swift` | **New** enum for snapshot provenance |
+| `Trio Watch Shared/TrioComplicationDataStore.swift` | `TrioComplicationSnapshot` + optional `dataSource`; `shouldUpdate` tie-break; `ComplicationSnapshotFingerprint` includes optional `dataSource`; `wouldAcceptMainThreadSave` for G7 path |
+| `Trio Watch App Extension/WatchState+G7ComplicationPipeline.swift` | `applyG7DirectFromObserver` |
+| `Trio Watch App Extension/WatchState.swift` | G7 + `displayedComplicationDataSource`; WC/HK snapshot builders set `dataSource` |
+| `Trio Watch App Extension/Views/TrioMainWatchView.swift` | `ScenePhase` + G7 `bind`/`start` (with `WatchState.shared`) |
+| `Trio Watch App Extension/Views/GlucoseTrendView.swift` | Recency + source + G7 status |
+
+**Baseline:** `dev` with **`git am --3way patches/01-..` through `10-..`**. Human must add **G7 Swift files + `TrioComplicationDataSource.swift` + shared file edits** to the correct targets in Xcode.
+
+## Phases
+
+1. Apply patches 01–10.  
+2. Integrate G7 on top (shared store + G7 module).  
+3. Xcode: target membership for new files.  
+
+## Changelog
+
+### v2 (2026-04-24 17:24 CEST)
+
+- Replaced plan: integration with `Trio Watch Shared` after patches 1–10; drop G7-local duplicate `TrioComplication*` types.
+
+### v1 (2026-04-24 16:02 CEST)
+
+- Initial plan (pre-patch baseline, listed G7 copies of store) — **superseded** by v2.

--- a/docs/in-progress/watch-g7-direct-ble-observer/03-implementation-log.md
+++ b/docs/in-progress/watch-g7-direct-ble-observer/03-implementation-log.md
@@ -1,0 +1,34 @@
+# Watch G7 direct BLE observer — implementation log
+
+**Version:** v2  
+**Created:** 2026-04-24 16:02 CEST  
+**Last updated:** 2026-04-24 17:24 CEST  
+
+---
+
+## Branch and base
+
+- **Branch:** `feature/watch-g7-direct-ble-observer-patched-cea9`  
+- **Base:** `dev` @ `1aa70ac077ef1492cddfce2bd39e0b2481f3d55c`  
+- **Patches applied (order):** `patches/01-*.patch` … `patches/10-*.patch` via `git am --3way` (clean apply, no conflict).  
+
+## What changed vs first attempt
+
+The earlier branch `feature/watch-g7-direct-ble-observer-clean-cea9` was from **plain `dev`** and missed the watch **complication / session** stack. Cherry-picking that commit onto **dev+01–10** **conflicts** with `TrioMainWatchView` and would **duplicate** `TrioComplicationDataStore` (patches 09+ already add `Trio Watch Shared/TrioComplicationDataStore.swift`).
+
+**Resolution:** Re-integrate the G7 observer to use the **shared** `TrioComplicationDataStore` + add optional `dataSource` on `TrioComplicationSnapshot`, G7 `applyG7DirectFromObserver`, and wire `TrioMainWatchView` to `G7DirectBLEManager` without dropping **WatchState.shared**, telemetry, or the third (debug) tab.
+
+## Validation
+
+- `scripts/patch-test.sh` not re-run in this follow-up; patches were applied with `git am` only.  
+- No `xcodebuild` (per process rules).  
+
+## Changelog
+
+### v2 (2026-04-24 17:24 CEST)
+
+- Logged rebased work on `dev+01–10`, conflict rationale, and shared-store integration.
+
+### v1 (2026-04-24 16:02 CEST)
+
+- Initial handoff log (plain-`dev` base).

--- a/scripts/capture-build-details.sh
+++ b/scripts/capture-build-details.sh
@@ -62,4 +62,34 @@ echo "${submodules_info}" | while IFS="|" read -r submodule_name sub_branch sub_
     /usr/libexec/PlistBuddy -c "Add :${submodules_key}:${submodule_name}:commit_sha string ${sub_sha}" "${info_plist_path}"
 done
 
+# --- Patch details ---
+patches_key="com-trio-patches"
+if /usr/libexec/PlistBuddy -c "Print :${patches_key}" "${info_plist_path}" 2>/dev/null; then
+    /usr/libexec/PlistBuddy -c "Delete :${patches_key}" "${info_plist_path}"
+fi
+/usr/libexec/PlistBuddy -c "Add :${patches_key} array" "${info_plist_path}"
+
+patch_files=$(find patches -maxdepth 1 -type f -name '*.patch' -print | sort)
+patch_index=0
+printf '%s\n' "${patch_files}" | while IFS= read -r patch_file; do
+    if [ -z "${patch_file}" ]; then
+        continue
+    fi
+    patch_name=$(basename "${patch_file}")
+    patch_from_sha=$(awk 'NR==1 {print $2}' "${patch_file}")
+    patch_date=$(awk -F 'Date: ' '/^Date: / {print $2; exit}' "${patch_file}")
+    patch_subject=$(awk -F 'Subject: ' '/^Subject: / {print $2; exit}' "${patch_file}")
+    patch_name_escaped=$(printf '%s' "${patch_name}" | sed 's/"/\\"/g')
+    patch_from_sha_escaped=$(printf '%s' "${patch_from_sha}" | sed 's/"/\\"/g')
+    patch_date_escaped=$(printf '%s' "${patch_date}" | sed 's/"/\\"/g')
+    patch_subject_escaped=$(printf '%s' "${patch_subject}" | sed 's/"/\\"/g')
+
+    /usr/libexec/PlistBuddy -c "Add :${patches_key}:${patch_index} dict" "${info_plist_path}"
+    /usr/libexec/PlistBuddy -c "Add :${patches_key}:${patch_index}:name string \"${patch_name_escaped}\"" "${info_plist_path}"
+    /usr/libexec/PlistBuddy -c "Add :${patches_key}:${patch_index}:from_sha string \"${patch_from_sha_escaped}\"" "${info_plist_path}"
+    /usr/libexec/PlistBuddy -c "Add :${patches_key}:${patch_index}:date string \"${patch_date_escaped}\"" "${info_plist_path}"
+    /usr/libexec/PlistBuddy -c "Add :${patches_key}:${patch_index}:subject string \"${patch_subject_escaped}\"" "${info_plist_path}"
+    patch_index=$((patch_index + 1))
+done
+
 echo "BuildDetails.plist has been updated at: ${info_plist_path}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Replaces

Supersedes **PR #20** (branch `feature/watch-g7-direct-ble-observer-clean-cea9`), which was cut from **plain `dev` only** and did not include the **patch 01–10** watch stack (e.g. shared `TrioComplicationDataStore`).

**Please close #20** if it is still open; GitHub does not allow repointing a PR’s head branch in place, and the bot token could not close it from here.

## This PR

- **Base:** `dev` (with the same pre-merge state as the fork’s `dev` when patches 01–10 are applied, or the branch is intended to merge after those patches are on `dev` as appropriate for your process).
- **Head:** `feature/watch-g7-direct-ble-observer-patched-cea9`
- **Content:** G7 eavesdrop observer under `Trio Watch App Extension/G7/`, integrated with **`Trio Watch Shared/TrioComplicationDataStore`** (optional `dataSource` on snapshots, tie-break, no duplicate store). Scene lifecycle + `WatchState.shared` + UI recency line preserved from the patched baseline.

## Docs

`docs/in-progress/watch-g7-direct-ble-observer/` (design, plan, log).

## Human

Xcode: target membership for new/changed Swift files; build verification.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad02bb16-7fdc-4605-84e2-5846a331cea9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad02bb16-7fdc-4605-84e2-5846a331cea9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

