### PR TITLE
Add watch Dexcom G7 direct BLE observer scaffold and source-attributed UI status

### DIFF
--- a/Trio Watch App Extension/G7DirectBLEObserver.swift
+++ b/Trio Watch App Extension/G7DirectBLEObserver.swift
@@ -1,0 +1,371 @@
+import CoreBluetooth
+import Foundation
+
+@MainActor
+final class G7DirectBLEObserver: NSObject {
+    enum Status: String {
+        case off, searching, connecting, active, stalled, unavailable
+
+        var shortLabel: String {
+            switch self {
+            case .off: return "off"
+            case .searching: return "search"
+            case .connecting: return "conn"
+            case .active: return "active"
+            case .stalled: return "stalled"
+            case .unavailable: return "unavail"
+            }
+        }
+    }
+
+    private enum UUIDs {
+        static let advertisement = CBUUID(string: "FEBC")
+        static let dataService = CBUUID(string: "F8083532-849E-531C-C594-30F1F86A4EA5")
+        static let authentication = CBUUID(string: "F8083535-849E-531C-C594-30F1F86A4EA5")
+        static let control = CBUUID(string: "F8083534-849E-531C-C594-30F1F86A4EA5")
+        static let backfill = CBUUID(string: "F8083536-849E-531C-C594-30F1F86A4EA5")
+        static let jpake = CBUUID(string: "F8083538-849E-531C-C594-30F1F86A4EA5")
+    }
+
+    private enum Opcode {
+        static let glucose = UInt8(0x4E)
+        static let authStatus = UInt8(0x05)
+    }
+
+    private let onReading: (TrioComplicationSnapshot) -> Void
+    private let onStatus: (Status, Date?) -> Void
+
+    private lazy var central = CBCentralManager(
+        delegate: self,
+        queue: nil,
+        options: [CBCentralManagerOptionRestoreIdentifierKey: "org.nightscout.trio.watch.g7observer"]
+    )
+
+    private var activePeripheral: CBPeripheral?
+    private var authCharacteristic: CBCharacteristic?
+    private var controlCharacteristic: CBCharacteristic?
+    private var authReady = false
+    private var controlReady = false
+    private var seenAuthenticatedState = false
+    private var reconnectTask: Task<Void, Never>?
+    private var isRunning = false
+    private var lastDirectBLEEventAt: Date?
+    private var lastEGVDate: Date?
+
+    init(onReading: @escaping (TrioComplicationSnapshot) -> Void, onStatus: @escaping (Status, Date?) -> Void) {
+        self.onReading = onReading
+        self.onStatus = onStatus
+        super.init()
+        _ = central
+    }
+
+    func start() {
+        isRunning = true
+        Task { await log("event=g7_ble_lifecycle action=start") }
+        attemptAttach()
+    }
+
+    func stop() {
+        isRunning = false
+        reconnectTask?.cancel()
+        reconnectTask = nil
+        if let activePeripheral {
+            central.cancelPeripheralConnection(activePeripheral)
+        }
+        updateStatus(.off)
+        Task { await log("event=g7_ble_lifecycle action=stop") }
+    }
+
+    func sceneDidBecomeActive() {
+        guard isRunning else { return }
+        reconnectTask?.cancel()
+        attemptAttach()
+    }
+
+    func sceneDidResignActive() {
+        guard isRunning else { return }
+        Task { await log("event=g7_ble_lifecycle action=scene_inactive note=no_forced_disconnect") }
+    }
+
+    private func attemptAttach() {
+        guard isRunning else { return }
+        guard central.state == .poweredOn else {
+            updateStatus(.unavailable)
+            return
+        }
+
+        if let connected = central.retrieveConnectedPeripherals(withServices: [UUIDs.dataService]).first {
+            Task { await log("event=g7_ble_connect_attempt source=retrieved_data_service id=\(connected.identifier.uuidString) name=\(connected.name ?? "nil")") }
+            connect(to: connected)
+            return
+        }
+
+        updateStatus(.searching)
+        Task { await log("event=g7_ble_scan_start mode=febc") }
+        central.scanForPeripherals(withServices: [UUIDs.advertisement], options: [CBCentralManagerScanOptionAllowDuplicatesKey: true])
+    }
+
+    private func connect(to peripheral: CBPeripheral) {
+        activePeripheral = peripheral
+        peripheral.delegate = self
+        updateStatus(.connecting)
+        central.stopScan()
+        central.connect(peripheral, options: [CBConnectPeripheralOptionNotifyOnDisconnectionKey: true])
+    }
+
+    private func scheduleReconnect(reason: String) {
+        guard isRunning else { return }
+        reconnectTask?.cancel()
+        reconnectTask = Task { [weak self] in
+            guard let self else { return }
+            await log("event=g7_ble_reconnect_scheduled reason=\(reason) delay_s=3")
+            try? await Task.sleep(nanoseconds: 3_000_000_000)
+            guard !Task.isCancelled else { return }
+            self.attemptAttach()
+        }
+    }
+
+    private func updateStatus(_ newStatus: Status) {
+        onStatus(newStatus, lastDirectBLEEventAt)
+    }
+
+    private func requestEGV(trigger: String) {
+        guard let activePeripheral, let controlCharacteristic else {
+            Task { await log("event=g7_ble_blocked_request reason=control_not_ready") }
+            return
+        }
+        activePeripheral.writeValue(Data([Opcode.glucose]), for: controlCharacteristic, type: .withResponse)
+        Task { await log("event=g7_ble_egv_request_sent trigger=\(trigger) opcode=0x4E") }
+    }
+
+    private func maybePromoteToActive() {
+        if authReady, controlReady, seenAuthenticatedState {
+            updateStatus(.active)
+            requestEGV(trigger: "auth_ready")
+        }
+    }
+
+    private func parseEGV(_ data: Data) -> TrioComplicationSnapshot? {
+        guard data.count >= 14 else { return nil }
+        let opcode = data[0]
+        guard opcode == Opcode.glucose else { return nil }
+
+        let glucose = Int(data.readUInt16LE(at: 1) & 0x0FFF)
+        let trendRaw = Int(Int8(bitPattern: data[3]))
+        let txTime = Int(data.readUInt32LE(at: 4))
+        let age = Int(data.readUInt16LE(at: 10))
+        let now = Date()
+
+        let activationDate: Date
+        if let lastEGVDate {
+            activationDate = lastEGVDate.addingTimeInterval(TimeInterval(-max(age, 0)))
+        } else {
+            activationDate = now.addingTimeInterval(TimeInterval(-txTime))
+        }
+        let readingDate = activationDate.addingTimeInterval(TimeInterval(txTime - age))
+
+        let delta = "--"
+        let trend = Self.arrow(for: trendRaw)
+
+        return TrioComplicationSnapshot(
+            glucose: String(glucose),
+            trend: trend,
+            delta: delta,
+            readingDate: readingDate,
+            date: now,
+            glucoseColor: nil,
+            source: .directBLE
+        )
+    }
+
+    private static func arrow(for trend: Int) -> String {
+        switch trend {
+        case ..<(-3): return "↓↓"
+        case -3 ..< -1: return "↓"
+        case -1 ... 1: return "→"
+        case 2 ... 3: return "↑"
+        default: return "↑↑"
+        }
+    }
+
+    private func log(_ line: String, file: String = #fileID, function: String = #function, lineNumber: Int = #line) async {
+        await WatchLogger.shared.log(line, file: file, function: function, line: lineNumber)
+    }
+}
+
+extension G7DirectBLEObserver: CBCentralManagerDelegate {
+    nonisolated func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            await log("event=g7_ble_central_state state=\(central.state.rawValue)")
+            if self.isRunning {
+                self.attemptAttach()
+            }
+        }
+    }
+
+    nonisolated func centralManager(_ central: CBCentralManager, willRestoreState dict: [String: Any]) {
+        Task { @MainActor [weak self] in
+            await self?.log("event=g7_ble_restore keys=\(dict.keys.joined(separator: ","))")
+        }
+    }
+
+    nonisolated func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral, advertisementData: [String: Any], rssi RSSI: NSNumber) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let name = peripheral.name ?? "nil"
+            await log("event=g7_ble_peripheral_discovered id=\(peripheral.identifier.uuidString) name=\(name) rssi=\(RSSI.intValue) adv=\(advertisementData)")
+            guard name.lowercased().contains("dexcom") || name.uppercased().hasPrefix("DX") else {
+                await log("event=g7_ble_peripheral_skipped reason=name_filter name=\(name)")
+                return
+            }
+            await log("event=g7_ble_connect_attempt source=scan id=\(peripheral.identifier.uuidString) name=\(name)")
+            self.connect(to: peripheral)
+        }
+    }
+
+    nonisolated func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            await log("event=g7_ble_did_connect id=\(peripheral.identifier.uuidString)")
+            self.updateStatus(.connecting)
+            peripheral.discoverServices(nil)
+        }
+    }
+
+    nonisolated func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            await log("event=g7_ble_disconnect id=\(peripheral.identifier.uuidString) error=\(error?.localizedDescription ?? "nil")")
+            self.authCharacteristic = nil
+            self.controlCharacteristic = nil
+            self.authReady = false
+            self.controlReady = false
+            self.seenAuthenticatedState = false
+            if self.isRunning {
+                self.updateStatus(.stalled)
+                self.scheduleReconnect(reason: "disconnect")
+            }
+        }
+    }
+
+    nonisolated func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let nserr = error as NSError?
+            await log("event=g7_ble_connect_failed error_domain=\(nserr?.domain ?? "nil") error_code=\(nserr?.code ?? -1) error_desc=\(error?.localizedDescription ?? "nil")")
+            self.updateStatus(.stalled)
+            self.scheduleReconnect(reason: "connect_failed")
+        }
+    }
+}
+
+extension G7DirectBLEObserver: CBPeripheralDelegate {
+    nonisolated func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            await log("event=g7_ble_services_discovered id=\(peripheral.identifier.uuidString) error=\(error?.localizedDescription ?? "nil")")
+            peripheral.services?.forEach { service in
+                peripheral.discoverCharacteristics(nil, for: service)
+            }
+        }
+    }
+
+    nonisolated func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            await log("event=g7_ble_characteristics_discovered service=\(service.uuid.uuidString) error=\(error?.localizedDescription ?? "nil")")
+
+            for characteristic in service.characteristics ?? [] {
+                switch characteristic.uuid {
+                case UUIDs.authentication:
+                    self.authCharacteristic = characteristic
+                    peripheral.setNotifyValue(true, for: characteristic)
+                case UUIDs.control:
+                    self.controlCharacteristic = characteristic
+                    peripheral.setNotifyValue(true, for: characteristic)
+                case UUIDs.backfill:
+                    await log("event=g7_ble_backfill_skipped")
+                case UUIDs.jpake:
+                    await log("event=g7_ble_jpake_skipped mode=observer")
+                default:
+                    break
+                }
+            }
+        }
+    }
+
+    nonisolated func peripheral(_ peripheral: CBPeripheral, didUpdateNotificationStateFor characteristic: CBCharacteristic, error: Error?) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            if characteristic.uuid == UUIDs.authentication {
+                self.authReady = (error == nil)
+                await log("event=g7_ble_auth_notify_enabled ok=\(error == nil)")
+            }
+            if characteristic.uuid == UUIDs.control {
+                self.controlReady = (error == nil)
+                await log("event=g7_ble_control_notify_enabled ok=\(error == nil)")
+            }
+            self.maybePromoteToActive()
+        }
+    }
+
+    nonisolated func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            guard error == nil, let data = characteristic.value else {
+                await log("event=g7_ble_update_value_error char=\(characteristic.uuid.uuidString) error=\(error?.localizedDescription ?? "nil")")
+                return
+            }
+
+            if characteristic.uuid == UUIDs.authentication {
+                await log("event=g7_ble_auth_payload_received bytes=\(data.map { String(format: "%02X", $0) }.joined())")
+                if data.first == Opcode.authStatus, data.count > 1, data[1] > 0 {
+                    self.seenAuthenticatedState = true
+                    self.maybePromoteToActive()
+                }
+                return
+            }
+
+            if characteristic.uuid == UUIDs.control {
+                if let snapshot = self.parseEGV(data) {
+                    self.lastDirectBLEEventAt = Date()
+                    self.lastEGVDate = snapshot.readingDate
+                    self.onReading(snapshot)
+                    self.onStatus(.active, self.lastDirectBLEEventAt)
+                    await log("event=g7_ble_egv_received glucose=\(snapshot.glucose) reading_epoch=\(Int(snapshot.readingDate.timeIntervalSince1970))")
+                } else {
+                    await log("event=g7_ble_control_payload_received bytes=\(data.map { String(format: "%02X", $0) }.joined())")
+                }
+            }
+        }
+    }
+
+    nonisolated func peripheral(_ peripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            if let error {
+                await log("event=g7_ble_control_write_failed error=\(error.localizedDescription)")
+                self.scheduleReconnect(reason: "control_write_failed")
+            } else {
+                await log("event=g7_ble_write_ok char=\(characteristic.uuid.uuidString)")
+            }
+        }
+    }
+}
+
+private extension Data {
+    func readUInt16LE(at offset: Int) -> UInt16 {
+        guard offset + 2 <= count else { return 0 }
+        return withUnsafeBytes { raw in
+            raw.load(fromByteOffset: offset, as: UInt16.self).littleEndian
+        }
+    }
+
+    func readUInt32LE(at offset: Int) -> UInt32 {
+        guard offset + 4 <= count else { return 0 }
+        return withUnsafeBytes { raw in
+            raw.load(fromByteOffset: offset, as: UInt32.self).littleEndian
+        }
+    }
+}

