### PR TITLE
Add watch G7 direct BLE observer scaffold and source-aware watch UI plumbing

### DIFF
--- a/Trio Watch App Extension/G7DirectBLEObserver.swift
+++ b/Trio Watch App Extension/G7DirectBLEObserver.swift
@@ -1,0 +1,403 @@
+import CoreBluetooth
+import Foundation
+
+final class G7DirectBLEObserver: NSObject {
+    static let shared = G7DirectBLEObserver()
+
+    private enum Constants {
+        static let restoreID = "org.nightscout.trio.watch.g7-observer"
+        static let service = CBUUID(string: "F8083532-849E-531C-C594-30F1F86A4EA5")
+        static let febcService = CBUUID(string: "FEBC")
+        static let authCharacteristic = CBUUID(string: "F8083535-849E-531C-C594-30F1F86A4EA5")
+        static let controlCharacteristic = CBUUID(string: "F8083534-849E-531C-C594-30F1F86A4EA5")
+        static let backfillCharacteristic = CBUUID(string: "F8083536-849E-531C-C594-30F1F86A4EA5")
+        static let jpakeCharacteristic = CBUUID(string: "F8084533-849E-531C-C594-30F1F86A4EA5")
+        static let glucoseRequestOpcode = UInt8(0x4e)
+        static let scanTimeout: TimeInterval = 12
+        static let reconnectDelay: TimeInterval = 2
+        static let authAdvanceFallback: TimeInterval = 4
+        static let requestCadence: TimeInterval = 295
+    }
+
+    private let queue = DispatchQueue(label: "org.nightscout.trio.watch.g7-observer")
+    private lazy var central: CBCentralManager = {
+        CBCentralManager(delegate: self, queue: queue, options: [CBCentralManagerOptionRestoreIdentifierKey: Constants.restoreID])
+    }()
+
+    private var shouldRun = false
+    private var scanning = false
+    private var connectedPeripheral: CBPeripheral?
+    private var candidatePeripherals: [UUID: CBPeripheral] = [:]
+    private var authCharacteristic: CBCharacteristic?
+    private var controlCharacteristic: CBCharacteristic?
+    private var activationBaseDate: Date?
+    private var hasSentRequest = false
+    private var scanTimeoutWorkItem: DispatchWorkItem?
+    private var reconnectWorkItem: DispatchWorkItem?
+    private var requestWorkItem: DispatchWorkItem?
+    private var authFallbackWorkItem: DispatchWorkItem?
+
+    private override init() {
+        super.init()
+        _ = central
+    }
+
+    func handleSceneDidBecomeActive() {
+        queue.async {
+            self.shouldRun = true
+            self.transitionStatus(.searching)
+            self.startAttachCycle(trigger: "scene_active")
+        }
+    }
+
+    func handleSceneDidResignActive() {
+        queue.async {
+            if self.shouldRun {
+                self.transitionStatus(.searching)
+            }
+        }
+    }
+
+    func stop() {
+        queue.async {
+            self.shouldRun = false
+            self.cancelTimers()
+            if let peripheral = self.connectedPeripheral {
+                self.central.cancelPeripheralConnection(peripheral)
+            }
+            self.stopScanIfNeeded(reason: "stop")
+            self.connectedPeripheral = nil
+            self.transitionStatus(.off)
+        }
+    }
+
+    private func startAttachCycle(trigger: String) {
+        guard shouldRun else { return }
+        guard central.state == .poweredOn else {
+            log("event=g7_ble_blocked_central_state state=\(central.state.rawValue) trigger=\(trigger)")
+            transitionStatus(.unavailable)
+            return
+        }
+
+        cancelTimers()
+        hasSentRequest = false
+        authCharacteristic = nil
+        controlCharacteristic = nil
+
+        let retrieved = central.retrieveConnectedPeripherals(withServices: [Constants.service])
+        if let peripheral = choosePeripheral(from: retrieved) {
+            connect(peripheral, source: "retrieved_data_service")
+            return
+        }
+
+        let febcRetrieved = central.retrieveConnectedPeripherals(withServices: [Constants.febcService])
+        if let peripheral = choosePeripheral(from: febcRetrieved) {
+            connect(peripheral, source: "retrieved_febc")
+            return
+        }
+
+        startScan()
+    }
+
+    private func choosePeripheral(from candidates: [CBPeripheral]) -> CBPeripheral? {
+        guard !candidates.isEmpty else { return nil }
+        let sorted = candidates.sorted { lhs, rhs in
+            (lhs.name ?? "") < (rhs.name ?? "")
+        }
+        return sorted.first { candidate in
+            let name = (candidate.name ?? "").uppercased()
+            return name.contains("DXCM") || name.contains("DEXCOM") || name.contains("G7")
+        } ?? sorted.first
+    }
+
+    private func startScan() {
+        guard !scanning else { return }
+        scanning = true
+        transitionStatus(.searching)
+        log("event=g7_ble_scan_start allow_duplicates=true")
+        central.scanForPeripherals(withServices: nil, options: [CBCentralManagerScanOptionAllowDuplicatesKey: true])
+
+        let work = DispatchWorkItem { [weak self] in
+            guard let self, self.shouldRun else { return }
+            if self.connectedPeripheral != nil {
+                self.log("event=g7_ble_scan_timeout_ignored reason=already_connected")
+                return
+            }
+            self.log("event=g7_ble_scan_timeout reconnect=true")
+            self.stopScanIfNeeded(reason: "timeout")
+            self.scheduleReconnect(reason: "scan_timeout")
+        }
+        scanTimeoutWorkItem = work
+        queue.asyncAfter(deadline: .now() + Constants.scanTimeout, execute: work)
+    }
+
+    private func stopScanIfNeeded(reason: String) {
+        guard scanning else { return }
+        scanning = false
+        central.stopScan()
+        log("event=g7_ble_scan_stopped reason=\(reason)")
+    }
+
+    private func connect(_ peripheral: CBPeripheral, source: String) {
+        stopScanIfNeeded(reason: "connect_attempt")
+        connectedPeripheral = peripheral
+        peripheral.delegate = self
+        transitionStatus(.connecting)
+        log("event=g7_ble_connect_attempt source=\(source) name=\(peripheral.name ?? "nil") id=\(peripheral.identifier.uuidString)")
+        central.connect(peripheral, options: [CBConnectPeripheralOptionNotifyOnDisconnectionKey: true])
+    }
+
+    private func scheduleReconnect(reason: String) {
+        reconnectWorkItem?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            guard let self, self.shouldRun else { return }
+            self.log("event=g7_ble_reconnect_fired reason=\(reason)")
+            self.startAttachCycle(trigger: "reconnect")
+        }
+        reconnectWorkItem = work
+        queue.asyncAfter(deadline: .now() + Constants.reconnectDelay, execute: work)
+    }
+
+    private func transitionStatus(_ status: G7DirectBLEStatus) {
+        Task { @MainActor in
+            WatchState.shared.updateDirectBLEStatus(status)
+        }
+    }
+
+    private func log(_ message: String, file: String = #fileID, line: Int = #line, function: String = #function) {
+        Task {
+            await WatchLogger.shared.log(message, file: file, line: line, function: function)
+        }
+    }
+
+    private func cancelTimers() {
+        scanTimeoutWorkItem?.cancel()
+        reconnectWorkItem?.cancel()
+        requestWorkItem?.cancel()
+        authFallbackWorkItem?.cancel()
+        scanTimeoutWorkItem = nil
+        reconnectWorkItem = nil
+        requestWorkItem = nil
+        authFallbackWorkItem = nil
+    }
+
+    private func enableControlAndRequest(reason: String) {
+        guard let controlCharacteristic, let peripheral = connectedPeripheral else {
+            log("event=g7_ble_blocked_control_not_ready reason=\(reason)")
+            return
+        }
+
+        if !controlCharacteristic.isNotifying {
+            peripheral.setNotifyValue(true, for: controlCharacteristic)
+        }
+
+        sendEGVRequest(reason: reason)
+    }
+
+    private func sendEGVRequest(reason: String) {
+        guard let controlCharacteristic, let peripheral = connectedPeripheral else { return }
+        let payload = Data([Constants.glucoseRequestOpcode])
+        peripheral.writeValue(payload, for: controlCharacteristic, type: .withResponse)
+        hasSentRequest = true
+        log("event=g7_ble_egv_request_sent reason=\(reason) opcode=0x4e")
+
+        let work = DispatchWorkItem { [weak self] in
+            self?.enableControlAndRequest(reason: "cadence")
+        }
+        requestWorkItem?.cancel()
+        requestWorkItem = work
+        queue.asyncAfter(deadline: .now() + Constants.requestCadence, execute: work)
+    }
+
+    private func parseAndStoreEGV(_ data: Data) {
+        guard data.count >= 16 else { return }
+        guard data.first == Constants.glucoseRequestOpcode else { return }
+
+        let glucose = Int(UInt16(data[1]) | (UInt16(data[2]) << 8))
+        let trendRaw = Int16(bitPattern: UInt16(data[9]) | (UInt16(data[10]) << 8))
+        let messageTimestamp = UInt32(data[11]) | (UInt32(data[12]) << 8) | (UInt32(data[13]) << 16) | (UInt32(data[14]) << 24)
+        let ageSeconds = Int(data[15])
+
+        if activationBaseDate == nil {
+            activationBaseDate = Date().addingTimeInterval(-TimeInterval(messageTimestamp))
+        }
+
+        let readingDate: Date
+        if let base = activationBaseDate {
+            readingDate = base.addingTimeInterval(TimeInterval(messageTimestamp - UInt32(max(ageSeconds, 0))))
+        } else {
+            readingDate = Date().addingTimeInterval(-TimeInterval(ageSeconds))
+        }
+
+        let trend = trendArrow(for: Double(trendRaw) / 100.0)
+        let snapshot = TrioComplicationSnapshot(
+            glucose: String(glucose),
+            trend: trend,
+            delta: "--",
+            readingDate: readingDate,
+            date: Date(),
+            source: .directBLE
+        )
+
+        Task { @MainActor in
+            TrioComplicationDataStore.shared.save(snapshot, triggerReload: true, minInterval: 5)
+            WatchState.shared.currentGlucose = String(glucose)
+            WatchState.shared.trend = trend
+            WatchState.shared.delta = "--"
+            WatchState.shared.currentReadingSource = .directBLE
+            WatchState.shared.recordDirectBLEReading(readingDate)
+        }
+
+        transitionStatus(.active)
+        log("event=g7_ble_egv_received glucose=\(glucose) trend_raw=\(trendRaw) reading_epoch=\(Int(readingDate.timeIntervalSince1970))")
+    }
+
+    private func trendArrow(for mgdlPerMinute: Double) -> String {
+        switch mgdlPerMinute {
+        case let x where x <= -3: return "↓↓↓"
+        case let x where x <= -2: return "↓↓"
+        case let x where x <= -1: return "↓"
+        case let x where x < 1: return "→"
+        case let x where x < 2: return "↑"
+        case let x where x < 3: return "↑↑"
+        default: return "↑↑↑"
+        }
+    }
+}
+
+extension G7DirectBLEObserver: CBCentralManagerDelegate {
+    func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        log("event=g7_ble_lifecycle central_state=\(central.state.rawValue)")
+        guard shouldRun else { return }
+        startAttachCycle(trigger: "state_update")
+    }
+
+    func centralManager(_ central: CBCentralManager, willRestoreState dict: [String: Any]) {
+        log("event=g7_ble_lifecycle restore_state keys=\(dict.keys.sorted().joined(separator: ","))")
+    }
+
+    func centralManager(
+        _ central: CBCentralManager,
+        didDiscover peripheral: CBPeripheral,
+        advertisementData: [String: Any],
+        rssi RSSI: NSNumber
+    ) {
+        guard shouldRun else { return }
+        let name = (peripheral.name ?? "") + " " + (advertisementData[CBAdvertisementDataLocalNameKey] as? String ?? "")
+        let upper = name.uppercased()
+        let matched = upper.contains("DXCM") || upper.contains("DEXCOM") || upper.contains("G7")
+        log("event=g7_ble_peripheral_discovered matched=\(matched) name=\(name) id=\(peripheral.identifier.uuidString) rssi=\(RSSI) adv=\(advertisementData)")
+        guard matched else {
+            return
+        }
+        candidatePeripherals[peripheral.identifier] = peripheral
+        connect(peripheral, source: "scan")
+    }
+
+    func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+        guard shouldRun else { return }
+        log("event=g7_ble_did_connect id=\(peripheral.identifier.uuidString) name=\(peripheral.name ?? "nil")")
+        transitionStatus(.connecting)
+        stopScanIfNeeded(reason: "did_connect")
+        peripheral.discoverServices(nil)
+    }
+
+    func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {
+        let nsError = error as NSError?
+        log("event=g7_ble_connect_failed error_domain=\(nsError?.domain ?? "nil") error_code=\(nsError?.code ?? -1) error_desc=\(nsError?.localizedDescription ?? "nil")")
+        transitionStatus(.stalled)
+        scheduleReconnect(reason: "did_fail_to_connect")
+    }
+
+    func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
+        let nsError = error as NSError?
+        log("event=g7_ble_session_outcome outcome=incomplete final_stage=disconnect error_domain=\(nsError?.domain ?? "nil") error_code=\(nsError?.code ?? -1)")
+        connectedPeripheral = nil
+        authCharacteristic = nil
+        controlCharacteristic = nil
+        transitionStatus(.stalled)
+        scheduleReconnect(reason: "did_disconnect")
+    }
+}
+
+extension G7DirectBLEObserver: CBPeripheralDelegate {
+    func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
+        if let error {
+            log("event=g7_ble_services_discovered success=false error=\(error.localizedDescription)")
+            scheduleReconnect(reason: "discover_services_error")
+            return
+        }
+        log("event=g7_ble_services_discovered success=true service_count=\(peripheral.services?.count ?? 0)")
+        peripheral.services?.forEach { service in
+            peripheral.discoverCharacteristics(nil, for: service)
+        }
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
+        if let error {
+            log("event=g7_ble_characteristics_discovered success=false service=\(service.uuid.uuidString) error=\(error.localizedDescription)")
+            return
+        }
+
+        for characteristic in service.characteristics ?? [] {
+            let uuid = characteristic.uuid
+            if uuid == Constants.authCharacteristic {
+                authCharacteristic = characteristic
+                peripheral.setNotifyValue(true, for: characteristic)
+                log("event=g7_ble_auth_notify_enabled")
+                authFallbackWorkItem?.cancel()
+                let work = DispatchWorkItem { [weak self] in
+                    self?.enableControlAndRequest(reason: "auth_fallback_timeout")
+                }
+                authFallbackWorkItem = work
+                queue.asyncAfter(deadline: .now() + Constants.authAdvanceFallback, execute: work)
+            } else if uuid == Constants.controlCharacteristic {
+                controlCharacteristic = characteristic
+                log("event=g7_ble_control_characteristic_found")
+                if hasSentRequest {
+                    peripheral.setNotifyValue(true, for: characteristic)
+                }
+            } else if uuid == Constants.backfillCharacteristic {
+                log("event=g7_ble_backfill_skipped")
+            } else if uuid == Constants.jpakeCharacteristic {
+                log("event=g7_ble_jpake_skipped")
+            }
+        }
+
+        log("event=g7_ble_characteristics_discovered success=true service=\(service.uuid.uuidString) count=\(service.characteristics?.count ?? 0)")
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didUpdateNotificationStateFor characteristic: CBCharacteristic, error: Error?) {
+        if let error {
+            log("event=g7_ble_notify_state_failed char=\(characteristic.uuid.uuidString) error=\(error.localizedDescription)")
+            return
+        }
+        if characteristic.uuid == Constants.controlCharacteristic {
+            log("event=g7_ble_control_notify_enabled")
+        }
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
+        if let error {
+            log("event=g7_ble_update_failed char=\(characteristic.uuid.uuidString) error=\(error.localizedDescription)")
+            return
+        }
+
+        guard let data = characteristic.value else { return }
+        if characteristic.uuid == Constants.authCharacteristic {
+            log("event=g7_ble_auth_payload_received bytes=\(data as NSData)")
+            enableControlAndRequest(reason: "auth_payload")
+        } else if characteristic.uuid == Constants.controlCharacteristic {
+            parseAndStoreEGV(data)
+        }
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?) {
+        if let error {
+            log("event=g7_ble_control_write_failed error=\(error.localizedDescription)")
+            scheduleReconnect(reason: "write_failed")
+            return
+        }
+        log("event=g7_ble_control_write_ok")
+    }
+}