--- a/Trio Watch App Extension/Views/GlucoseTrendView.swift
+++ b/Trio Watch App Extension/Views/GlucoseTrendView.swift
@@ -148,12 +148,7 @@ struct GlucoseTrendView: View {
 
             Spacer()
 
-            Text(
-                isWatchStateDated ?
-                    String(localized: "STALE DATA", comment: "Information displayed when watch app data outdated or stale.") :
-                    state
-                    .lastLoopTime ?? "--"
-            )
+            Text(state.g7BLEStatusLine(isWatchStateDated: isWatchStateDated))
             .font(.system(size: minutesAgoFontSize))
             .fontWidth(isWatchStateDated ? .expanded : .standard)
 

--- a/Trio Watch App Extension/Views/TrioMainWatchView.swift
+++ b/Trio Watch App Extension/Views/TrioMainWatchView.swift
@@ -132,6 +132,7 @@ struct TrioMainWatchView: View {
                         state.currentGlucoseColorString = glucoseColor
                     }
                     state.lastWatchStateUpdate = snapshot.readingDate
+                    state.currentComplicationSource = snapshot.source
                     state.showSyncingAnimation = true
                 } else if let snapshot = cachedSnapshot,
                           let lastUpdate = state.lastWatchStateUpdate,
@@ -144,6 +145,7 @@ struct TrioMainWatchView: View {
                         state.currentGlucoseColorString = glucoseColor
                     }
                     state.lastWatchStateUpdate = snapshot.readingDate