--- a/Trio Watch App Extension/G7DirectBLEStatus.swift
+++ b/Trio Watch App Extension/G7DirectBLEStatus.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+enum G7DirectBLEStatus: String {
+    case off
+    case searching
+    case connecting
+    case active
+    case stalled
+    case unavailable
+
+    var shortLabel: String {
+        switch self {
+        case .off: return "OFF"
+        case .searching: return "SEARCH"
+        case .connecting: return "CONN"
+        case .active: return "ACTIVE"
+        case .stalled: return "STALL"
+        case .unavailable: return "UNAV"
+        }
+    }
+}

--- a/Trio Watch App Extension/TrioWatchApp.swift
+++ b/Trio Watch App Extension/TrioWatchApp.swift
@@ -24,8 +24,10 @@ import WatchKit
 
             if newPhase == .active {
                 WatchState.shared.handleForegroundActiveEntry()
+                G7DirectBLEObserver.shared.handleSceneDidBecomeActive()
             } else if newPhase == .background || newPhase == .inactive {
                 WatchState.shared.handleForegroundInactiveOrBackground()
+                G7DirectBLEObserver.shared.handleSceneDidResignActive()
             }
 
             let forceFlush = newPhase != .active

--- a/Trio Watch App Extension/Views/GlucoseTrendView.swift
+++ b/Trio Watch App Extension/Views/GlucoseTrendView.swift
@@ -114,6 +114,26 @@ struct GlucoseTrendView: View {
         }
     }
 
+
+    private var sourceLabel: String {
+        switch state.currentReadingSource {
+        case .directBLE: return "SRC:BLE"
+        case .watchConnectivity: return "SRC:PHONE"
+        case .healthKit: return "SRC:HK"
+        case .unknown: return "SRC:--"
+        }
+    }
+
+    private var bleStatusLabel: String {
+        "BLE:\(state.directBLEStatus.shortLabel)"
+    }
+
+    private var bleRecencyLabel: String {
+        guard let lastEvent = state.directBLELastEventAt else { return "BLE:--" }
+        let age = max(0, Int(Date().timeIntervalSince(lastEvent) / 60))
+        return "BLE:\(age)m"
+    }
+
     var body: some View {
         VStack {
             ZStack {
@@ -151,11 +171,14 @@ struct GlucoseTrendView: View {
             Text(
                 isWatchStateDated ?
                     String(localized: "STALE DATA", comment: "Information displayed when watch app data outdated or stale.") :
-                    state
-                    .lastLoopTime ?? "--"
+                    "\(state.lastLoopTime ?? "--") · \(bleStatusLabel)"
             )
             .font(.system(size: minutesAgoFontSize))
             .fontWidth(isWatchStateDated ? .expanded : .standard)
+
+            Text("\(sourceLabel) · \(bleRecencyLabel)")
+                .font(.system(size: max(8, minutesAgoFontSize - 1)))
+                .foregroundStyle(.secondary)
 
             Spacer()
 

--- a/Trio Watch App Extension/Views/TrioMainWatchView.swift
+++ b/Trio Watch App Extension/Views/TrioMainWatchView.swift
@@ -132,6 +132,7 @@ struct TrioMainWatchView: View {
                         state.currentGlucoseColorString = glucoseColor
                     }
                     state.lastWatchStateUpdate = snapshot.readingDate
+                    state.currentReadingSource = snapshot.source
                     state.showSyncingAnimation = true
                 } else if let snapshot = cachedSnapshot,
                           let lastUpdate = state.lastWatchStateUpdate,
@@ -144,6 +145,7 @@ struct TrioMainWatchView: View {
                         state.currentGlucoseColorString = glucoseColor
                     }
                     state.lastWatchStateUpdate = snapshot.readingDate
+                    state.currentReadingSource = snapshot.source
                     state.showSyncingAnimation = false
                 }
 

--- a/Trio Watch App Extension/WatchState.swift
+++ b/Trio Watch App Extension/WatchState.swift
@@ -56,6 +56,11 @@ enum BackgroundTaskWindowCounter {
     var overridePresets: [OverridePresetWatch] = []
     var tempTargetPresets: [TempTargetPresetWatch] = []
 
+    var directBLEStatus: G7DirectBLEStatus = .off
+    var directBLELastEventAt: Date?
+    var directBLELastReadingAt: Date?
+    var currentReadingSource: TrioComplicationDataSource = .unknown
+
     // MARK: - Treatment inputs
 
     var carbsAmount: Int = 0
@@ -173,6 +178,18 @@ enum BackgroundTaskWindowCounter {
     private var isColdStart: Bool {
         guard let activationTimestamp = activationTimestamp else { return true }
         return Date().timeIntervalSince(activationTimestamp) < 60
+    }
+
+    func updateDirectBLEStatus(_ status: G7DirectBLEStatus, eventAt: Date = Date()) {
+        directBLEStatus = status
+        directBLELastEventAt = eventAt
+    }
+
+    func recordDirectBLEReading(_ readingDate: Date) {
+        directBLELastReadingAt = readingDate
+        directBLELastEventAt = Date()
+        currentReadingSource = .directBLE
+        lastWatchStateUpdate = readingDate
     }
 
     override init() {
@@ -664,13 +681,15 @@ enum BackgroundTaskWindowCounter {
             )
         }
 
+        currentReadingSource = .healthKit
         let snapshot = TrioComplicationSnapshot(
             glucose: glucoseString,
             trend: trendString,
             delta: deltaString,
             readingDate: readingDate,
             date: Date(),
-            glucoseColor: nil
+            glucoseColor: nil,
+            source: .healthKit
         )
 
         DispatchQueue.main.async {
@@ -1097,7 +1116,8 @@ enum BackgroundTaskWindowCounter {
             trend: payload[WatchMessageKeys.trend] as? String ?? "",
             delta: payload[WatchMessageKeys.delta] as? String ?? "",
             readingDate: readingDate,
-            date: Date()
+            date: Date(),
+            source: .watchConnectivity
         )
         if TrioComplicationDataStore.shared.shouldSkipPreDispatch(for: tempSnapshot, handler: "userInfo") {
             DispatchQueue.main.async { [weak self] in
@@ -1837,13 +1857,15 @@ enum BackgroundTaskWindowCounter {
             await WatchLogger.shared.log("🔍 Debug: glucoseValue source - message: \(message[WatchMessageKeys.currentGlucose] as? String ?? "nil"), currentGlucose: \(currentGlucose)")
         }
 
+        currentReadingSource = .watchConnectivity
         let snapshot = TrioComplicationSnapshot(
             glucose: glucoseValue,
             trend: trendValue,
             delta: deltaValue,
             readingDate: readingDate,
             date: Date(),
-            glucoseColor: glucoseColorValue
+            glucoseColor: glucoseColorValue,
+            source: .watchConnectivity
         )
 
         // Phase 3.0 — pre-dispatch dedup. saveOnMain is authoritative.
@@ -1898,13 +1920,15 @@ enum BackgroundTaskWindowCounter {
             return
         }
 
+        currentReadingSource = .watchConnectivity
         let snapshot = TrioComplicationSnapshot(
             glucose: currentGlucose,
             trend: trend ?? "",
             delta: delta ?? "",
             readingDate: effectiveReadingDate,
             date: Date(),
-            glucoseColor: currentGlucoseColorString
+            glucoseColor: currentGlucoseColorString,
+            source: .watchConnectivity
         )
 
         Task {

--- a/Trio Watch Shared/TrioComplicationDataSource.swift
+++ b/Trio Watch Shared/TrioComplicationDataSource.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+enum TrioComplicationDataSource: String, Codable, Equatable {
+    case unknown
+    case watchConnectivity
+    case healthKit
+    case directBLE
+}

--- a/Trio Watch Shared/TrioComplicationDataStore.swift
+++ b/Trio Watch Shared/TrioComplicationDataStore.swift
@@ -18,6 +18,7 @@ struct TrioComplicationSnapshot: Equatable, Codable {
     let readingDate: Date
     let state: String?
     let glucoseColor: String?
+    let source: TrioComplicationDataSource
 
     // INVARIANT (Phase 3.4): All display-field sanitization here.
     // Dedup always compares sanitized values.
@@ -28,7 +29,8 @@ struct TrioComplicationSnapshot: Equatable, Codable {
         readingDate: Date,
         date: Date,
         state: String? = nil,
-        glucoseColor: String? = nil
+        glucoseColor: String? = nil,
+        source: TrioComplicationDataSource = .unknown
     ) {
         glucose = Self.sanitizedGlucose(from: rawGlucose)
         trend = rawTrend.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -37,6 +39,7 @@ struct TrioComplicationSnapshot: Equatable, Codable {
         self.date = date
         self.state = state
         self.glucoseColor = glucoseColor
+        self.source = source
     }
 
     private static func sanitizedGlucose(from value: String) -> String {
@@ -81,6 +84,43 @@ struct TrioComplicationSnapshot: Equatable, Codable {
     }
 }
 
+extension TrioComplicationSnapshot {
+    private enum CodingKeys: String, CodingKey {
+        case glucose
+        case trend
+        case delta
+        case date
+        case readingDate
+        case state
+        case glucoseColor
+        case source
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        glucose = try container.decode(String.self, forKey: .glucose)
+        trend = try container.decode(String.self, forKey: .trend)
+        delta = try container.decode(String.self, forKey: .delta)
+        date = try container.decode(Date.self, forKey: .date)
+        readingDate = try container.decode(Date.self, forKey: .readingDate)
+        state = try container.decodeIfPresent(String.self, forKey: .state)
+        glucoseColor = try container.decodeIfPresent(String.self, forKey: .glucoseColor)
+        source = try container.decodeIfPresent(TrioComplicationDataSource.self, forKey: .source) ?? .unknown
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(glucose, forKey: .glucose)
+        try container.encode(trend, forKey: .trend)
+        try container.encode(delta, forKey: .delta)
+        try container.encode(date, forKey: .date)
+        try container.encode(readingDate, forKey: .readingDate)
+        try container.encodeIfPresent(state, forKey: .state)
+        try container.encodeIfPresent(glucoseColor, forKey: .glucoseColor)
+        try container.encode(source, forKey: .source)
+    }
+}
+
 // Phase 3.0 — pre-dispatch dedup. saveOnMain is authoritative.
 // glucoseColor excluded: see shouldUpdate comment (Phase 3.2) for rationale.
 struct ComplicationSnapshotFingerprint: Codable, Equatable {
@@ -89,6 +129,7 @@ struct ComplicationSnapshotFingerprint: Codable, Equatable {
     let trend: String
     let delta: String
     let state: String
+    let source: String?
 }
 
 extension ComplicationSnapshotFingerprint {
@@ -100,6 +141,7 @@ extension ComplicationSnapshotFingerprint {
         // Sentinel for nil: state is always optional in the model; sentinel ensures
         // nil and non-nil are always distinguishable in Equatable comparison.
         state = snapshot.state ?? "<nil>"
+        source = snapshot.source.rawValue
     }
 }
 
@@ -629,7 +671,8 @@ final class TrioComplicationDataStore {
             delta: delta ?? "",
             readingDate: readingDate,
             date: date,
-            glucoseColor: glucoseColor
+            glucoseColor: glucoseColor,
+            source: .unknown
         )
         save(snapshot, triggerReload: triggerReload)
     }

--- a/docs/in-progress/watch-g7-direct-ble-observer/01-design.md
+++ b/docs/in-progress/watch-g7-direct-ble-observer/01-design.md
@@ -1,0 +1,82 @@
+# Watch G7 Direct BLE Observer — Design
+
+## Mission and premise
+Implement a watch-only Dexcom G7 observer that piggybacks on the same-device BLE session owned by the Dexcom G7 watch app, then writes EGV readings into `TrioComplicationDataStore` for faster watch freshness.
+
+## Reference validation
+Fetched and reviewed the required DiaBLE + G7SensorKit files before implementation (using GitHub URLs). Core mechanics were taken from their shared behavior: eager restoration-backed central, broad service/characteristic discovery, auth notify observation, control write for glucose request, and control notify for payload delivery.
+
+## Observer sequence
+1. Create long-lived `CBCentralManager` with restoration identifier at app lifetime.
+2. On `.active`, attempt attach via `retrieveConnectedPeripherals(withServices:)` using G7 data-service UUID then FEBC UUID.
+3. If retrieval misses, start broad scan and match Dexcom-like names from discovered peripherals.
+4. Connect; discover services/characteristics with `nil` breadth.
+5. Enable auth notifications.
+6. Observe auth notifications (never respond, never write auth, never J-PAKE writes).
+7. Enable control notifications and write opcode `0x4e` (glucose request).
+8. Parse control response into glucose/trend/time, build snapshot, persist with `source=.directBLE`.
+9. Keep request cadence running to sustain multiple reads over time.
+
+## Attach strategy
+Primary: connected-service retrieval; fallback: scan. This matches high-fidelity reference behavior and prioritizes immediate piggyback attach to the session already held by Dexcom.
+
+## Filtering choice
+Used standalone tolerant matching (DiaBLE-like) by peripheral/advertised name patterns (`DXCM`/`DEXCOM`/`G7`) to avoid optional iPhone dependencies for this pass.
+
+## Auth advance + request cadence
+Advance condition: first auth payload observed OR auth-fallback timeout (4s) after auth notify enable. This avoids permanent stalls if a strict auth state never appears on the observer side.
+Cadence: immediate request after advance, then repeat every ~295s while connected.
+
+## Reconnect model
+On fail/disconnect/timeout, schedule reconnect with simple 2s delay; no permanent give-up while active.
+
+## Scene/lifecycle
+- Start/resume on `.active`.
+- `.inactive`/`.background` do not hard-stop BLE manager; they only update status.
+- `stop()` exists as explicit hard-off API.
+- No `WKExtendedRuntimeSession` in this pass.
+
+## UI indicator
+Integrated into existing recency line:
+- `"<loop recency> · BLE:<status>"`
+- second line: `"SRC:<BLE|PHONE|HK|--> · BLE:<last-event-age>"`
+This gives both live observer status and source attribution for the displayed reading.
+
+## Source attribution model
+Added `TrioComplicationDataSource` and stored `source` in `TrioComplicationSnapshot`.
+- WatchConnectivity saves as `.watchConnectivity`
+- HealthKit saves as `.healthKit`
+- Observer saves as `.directBLE`
+
+## Observability
+All observer logs use `WatchLogger` with `event=g7_ble_*` taxonomy including discovery details, attach source, notify setup, payload reception, write outcomes, and reconnect reasons.
+
+## Open design questions and decisions
+1. Filtering: standalone tolerant matching (max autonomy, fewer dependencies).
+2. Attach ladder: retrieve data-service, retrieve FEBC, then scan.
+3. Discovery breadth: `discoverServices(nil)` + `discoverCharacteristics(nil, for:)` (reference-aligned tolerance).
+4. Timeouts: scan 12s, reconnect 2s, auth fallback 4s.
+5. Queue: dedicated serial CB queue; MainActor hop for UI/store writes.
+6. Restoration: enabled; logs restored keys.
+7. connect options: set notify-on-disconnect true.
+8. Auth gate: payload-or-timeout to avoid strict-state deadlock.
+9. EGV cadence: immediate + periodic 295s.
+10. Write failure: reconnect.
+11. Backfill: discover + log skipped.
+12. Stop scan after connect: yes.
+13. Multi-peripheral: pick first matching discovery/retrieval candidate.
+14. Identifier persistence: none in this pass.
+15. Delta on watch: left as `--` for direct BLE path.
+16. Winner policy: existing store dedup/minInterval + latest reading recency.
+17. UI palette: off/searching/connecting/active/stalled/unavailable.
+18. Active-name mid-session: not applicable (no iPhone filter bridge).
+19. Attach-ladder cadence: single sweep then reconnect retry loop.
+
+## Deviations from references
+- Did not add backfill parsing in this pass (logged as skipped).
+- Simplified auth advance (payload/timeout) vs strict auth-state interpretation to prioritize sustained reads.
+
+## Risks / device-test questions
+- Exact control payload layout may vary; parser assumptions need on-device validation.
+- Some Dexcom configurations may require tighter auth-state interpretation.
+- Multi-sensor environments may require stronger disambiguation than name heuristics.

--- a/docs/in-progress/watch-g7-direct-ble-observer/02-implementation-plan.md
+++ b/docs/in-progress/watch-g7-direct-ble-observer/02-implementation-plan.md
@@ -1,0 +1,28 @@
+# Watch G7 Direct BLE Observer — Implementation Plan
+
+## New files
+- `Trio Watch App Extension/G7DirectBLEObserver.swift` — CoreBluetooth observer manager and protocol flow.
+- `Trio Watch App Extension/G7DirectBLEStatus.swift` — glanceable BLE status model for UI.
+- `Trio Watch Shared/TrioComplicationDataSource.swift` — shared snapshot source attribution enum.
+
+## Existing files to modify
+- `Trio Watch App Extension/TrioWatchApp.swift` — scene-phase start/resume hooks.
+- `Trio Watch App Extension/WatchState.swift` — observer status/source fields and direct BLE state updates.
+- `Trio Watch App Extension/Views/TrioMainWatchView.swift` — load source from cached snapshot.
+- `Trio Watch App Extension/Views/GlucoseTrendView.swift` — add BLE status/source indicators.
+- `Trio Watch Shared/TrioComplicationDataStore.swift` — extend snapshot/fingerprint model with source attribution.
+
+## Phases
+1. Add shared source attribution model.
+2. Extend snapshot/store model with source field.
+3. Implement BLE observer manager (central lifecycle, attach ladder, discovery, auth observe, control write, parse/save, reconnect).
+4. Wire scene lifecycle start/resume into watch app.
+5. Add watch state fields for BLE status + last event + source.
+6. Add UI status/source indicators in main glucose trend view.
+7. Static review pass for invariants and anti-patterns.
+
+## Sequencing rationale
+Data model first prevents temporary parallel storage pathways. Observer second establishes data path. UI last consumes stable state fields.
+
+## Tests for this pass
+No compile/build per constraints. Validation is static review + targeted grep checks for forbidden auth writes/J-PAKE ownership behavior and scene-gated reconnect anti-patterns.

--- a/docs/in-progress/watch-g7-direct-ble-observer/03-implementation-log.md
+++ b/docs/in-progress/watch-g7-direct-ble-observer/03-implementation-log.md
@@ -1,0 +1,31 @@
+# Watch G7 Direct BLE Observer — Implementation Log
+
+## Branch and base
+- Branch: `feature/watch-g7-direct-ble-observer-a`
+- Requested base: `baseline-dev-patches-01-10`
+- Environment note: that base branch was not present in this local clone; work was started from current local branch state.
+
+## Phase log
+1. **Reference fetch**
+   - Raw GitHub URLs returned 403 from shell `curl`, so references were fetched via GitHub blob URLs in the web fetch tool.
+2. **Data model extension**
+   - Added `TrioComplicationDataSource`.
+   - Extended snapshot and dedup fingerprint to carry `source`.
+   - Updated existing WatchConnectivity/HealthKit snapshot writes to set source.
+3. **Observer implementation**
+   - Added `G7DirectBLEObserver` with eager restoration-backed central, retrieval+scan attach ladder, auth observation, control writes (`0x4e`), periodic requests, reconnect loop, and structured `g7_ble_*` logs.
+4. **State + UI integration**
+   - Added BLE status/event/source fields in `WatchState`.
+   - Wired scene active/inactive calls from `TrioWatchApp`.
+   - Updated main trend UI to show BLE status and source attribution.
+
+## Plan changes during implementation
+- Kept backfill as explicit "discovered + skipped" (documented) instead of implementing active backfill parsing in this pass.
+
+## Validation performed
+- Static review completed across all touched files.
+- Grep-based checks for prohibited auth-init/J-PAKE ownership writes and reconnect anti-patterns.
+
+## Final handoff state
+- Done: docs, observer source, shared data-source plumbing, UI indicator integration.
+- Pending human step: Xcode target membership + compile/device verification in Xcode.


### PR DESCRIPTION
### Motivation
- Add a clean-room watch-only Dexcom G7 observer that piggybacks on the Dexcom G7 watch app's same-device BLE session and delivers multiple EGV readings into the existing complication pipeline for faster complication freshness. 
- Provide source attribution and a glanceable BLE status indicator so the UI and complication pipeline can distinguish direct-BLE-delivered readings from WatchConnectivity/HealthKit paths.

### Description
- Implemented a new `G7DirectBLEObserver` (watch extension) that allocates a restoration-backed `CBCentralManager`, uses a retrieval+scan attach ladder (`retrieveConnectedPeripherals(withServices:)` on G7 service + FEBC, then scan), discovers services with `discoverServices(nil)`, observes auth notifications only (never writes auth/J-PAKE), enables control notify and writes the glucose-request opcode (`0x4e`), parses control responses into EGV snapshots, and runs a periodic request cadence plus a simple reconnect/backoff loop.  
- Added `G7DirectBLEStatus` for glanceable observer state, `TrioComplicationDataSource` to model snapshot source, and extended `TrioComplicationSnapshot`/fingerprint to carry `source` (with decoder fallback to `.unknown`) so existing store dedup and WidgetKit flows remain intact.  
- Wired observer lifecycle into scene-phase events in `TrioWatchApp`, added watch-state fields/methods in `WatchState` to track BLE status/last-event/last-reading and to mark the current reading source, and updated main watch UI (`GlucoseTrendView` / `TrioMainWatchView`) to show BLE status and source-of-reading.  
- Added docs under `docs/in-progress/watch-g7-direct-ble-observer/` (design, implementation plan, implementation log) and kept the implementation intentionally observer-only (no auth-init writes, no J-PAKE ownership, backfill discovered+logged but skipped in this pass). No Xcode project file edits or build/script runs were performed.

### Testing
- Performed a static review and automated grep checks to validate that no auth-init/J-PAKE ownership writes appear in the new observer code and that reconnect/scan timeout anti-patterns are not present, and these checks passed.  
- Ran `git diff --check` and basic `rg` searches for the new event taxonomy and integration points; no whitespace/hunk issues or forbidden patterns were reported.  
- Committed the change on branch `feature/watch-g7-direct-ble-observer-a` (commit `15daf69a`); note that raw `curl` of reference raw URLs returned HTTP 403 in this environment and references were validated via GitHub blob pages instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ebb81432708324a8fb694c9335bc69)