+                    state.currentComplicationSource = snapshot.source
                     state.showSyncingAnimation = false
                 }
 

--- a/Trio Watch App Extension/WatchState.swift
+++ b/Trio Watch App Extension/WatchState.swift
@@ -53,6 +53,9 @@ enum BackgroundTaskWindowCounter {
     var cob: String? = "--"
     var iob: String? = "--"
     var lastLoopTime: String? = "--"
+    var g7BLEStatus: String = "off"
+    var g7BLELastEventAt: Date?
+    var currentComplicationSource: TrioComplicationDataSource = .unknown
     var overridePresets: [OverridePresetWatch] = []
     var tempTargetPresets: [TempTargetPresetWatch] = []
 
@@ -170,6 +173,8 @@ enum BackgroundTaskWindowCounter {
 
     var deviceType = WatchSize.current
 
+    private var g7DirectBLEObserver: G7DirectBLEObserver?
+
     private var isColdStart: Bool {
         guard let activationTimestamp = activationTimestamp else { return true }
         return Date().timeIntervalSince(activationTimestamp) < 60
@@ -178,11 +183,43 @@ enum BackgroundTaskWindowCounter {
     override init() {
         super.init()
         setupSession()
+        setupG7DirectBLEObserver()
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
             self.forceComplicationUpdate()
             self.scheduleBackgroundRefresh()
         }
+    }
+
+    private func setupG7DirectBLEObserver() {
+        g7DirectBLEObserver = G7DirectBLEObserver(
+            onReading: { [weak self] snapshot in
+                guard let self else { return }
+                TrioComplicationDataStore.shared.save(snapshot, minInterval: 5)
+                self.currentComplicationSource = .directBLE
+                self.currentGlucose = snapshot.glucose
+                self.trend = snapshot.trend
+                self.delta = snapshot.delta
+                self.lastWatchStateUpdate = snapshot.readingDate
+            },
+            onStatus: { [weak self] status, lastEventAt in
+                guard let self else { return }
+                self.g7BLEStatus = status.shortLabel
+                self.g7BLELastEventAt = lastEventAt
+            }
+        )
+    }
+
+    func g7BLEStatusLine(isWatchStateDated: Bool) -> String {
+        let recency = isWatchStateDated ? String(localized: "STALE DATA", comment: "Information displayed when watch app data outdated or stale.") : (lastLoopTime ?? "--")
+        let source = currentComplicationSource.shortLabel
+        let bleEvent = g7BLELastEventAt.map { "ble \(Self.minutesAgoText(since: $0))" } ?? "ble --"
+        return "\(recency) · \(source) · BLE:\(g7BLEStatus) · \(bleEvent)"
+    }
+
+    private static func minutesAgoText(since date: Date) -> String {
+        let minutes = max(0, Int(Date().timeIntervalSince(date) / 60.0))
+        return "\(minutes)m"
     }
 
     func noteAppBecameActive() {
@@ -231,6 +268,8 @@ enum BackgroundTaskWindowCounter {
         startupBackgroundLaunchDisarmWorkItem = nil
         WatchStartupTransportGate.arm(activationSequence: activationSequence)
         noteAppBecameActive()
+        g7DirectBLEObserver?.start()
+        g7DirectBLEObserver?.sceneDidBecomeActive()
         WatchErrorReporter.markBecameActiveImmediately()
         scheduleStartupSequenceOnMain(activationSequence: activationSequence)
 
@@ -258,6 +297,7 @@ enum BackgroundTaskWindowCounter {
         let pendingTasks = startupPendingTasksFieldOnMain()
         cancelStartupSequenceOnMain()
         startupCurrentActivationSequence = nil
+        g7DirectBLEObserver?.sceneDidResignActive()
         WatchErrorReporter.markEnteredBackgroundOrInactiveImmediately()
 
         if let activationSequence {
@@ -670,7 +710,8 @@ enum BackgroundTaskWindowCounter {
             delta: deltaString,
             readingDate: readingDate,
             date: Date(),
-            glucoseColor: nil
+            glucoseColor: nil,
+            source: .healthKit
         )
 
         DispatchQueue.main.async {
@@ -1843,7 +1884,8 @@ enum BackgroundTaskWindowCounter {
             delta: deltaValue,
             readingDate: readingDate,
             date: Date(),
-            glucoseColor: glucoseColorValue
+            glucoseColor: glucoseColorValue,
+            source: .watchConnectivity
         )
 
         // Phase 3.0 — pre-dispatch dedup. saveOnMain is authoritative.
@@ -1904,7 +1946,8 @@ enum BackgroundTaskWindowCounter {
             delta: delta ?? "",
             readingDate: effectiveReadingDate,
             date: Date(),
-            glucoseColor: currentGlucoseColorString
+            glucoseColor: currentGlucoseColorString,
+            source: currentComplicationSource
         )
 
         Task {
@@ -2077,6 +2120,7 @@ enum BackgroundTaskWindowCounter {
                 self.currentGlucoseColorString = glucoseColor
             }
             self.lastWatchStateUpdate = snapshot.readingDate
+            self.currentComplicationSource = snapshot.source
             self.showSyncingAnimation = false
             self.syncTimeoutWorkItem?.cancel()
         }

--- a/Trio Watch Shared/TrioComplicationDataSource.swift
+++ b/Trio Watch Shared/TrioComplicationDataSource.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+enum TrioComplicationDataSource: String, Codable {
+    case watchConnectivity
+    case healthKit
+    case directBLE
+    case unknown
+
+    var shortLabel: String {
+        switch self {
+        case .watchConnectivity: return "PHONE"
+        case .healthKit: return "HK"
+        case .directBLE: return "BLE"
+        case .unknown: return "?"
+        }
+    }
+}

--- a/Trio Watch Shared/TrioComplicationDataStore.swift
+++ b/Trio Watch Shared/TrioComplicationDataStore.swift
@@ -18,6 +18,7 @@ struct TrioComplicationSnapshot: Equatable, Codable {
     let readingDate: Date
     let state: String?
     let glucoseColor: String?
+    let source: TrioComplicationDataSource
 
     // INVARIANT (Phase 3.4): All display-field sanitization here.
     // Dedup always compares sanitized values.
@@ -28,7 +29,8 @@ struct TrioComplicationSnapshot: Equatable, Codable {
         readingDate: Date,
         date: Date,
         state: String? = nil,
-        glucoseColor: String? = nil
+        glucoseColor: String? = nil,
+        source: TrioComplicationDataSource = .unknown
     ) {
         glucose = Self.sanitizedGlucose(from: rawGlucose)
         trend = rawTrend.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -37,6 +39,7 @@ struct TrioComplicationSnapshot: Equatable, Codable {
         self.date = date
         self.state = state
         self.glucoseColor = glucoseColor
+        self.source = source
     }
 
     private static func sanitizedGlucose(from value: String) -> String {
@@ -89,6 +92,7 @@ struct ComplicationSnapshotFingerprint: Codable, Equatable {
     let trend: String
     let delta: String
     let state: String
+    let source: String
 }
 
 extension ComplicationSnapshotFingerprint {
@@ -100,6 +104,7 @@ extension ComplicationSnapshotFingerprint {
         // Sentinel for nil: state is always optional in the model; sentinel ensures
         // nil and non-nil are always distinguishable in Equatable comparison.
         state = snapshot.state ?? "<nil>"
+        source = snapshot.source.rawValue
     }
 }
 

--- a/docs/in-progress/watch-g7-direct-ble-observer/01-design.md
+++ b/docs/in-progress/watch-g7-direct-ble-observer/01-design.md
@@ -1,0 +1,61 @@
+# Trio Watch Dexcom G7 Direct BLE Observer — Design v1
+
+## Mission and premise
+Implement a watch-only observer that attaches to the Dexcom G7 watch app’s existing same-device BLE session and requests EGV payloads on Trio’s own control-characteristic channel. Trio does **not** initiate or own auth.
+
+## Protocol sequence
+1. Eager restoration-backed `CBCentralManager` is allocated at watch app startup.
+2. On scene `.active`, attempt attach via `retrieveConnectedPeripherals(withServices:[dataService])`; fallback to FEBC scan.
+3. Connect, discover services/characteristics broadly (`nil`) and locate auth/control/backfill/jPake chars.
+4. Enable auth notify and control notify.
+5. Observe auth packets only; never respond; explicitly log jPake as skipped.
+6. Once auth-ready + control-ready + observed authenticated auth status packet, write opcode `0x4E` on control.
+7. Parse control notification payload into EGV snapshot and persist to `TrioComplicationDataStore` with source `.directBLE`.
+
+## Attach and filtering strategy
+- Filtering: DiaBLE-style local tolerant matching (`Dexcom`/`DX` peripheral names) to avoid dependency on phone bridge state.
+- Attach order: connected-service retrieval first (fast path when Dexcom app already owns link), then scan fallback.
+- Connect attempts are logged with `source=` tags.
+
+## Lifecycle and reconnect
+- Start on `.active`; no proactive disconnect on `.inactive`/`.background`.
+- `stop()` remains explicit hard-off API.
+- On disconnect/connect-failure/control-write-failure, schedule bounded-delay reconnect (3s), reset by active re-entry.
+
+## UI and source attribution
+- `TrioComplicationSnapshot` extended with `source: TrioComplicationDataSource`.
+- Main bobble recency line now includes: recency + source label + BLE status + BLE-last-event recency.
+- Source labels: `BLE`, `PHONE`, `HK`, `?`.
+
+## Observability
+Structured logs (via `WatchLogger`) under `event=g7_ble_*` include lifecycle, scan, discovered/skipped, connect attempts with source, notify enabled, auth/control payloads, EGV requests, EGV received, reconnect scheduling, and write failures.
+
+## Design question answers
+1. **Filtering:** standalone tolerant matching. Maximizes attach independence from iPhone transport.
+2. **Attach strategy:** retrieve-connected(dataService) then FEBC scan. Optimizes fast attach while keeping robust fallback.
+3. **Discovery breadth:** broad `discoverServices(nil)` + `discoverCharacteristics(nil, for:)`. More robust to watchOS GATT presentation variance.
+4. **Timeout/backoff:** 3s reconnect backoff; no destructive scan-timeout teardown.
+5. **Queue:** `queue:nil` (main queue semantics) + MainActor state/store updates.
+6. **Restoration:** enabled; logs restore keys for diagnostics.
+7. **connect options:** uses disconnect notification option for observability.
+8. **Auth advance condition:** auth notify enabled + control notify enabled + observed auth status packet with nonzero status byte.
+9. **EGV cadence:** send on readiness transition (per attach cycle). Simpler baseline to validate sustained reconnect cycles.
+10. **Control write failure:** log + reconnect.
+11. **Backfill:** discover and explicitly log skipped (does not gate EGV path).
+12. **Stop scan after connect:** yes.
+13. **Multi-peripheral disambiguation:** first acceptable candidate; log IDs for post-hoc analysis.
+14. **Identifier persistence:** not used in this pass.
+15. **Delta computation:** leave unset (`--`) for BLE path in this pass.
+16. **Winner policy:** existing store dedup/min-interval behavior retained; source is carried for UI attribution.
+17. **UI status palette:** kept 6-state label set (`off/search/conn/active/stalled/unavail`) rendered inline with recency/source.
+18. **Active-name mid-session:** not applicable (no phone-bridged name).
+19. **Attach ladder cadence:** single sweep (retrieve then scan), reconnect loop on failures.
+
+## Deviations from references
+- No backfill consumption yet (logged skip only) to keep first pass focused on reliable live EGV capture.
+- EGV trigger currently once-per-ready-cycle rather than additional cadence timer.
+
+## Risks / open test questions
+- Exact auth-status byte interpretation may vary across firmware variants.
+- Name-based tolerant filter may admit extra candidates in dense BLE environments.
+- Control payload parsing offsets need on-device verification against real notifications.

--- a/docs/in-progress/watch-g7-direct-ble-observer/02-implementation-plan.md
+++ b/docs/in-progress/watch-g7-direct-ble-observer/02-implementation-plan.md
@@ -1,0 +1,25 @@
+# Implementation Plan v1
+
+## New files
+- `Trio Watch App Extension/G7DirectBLEObserver.swift` — CoreBluetooth observer manager, attach/reconnect, protocol handling, EGV parse, logging.
+- `Trio Watch Shared/TrioComplicationDataSource.swift` — source attribution enum shared by watch app + complication data model.
+- `docs/in-progress/watch-g7-direct-ble-observer/01-design.md`
+- `docs/in-progress/watch-g7-direct-ble-observer/02-implementation-plan.md`
+- `docs/in-progress/watch-g7-direct-ble-observer/03-implementation-log.md`
+
+## Modified files
+- `Trio Watch Shared/TrioComplicationDataStore.swift` — add source field to `TrioComplicationSnapshot` + fingerprint.
+- `Trio Watch App Extension/WatchState.swift` — observer wiring, BLE status/source state, source tagging on save paths.
+- `Trio Watch App Extension/Views/GlucoseTrendView.swift` — inline BLE/source status line.
+- `Trio Watch App Extension/Views/TrioMainWatchView.swift` — hydrate source from cached snapshot.
+
+## Phases
+1. Add source attribution model in shared snapshot/store.
+2. Add observer manager with central lifecycle, attach ladder, discovery, notify, control write, EGV parse.
+3. Wire observer into watch foreground lifecycle and complication store save path.
+4. Surface status/source/last-BLE-event signal in main watch view line.
+5. Static review and command-level checks.
+
+## Tests planned
+- Static checks only in this pass (`swift` compile not run by instruction).
+- `git diff` + targeted file re-read for state transitions and prohibited auth writes.

--- a/docs/in-progress/watch-g7-direct-ble-observer/03-implementation-log.md
+++ b/docs/in-progress/watch-g7-direct-ble-observer/03-implementation-log.md
@@ -1,0 +1,30 @@
+# Implementation Log
+
+## Branch/base
+- Branch: `feature/watch-g7-direct-ble-observer-a`
+- Base requested: `baseline-dev-patches-01-10` (not present locally in this worktree; branch created from available local HEAD).
+
+## Phase log
+1. **Scaffold + model extension**
+   - Added `TrioComplicationDataSource` enum.
+   - Extended `TrioComplicationSnapshot` with `source` and fingerprint persistence.
+2. **Observer implementation**
+   - Added `G7DirectBLEObserver` with eager central allocation, retrieval-first attach, FEBC scan fallback, reconnect loop, auth/control notify setup, observer-only auth posture, control write opcode `0x4E`, and EGV parse/save callback.
+3. **Watch integration**
+   - Wired observer into `WatchState` active/inactive hooks without scene-driven hard stop.
+   - Added watch-state fields for BLE status / last direct-BLE event / current snapshot source.
+   - Tagged WatchConnectivity saves as `.watchConnectivity`; HealthKit saves as `.healthKit`; direct BLE saves as `.directBLE`.
+4. **UI integration**
+   - Replaced bottom recency-only line with recency + source + BLE status + BLE event age.
+
+## Plan changes during implementation
+- Kept no iPhone WatchConnectivity bridge for active peripheral name (chose standalone matching).
+- Deferred backfill consumption to a future phase; implemented explicit skip logs.
+
+## Validation
+- Static review pass across modified files completed.
+- No xcodebuild/ci/local-build run per constraints.
+
+## Final handoff state
+- Done: docs, source files, watch-side integration and UI status indicator.
+- Pending human follow-up: Xcode target membership wiring and on-device validation against Dexcom watch app direct mode.


### PR DESCRIPTION
### Motivation
- Provide a watch-only Dexcom G7 direct BLE observer that eavesdrops the Dexcom G7 watch app’s same-device BLE session and supplies live EGV readings into the existing complication pipeline for faster updates.
- Keep the observer strictly passive for authentication (observe auth, never initiate J‑PAKE/auth ownership) while actively requesting EGVs on the control characteristic.
- Integrate with existing watch scaffolding (`TrioComplicationDataStore`, `WatchState`, `WatchLogger`) and expose a glanceable BLE status + source indicator in the main watch UI.

### Description
- Added `Trio Watch App Extension/G7DirectBLEObserver.swift`, a restoration-backed `CBCentralManager`-based observer implementing retrieval-first attach + FEBC scan fallback, service/characteristic discovery (broad discovery), auth-notify observation, control notify enablement, control write of EGV-request opcode (`0x4E`), EGV parsing and structured `event=g7_ble_*` logging, and a simple reconnect policy.
- Introduced `Trio Watch Shared/TrioComplicationDataSource.swift` and extended `TrioComplicationSnapshot` + `ComplicationSnapshotFingerprint` to carry `source` attribution (`.directBLE`, `.watchConnectivity`, `.healthKit`, `.unknown`).
- Wired the observer into `WatchState` (start on foreground-active, tolerate brief inactive events, provide `stop()`), added BLE status fields and last-event timestamp, and saved direct-BLE snapshots via the existing `TrioComplicationDataStore.save(... )` API (keeps existing dedup/min-interval behavior).
- Updated the main watch UI recency line (`GlucoseTrendView` / `TrioMainWatchView`) to show recency + source + BLE status + last-BLE-event age and added the required in-progress docs under `docs/in-progress/watch-g7-direct-ble-observer/` (design, implementation plan, implementation log).

### Testing
- `git commit` and branch operations completed successfully on `feature/watch-g7-direct-ble-observer-a` (commit created). — succeeded.
- `git diff --check` and `git status --short --branch` were executed to validate workspace state and showed no whitespace/merge errors. — succeeded.
- Attempted automated fetch of the provided DiaBLE / G7SensorKit reference URLs via curl in this environment failed with HTTP 403 (network proxy restrictions), so external reference file retrieval could not be validated here. — failed (network fetch).
- No Xcode build (`xcodebuild` / `ci/local-build.sh`) or unit/integration compile run was performed per repository constraints; static review of diffs and repo searches were used instead. — intentionally not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ebb81432708324a8fb694c9335bc69)