### PR TITLE
feat: add watch G7 direct BLE observer with source-attributed complication snapshots

### DIFF
--- a/Trio Watch App Extension/G7DirectBLEObserver.swift
+++ b/Trio Watch App Extension/G7DirectBLEObserver.swift
@@ -1,0 +1,351 @@
+import CoreBluetooth
+import Foundation
+
+@MainActor
+protocol G7DirectBLEObserverDelegate: AnyObject {
+    func g7ObserverDidUpdateStatus(_ status: WatchState.G7BLEStatus)
+    func g7ObserverDidReceiveEGV(glucose: String, trend: String, delta: String, readingDate: Date)
+    func g7ObserverDidRecordDirectEvent(at date: Date)
+}
+
+final class G7DirectBLEObserver: NSObject {
+    static let shared = G7DirectBLEObserver()
+
+    private enum C {
+        static let restoreID = "org.nightscout.trio.watch.g7observer"
+        static let dexcomAdvertisementService = CBUUID(string: "FEBC")
+        static let dexcomDataService = CBUUID(string: "F8083532-849E-531C-C594-30F1F86A4EA5")
+        static let controlCharacteristic = CBUUID(string: "F8083534-849E-531C-C594-30F1F86A4EA5")
+        static let authCharacteristic = CBUUID(string: "F8083535-849E-531C-C594-30F1F86A4EA5")
+        static let backfillCharacteristic = CBUUID(string: "F8083536-849E-531C-C594-30F1F86A4EA5")
+        static let jpakeCharacteristic = CBUUID(string: "F8084533-849E-531C-C594-30F1F86A4EA5")
+        static let egvRequestOpcode = Data([0x4e])
+    }
+
+    weak var delegate: G7DirectBLEObserverDelegate?
+
+    private let central: CBCentralManager
+    private var shouldRun = false
+    private var sceneActive = false
+
+    private var peripheral: CBPeripheral?
+    private var authCharacteristic: CBCharacteristic?
+    private var controlCharacteristic: CBCharacteristic?
+    private var lastGlucose: Int?
+    private var authSeen = false
+    private var requestTimer: Timer?
+    private var scanTimeoutTimer: Timer?
+    private var reconnectWorkItem: DispatchWorkItem?
+    private var reconnectAttempts = 0
+
+    override init() {
+        central = CBCentralManager(
+            delegate: nil,
+            queue: nil,
+            options: [CBCentralManagerOptionRestoreIdentifierKey: C.restoreID]
+        )
+        super.init()
+        central.delegate = self
+    }
+
+    func start(sceneActive: Bool) {
+        shouldRun = true
+        self.sceneActive = sceneActive
+        log("event=g7_ble_lifecycle action=start scene_active=\(sceneActive)")
+        guard sceneActive else {
+            updateStatus(.off)
+            return
+        }
+        evaluateAttachPath(reason: "start")
+    }
+
+    func updateScene(active: Bool) {
+        sceneActive = active
+        log("event=g7_ble_lifecycle action=scene_update active=\(active)")
+        if active, shouldRun {
+            reconnectAttempts = 0
+            evaluateAttachPath(reason: "scene_active")
+        }
+    }
+
+    func stop() {
+        shouldRun = false
+        requestTimer?.invalidate()
+        requestTimer = nil
+        scanTimeoutTimer?.invalidate()
+        scanTimeoutTimer = nil
+        reconnectWorkItem?.cancel()
+        reconnectWorkItem = nil
+
+        if let peripheral {
+            central.cancelPeripheralConnection(peripheral)
+        }
+        peripheral = nil
+        authCharacteristic = nil
+        controlCharacteristic = nil
+        authSeen = false
+        central.stopScan()
+        updateStatus(.off)
+        log("event=g7_ble_lifecycle action=stop")
+    }
+
+    private func evaluateAttachPath(reason: String) {
+        guard shouldRun, sceneActive else { return }
+        guard central.state == .poweredOn else {
+            updateStatus(.unavailable)
+            log("event=g7_ble_blocked_state reason=central_not_powered state=\(central.state.rawValue)")
+            return
+        }
+
+        if let current = peripheral {
+            if current.state == .connected {
+                updateStatus(.active)
+                return
+            }
+        }
+
+        let connected = central.retrieveConnectedPeripherals(withServices: [C.dexcomDataService])
+        if let candidate = connected.first {
+            connect(candidate, source: "retrieved_data_service")
+            return
+        }
+
+        scan(reason: reason)
+    }
+
+    private func scan(reason: String) {
+        guard shouldRun else { return }
+        updateStatus(.searching)
+        log("event=g7_ble_scan_start reason=\(reason)")
+        central.scanForPeripherals(withServices: nil, options: [CBCentralManagerScanOptionAllowDuplicatesKey: true])
+
+        scanTimeoutTimer?.invalidate()
+        scanTimeoutTimer = Timer.scheduledTimer(withTimeInterval: 12, repeats: false) { [weak self] _ in
+            guard let self else { return }
+            Task { @MainActor in
+                guard self.peripheral == nil else {
+                    self.log("event=g7_ble_scan_timeout_ignored reason=connected")
+                    return
+                }
+                self.log("event=g7_ble_scan_timeout action=reconnect")
+                self.central.stopScan()
+                self.scheduleReconnect(reason: "scan_timeout")
+            }
+        }
+    }
+
+    private func connect(_ candidate: CBPeripheral, source: String) {
+        guard shouldRun else { return }
+        peripheral = candidate
+        candidate.delegate = self
+        updateStatus(.connecting)
+        log("event=g7_ble_connect_attempt source=\(source) id=\(candidate.identifier.uuidString) name=\(candidate.name ?? "nil")")
+        central.connect(candidate, options: [CBConnectPeripheralOptionNotifyOnDisconnectionKey: true])
+    }
+
+    private func scheduleReconnect(reason: String) {
+        guard shouldRun, sceneActive else { return }
+        reconnectWorkItem?.cancel()
+        reconnectAttempts += 1
+        let delay = min(pow(2.0, Double(reconnectAttempts)), 20)
+        updateStatus(.stalled)
+        log("event=g7_ble_reconnect_scheduled reason=\(reason) delay_s=\(Int(delay))")
+
+        let item = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            Task { @MainActor in
+                self.evaluateAttachPath(reason: "reconnect")
+            }
+        }
+        reconnectWorkItem = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: item)
+    }
+
+    private func updateStatus(_ status: WatchState.G7BLEStatus) {
+        delegate?.g7ObserverDidUpdateStatus(status)
+    }
+
+    private func startEGVTimer() {
+        requestTimer?.invalidate()
+        requestTimer = Timer.scheduledTimer(withTimeInterval: 300, repeats: true) { [weak self] _ in
+            guard let self else { return }
+            Task { @MainActor in
+                self.sendEGVRequest(reason: "timer")
+            }
+        }
+    }
+
+    private func sendEGVRequest(reason: String) {
+        guard shouldRun, authSeen, let peripheral, let controlCharacteristic else {
+            log("event=g7_ble_blocked_egv_request reason=not_ready")
+            return
+        }
+        peripheral.writeValue(C.egvRequestOpcode, for: controlCharacteristic, type: .withResponse)
+        log("event=g7_ble_egv_request_sent reason=\(reason) write_type=withResponse")
+    }
+
+    private func decodeEGV(from data: Data) -> (glucose: Int, trend: String, readingDate: Date)? {
+        // Clean-room parser, aligned to G7 control message shape from G7SensorKit Messages.
+        guard data.count >= 11 else { return nil }
+
+        let glucose = Int(UInt16(data[2]) | (UInt16(data[3]) << 8))
+        guard (40...400).contains(glucose) else { return nil }
+
+        let trendRateRaw = Int8(bitPattern: data[4])
+        let trend: String
+        switch trendRateRaw {
+        case ..<(-6): trend = "↘︎"
+        case -6..<(-2): trend = "↘"
+        case -2...2: trend = "→"
+        case 3...6: trend = "↗"
+        default: trend = "↗︎"
+        }
+
+        let sensorSeconds = UInt32(data[5])
+            | (UInt32(data[6]) << 8)
+            | (UInt32(data[7]) << 16)
+            | (UInt32(data[8]) << 24)
+        let ageSeconds = UInt16(data[9]) | (UInt16(data[10]) << 8)
+        let readingDate = Date(timeIntervalSinceNow: -TimeInterval(ageSeconds == 0 ? 0 : ageSeconds))
+        _ = sensorSeconds
+        return (glucose, trend, readingDate)
+    }
+
+    private func handleControlPayload(_ data: Data) {
+        log("event=g7_ble_control_payload_received bytes=\(data.count)")
+        guard let parsed = decodeEGV(from: data) else {
+            return
+        }
+        let previous = lastGlucose
+        lastGlucose = parsed.glucose
+        let delta = previous.map { String(format: "%+d", parsed.glucose - $0) } ?? "--"
+
+        delegate?.g7ObserverDidRecordDirectEvent(at: Date())
+        delegate?.g7ObserverDidReceiveEGV(
+            glucose: String(parsed.glucose),
+            trend: parsed.trend,
+            delta: delta,
+            readingDate: parsed.readingDate
+        )
+        updateStatus(.active)
+        log("event=g7_ble_egv_received glucose=\(parsed.glucose) trend=\(parsed.trend) reading_epoch=\(Int(parsed.readingDate.timeIntervalSince1970))")
+    }
+
+    private func log(
+        _ message: String,
+        function: String = #function,
+        file: String = #fileID,
+        line: Int = #line
+    ) {
+        Task {
+            await WatchLogger.shared.log(message, function: function, file: file, line: line)
+        }
+    }
+}
+
+extension G7DirectBLEObserver: CBCentralManagerDelegate {
+    func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        log("event=g7_ble_central_state state=\(central.state.rawValue)")
+        if central.state == .poweredOn {
+            evaluateAttachPath(reason: "state_update")
+        } else {
+            updateStatus(.unavailable)
+        }
+    }
+
+    func centralManager(_ central: CBCentralManager, willRestoreState dict: [String: Any]) {
+        log("event=g7_ble_restore_state keys=\(dict.keys.joined(separator: ","))")
+    }
+
+    func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral, advertisementData: [String: Any], rssi RSSI: NSNumber) {
+        log("event=g7_ble_peripheral_discovered name=\(peripheral.name ?? "nil") rssi=\(RSSI.intValue) id=\(peripheral.identifier.uuidString) ad=\(advertisementData)")
+
+        let candidateName = (peripheral.name ?? (advertisementData[CBAdvertisementDataLocalNameKey] as? String) ?? "").lowercased()
+        let serviceUUIDs = (advertisementData[CBAdvertisementDataServiceUUIDsKey] as? [CBUUID]) ?? []
+        let matched = candidateName.contains("dexcom") || candidateName.contains("dxcm") || serviceUUIDs.contains(C.dexcomAdvertisementService)
+
+        guard matched else {
+            log("event=g7_ble_peripheral_skipped reason=filter_miss name=\(candidateName)")
+            return
+        }
+
+        central.stopScan()
+        connect(peripheral, source: "scan")
+    }
+
+    func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+        reconnectAttempts = 0
+        updateStatus(.connecting)
+        log("event=g7_ble_did_connect id=\(peripheral.identifier.uuidString)")
+        peripheral.discoverServices(nil)
+        central.stopScan()
+        scanTimeoutTimer?.invalidate()
+        startEGVTimer()
+    }
+
+    func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {
+        let ns = error as NSError?
+        log("event=g7_ble_connect_failed error_domain=\(ns?.domain ?? "nil") error_code=\(ns?.code ?? -1) error_desc=\(ns?.localizedDescription ?? "nil")")
+        self.peripheral = nil
+        scheduleReconnect(reason: "did_fail_to_connect")
+    }
+
+    func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
+        let ns = error as NSError?
+        log("event=g7_ble_disconnected error_domain=\(ns?.domain ?? "nil") error_code=\(ns?.code ?? -1) error_desc=\(ns?.localizedDescription ?? "nil")")
+        self.peripheral = nil
+        authCharacteristic = nil
+        controlCharacteristic = nil
+        authSeen = false
+        scheduleReconnect(reason: "disconnect")
+    }
+}
+
+extension G7DirectBLEObserver: CBPeripheralDelegate {
+    func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
+        log("event=g7_ble_services_discovered count=\(peripheral.services?.count ?? 0)")
+        peripheral.services?.forEach { service in
+            peripheral.discoverCharacteristics(nil, for: service)
+        }
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
+        log("event=g7_ble_characteristics_discovered service=\(service.uuid.uuidString) count=\(service.characteristics?.count ?? 0)")
+        for characteristic in service.characteristics ?? [] {
+            switch characteristic.uuid {
+            case C.authCharacteristic:
+                authCharacteristic = characteristic
+                peripheral.setNotifyValue(true, for: characteristic)
+                log("event=g7_ble_auth_notify_enabled")
+            case C.controlCharacteristic:
+                controlCharacteristic = characteristic
+                peripheral.setNotifyValue(true, for: characteristic)
+                log("event=g7_ble_control_notify_enabled")
+            case C.jpakeCharacteristic:
+                log("event=g7_ble_jpake_skipped")
+            case C.backfillCharacteristic:
+                log("event=g7_ble_backfill_skipped")
+            default:
+                break
+            }
+        }
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
+        guard let value = characteristic.value else { return }
+        if characteristic.uuid == C.authCharacteristic {
+            authSeen = true
+            log("event=g7_ble_auth_payload_received bytes=\(value.count)")
+            sendEGVRequest(reason: "auth_payload")
+        } else if characteristic.uuid == C.controlCharacteristic {
+            handleControlPayload(value)
+        }
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?) {
+        if let error {
+            log("event=g7_ble_control_write_failed error=\(error.localizedDescription)")
+            scheduleReconnect(reason: "control_write_failed")
+        }
+    }
+}

--- a/Trio Watch App Extension/Views/GlucoseTrendView.swift
+++ b/Trio Watch App Extension/Views/GlucoseTrendView.swift
@@ -114,6 +114,16 @@ struct GlucoseTrendView: View {
         }
     }
 
+
+    private var sourceBadge: String {
+        state.g7DisplayedSource.shortLabel
+    }
+
+    private var bleHeartbeat: String {
+        guard let at = state.g7LastDirectEventAt else { return "--" }
+        return "\(Int(Date().timeIntervalSince(at) / 60))m"
+    }
+
     var body: some View {
         VStack {
             ZStack {
@@ -151,8 +161,7 @@ struct GlucoseTrendView: View {
             Text(
                 isWatchStateDated ?
                     String(localized: "STALE DATA", comment: "Information displayed when watch app data outdated or stale.") :
-                    state
-                    .lastLoopTime ?? "--"
+                    "\(state.lastLoopTime ?? "--") · \(sourceBadge) · BLE:\(state.g7BLEStatus.display) · \(bleHeartbeat)"
             )
             .font(.system(size: minutesAgoFontSize))
             .fontWidth(isWatchStateDated ? .expanded : .standard)

--- a/Trio Watch App Extension/Views/TrioMainWatchView.swift
+++ b/Trio Watch App Extension/Views/TrioMainWatchView.swift
@@ -132,6 +132,7 @@ struct TrioMainWatchView: View {
                         state.currentGlucoseColorString = glucoseColor
                     }
                     state.lastWatchStateUpdate = snapshot.readingDate
+                    state.g7DisplayedSource = snapshot.source ?? .unknown
                     state.showSyncingAnimation = true
                 } else if let snapshot = cachedSnapshot,
                           let lastUpdate = state.lastWatchStateUpdate,
@@ -144,6 +145,7 @@ struct TrioMainWatchView: View {
                         state.currentGlucoseColorString = glucoseColor
                     }
                     state.lastWatchStateUpdate = snapshot.readingDate
+                    state.g7DisplayedSource = snapshot.source ?? .unknown
                     state.showSyncingAnimation = false
                 }
 

--- a/Trio Watch App Extension/WatchState+G7DirectBLE.swift
+++ b/Trio Watch App Extension/WatchState+G7DirectBLE.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+extension WatchState {
+    enum G7BLEStatus: String {
+        case off
+        case searching
+        case connecting
+        case active
+        case stalled
+        case unavailable
+
+        var display: String {
+            switch self {
+            case .off: "off"
+            case .searching: "search"
+            case .connecting: "conn"
+            case .active: "active"
+            case .stalled: "stall"
+            case .unavailable: "na"
+            }
+        }
+    }
+
+    var g7BLEStatus: G7BLEStatus {
+        get { _g7BLEStatus }
+        set { _g7BLEStatus = newValue }
+    }
+
+    var g7LastDirectEventAt: Date? {
+        get { _g7LastDirectEventAt }
+        set { _g7LastDirectEventAt = newValue }
+    }
+
+    var g7DisplayedSource: TrioComplicationDataSource {
+        get { _g7DisplayedSource }
+        set { _g7DisplayedSource = newValue }
+    }
+
+    func startG7ObserverForActiveScene() {
+        G7DirectBLEObserver.shared.delegate = self
+        G7DirectBLEObserver.shared.start(sceneActive: true)
+    }
+
+    func updateG7ObserverForScene(active: Bool) {
+        G7DirectBLEObserver.shared.updateScene(active: active)
+    }
+
+    func stopG7Observer() {
+        G7DirectBLEObserver.shared.stop()
+    }
+}
+
+extension WatchState: G7DirectBLEObserverDelegate {
+    func g7ObserverDidUpdateStatus(_ status: G7BLEStatus) {
+        g7BLEStatus = status
+    }
+
+    func g7ObserverDidRecordDirectEvent(at date: Date) {
+        g7LastDirectEventAt = date
+    }
+
+    func g7ObserverDidReceiveEGV(glucose: String, trend: String, delta: String, readingDate: Date) {
+        currentGlucose = glucose
+        self.trend = trend
+        self.delta = delta
+        lastWatchStateUpdate = readingDate
+        g7DisplayedSource = .directBLE
+        g7LastDirectEventAt = Date()
+
+        let snapshot = TrioComplicationSnapshot(
+            glucose: glucose,
+            trend: trend,
+            delta: delta,
+            readingDate: readingDate,
+            date: Date(),
+            glucoseColor: currentGlucoseColorString,
+            source: .directBLE
+        )
+        TrioComplicationDataStore.shared.save(snapshot, minInterval: 5)
+
+        Task {
+            await WatchLogger.shared.log(
+                "event=g7_ble_snapshot_saved glucose=\(glucose) trend=\(trend) reading_epoch=\(Int(readingDate.timeIntervalSince1970))"
+            )
+        }
+    }
+}

--- a/Trio Watch App Extension/WatchState.swift
+++ b/Trio Watch App Extension/WatchState.swift
@@ -56,6 +56,12 @@ enum BackgroundTaskWindowCounter {
     var overridePresets: [OverridePresetWatch] = []
     var tempTargetPresets: [TempTargetPresetWatch] = []
 
+    // MARK: - G7 direct BLE observer
+
+    var _g7BLEStatus: G7BLEStatus = .off
+    var _g7LastDirectEventAt: Date?
+    var _g7DisplayedSource: TrioComplicationDataSource = .unknown
+
     // MARK: - Treatment inputs
 
     var carbsAmount: Int = 0
@@ -232,6 +238,7 @@ enum BackgroundTaskWindowCounter {
         WatchStartupTransportGate.arm(activationSequence: activationSequence)
         noteAppBecameActive()
         WatchErrorReporter.markBecameActiveImmediately()
+        startG7ObserverForActiveScene()
         scheduleStartupSequenceOnMain(activationSequence: activationSequence)
 
         Task {
@@ -258,6 +265,7 @@ enum BackgroundTaskWindowCounter {
         let pendingTasks = startupPendingTasksFieldOnMain()
         cancelStartupSequenceOnMain()
         startupCurrentActivationSequence = nil
+        updateG7ObserverForScene(active: false)
         WatchErrorReporter.markEnteredBackgroundOrInactiveImmediately()
 
         if let activationSequence {
@@ -670,10 +678,12 @@ enum BackgroundTaskWindowCounter {
             delta: deltaString,
             readingDate: readingDate,
             date: Date(),
-            glucoseColor: nil
+            glucoseColor: nil,
+            source: .healthKit
         )
 
         DispatchQueue.main.async {
+            self.g7DisplayedSource = .healthKit
             TrioComplicationDataStore.shared.save(snapshot, minInterval: 5)
             completionHandler()
         }
@@ -1843,7 +1853,8 @@ enum BackgroundTaskWindowCounter {
             delta: deltaValue,
             readingDate: readingDate,
             date: Date(),
-            glucoseColor: glucoseColorValue
+            glucoseColor: glucoseColorValue,
+            source: .watchConnectivity
         )
 
         // Phase 3.0 — pre-dispatch dedup. saveOnMain is authoritative.
@@ -1851,6 +1862,7 @@ enum BackgroundTaskWindowCounter {
             return
         }
 
+        g7DisplayedSource = .watchConnectivity
         TrioComplicationDataStore.shared.save(snapshot, minInterval: 5)
 
         // R5c — log decode latency and reading_epoch for the payload we just saved (avoids misattribution when overlapping userInfo deliveries).
@@ -1904,7 +1916,8 @@ enum BackgroundTaskWindowCounter {
             delta: delta ?? "",
             readingDate: effectiveReadingDate,
             date: Date(),
-            glucoseColor: currentGlucoseColorString
+            glucoseColor: currentGlucoseColorString,
+            source: g7DisplayedSource
         )
 
         Task {

--- a/Trio Watch Shared/TrioComplicationDataSource.swift
+++ b/Trio Watch Shared/TrioComplicationDataSource.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+enum TrioComplicationDataSource: String, Codable {
+    case watchConnectivity
+    case healthKit
+    case directBLE
+    case unknown
+
+    var shortLabel: String {
+        switch self {
+        case .watchConnectivity: "Phone"
+        case .healthKit: "HK"
+        case .directBLE: "BLE"
+        case .unknown: "?"
+        }
+    }
+}

--- a/Trio Watch Shared/TrioComplicationDataStore.swift
+++ b/Trio Watch Shared/TrioComplicationDataStore.swift
@@ -18,6 +18,7 @@ struct TrioComplicationSnapshot: Equatable, Codable {
     let readingDate: Date
     let state: String?
     let glucoseColor: String?
+    let source: TrioComplicationDataSource?
 
     // INVARIANT (Phase 3.4): All display-field sanitization here.
     // Dedup always compares sanitized values.
@@ -28,7 +29,8 @@ struct TrioComplicationSnapshot: Equatable, Codable {
         readingDate: Date,
         date: Date,
         state: String? = nil,
-        glucoseColor: String? = nil
+        glucoseColor: String? = nil,
+        source: TrioComplicationDataSource? = nil
     ) {
         glucose = Self.sanitizedGlucose(from: rawGlucose)
         trend = rawTrend.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -37,6 +39,7 @@ struct TrioComplicationSnapshot: Equatable, Codable {
         self.date = date
         self.state = state
         self.glucoseColor = glucoseColor
+        self.source = source
     }
 
     private static func sanitizedGlucose(from value: String) -> String {
@@ -621,6 +624,7 @@ final class TrioComplicationDataStore {
         readingDate: Date,
         date: Date,
         glucoseColor: String? = nil,
+        source: TrioComplicationDataSource? = nil,
         triggerReload: Bool = true
     ) {
         let snapshot = TrioComplicationSnapshot(
@@ -629,7 +633,8 @@ final class TrioComplicationDataStore {
             delta: delta ?? "",
             readingDate: readingDate,
             date: date,
-            glucoseColor: glucoseColor
+            glucoseColor: glucoseColor,
+            source: source
         )
         save(snapshot, triggerReload: triggerReload)
     }

--- a/docs/in-progress/watch-g7-direct-ble-observer/01-design.md
+++ b/docs/in-progress/watch-g7-direct-ble-observer/01-design.md
@@ -1,0 +1,79 @@
+# Watch G7 Direct BLE Observer — Design v1
+
+## Mission and premise
+Implement a watch-only Dexcom G7 observer path that attaches to the same-device BLE session owned by the official Dexcom G7 watch app, requests EGV payloads on Trio's own control characteristic channel, and persists readings into the existing watch complication snapshot pipeline.
+
+## Reference validation status
+The required raw GitHub URL fetches were attempted first using `curl -fsSL` for all listed DiaBLE and G7SensorKit files, but this environment returned HTTP 403 for every URL. Because of that, implementation relied on already-known Dexcom G7 UUID/opcode conventions and baseline Trio architecture, and logs this as the top empirical risk.
+
+## Protocol sequence implemented
+1. Eager restoration-backed `CBCentralManager` allocated at process init.
+2. On scene `.active`, attempt attach via `retrieveConnectedPeripherals(withServices: [data-service])`, then scan fallback.
+3. Connect candidate and discover services/characteristics using broad discovery (`nil`).
+4. Enable auth notify; explicitly skip J-PAKE and log skip.
+5. Enable control notify.
+6. Observe auth traffic (no auth writes), then send EGV request opcode on control write channel.
+7. Parse control notifications into EGV, trend, readingDate, delta; save into `TrioComplicationDataStore` with source attribution.
+
+## Discovery / attach strategy
+- Order: connected-service retrieval first, then broad scan.
+- Rationale: fast-path attached peripherals first, with scan fallback for cases where retrieval misses or cache is stale.
+- Connect `source=` tags are emitted (`retrieved_data_service`, `scan`).
+
+## Filtering approach
+- Chosen: DiaBLE-style standalone tolerant matching by peripheral name/advertisement patterns (Dexcom/DXCM/FEBC hints).
+- Rationale: avoids iPhone dependency and keeps observer self-contained for watch-only attach reliability.
+
+## Auth advance condition + request cadence
+- Advance condition: any auth payload observed marks link auth-ready for observer sends.
+- EGV request cadence: on auth payload + recurring 5-minute timer while connected.
+- Rationale: avoids over-strict auth-state gating stalls and targets sustained reads over time.
+
+## Reconnect policy
+- Automatic reconnect with bounded exponential backoff (2s→20s), reset on connect.
+- No scene-gated hard stop; inactive/background transitions do not forcibly tear down a healthy link.
+
+## Scene/lifecycle model
+- Start on foreground active.
+- Inactive/background only updates scene activity marker; no proactive BLE teardown.
+- Explicit `stop()` remains available and is not scene-wired.
+
+## UI indicator design
+- Existing recency line is augmented to include source + BLE status + last direct BLE event age.
+- Format: `"<recency> · <source> · BLE:<status> · <heartbeat>"`.
+- Source labels: `Phone`, `HK`, `BLE`, `?`.
+
+## Source attribution model
+- New `TrioComplicationDataSource` enum added in shared watch code.
+- `TrioComplicationSnapshot` extended with optional `source`.
+- WatchConnectivity saves as `.watchConnectivity`, HK saves as `.healthKit`, direct observer saves as `.directBLE`.
+
+## Observability plan
+- Structured `event=g7_ble_*` logs include state transitions, scan/connect attempts, peripheral discovery details, characteristic setup, auth payload receipt, EGV request sends, control payload handling, snapshot saves, and reconnect scheduling.
+- Logging helper forwards call-site file/line/function through `WatchLogger`.
+
+## Design question decisions
+1. Filtering: standalone tolerant matching — fewer dependencies.
+2. Attach strategy: retrieveConnected(data service) then scan — fast attach + robust fallback.
+3. Discovery breadth: broad (`nil`) discovery — reduces risk of missing required chars.
+4. Timeout/backoff: 12s scan timeout, 2→20s reconnect — practical aggressive retry.
+5. Central queue: main queue (`queue:nil`) plus MainActor model interactions.
+6. Restoration: enabled with restore identifier + restore-state logging.
+7. Connect options: notify-on-disconnect enabled.
+8. Auth advance: first auth payload gates readiness (looser to avoid deadlock).
+9. Request cadence: auth-event + 5-minute periodic timer.
+10. Control write failure: log + reconnect schedule.
+11. Backfill: discovered/logged as skipped in this pass.
+12. Stop scanning after connect: yes.
+13. Multi-peripheral disambiguation: first passing candidate wins.
+14. Identifier persistence: none in this pass.
+15. Delta computation: local from previous direct-BLE glucose.
+16. Winner policy: existing store dedup + source tagging (no extra arbitration layer).
+17. UI palette: six-state compact text (`off/search/conn/active/stall/na`) + heartbeat age.
+18. Active-name filter changes: not applicable (no iPhone-bridged filter).
+19. Attach-ladder cadence: single-sweep with reconnect loop.
+
+## Known risks / device-test questions
+- Required external reference files were inaccessible from this environment (HTTP 403), so parser/auth nuances may need device calibration.
+- EGV payload decode offsets are best-effort and require watch-on-device validation.
+- Backfill is currently non-active (log-only skip).

--- a/docs/in-progress/watch-g7-direct-ble-observer/02-implementation-plan.md
+++ b/docs/in-progress/watch-g7-direct-ble-observer/02-implementation-plan.md
@@ -1,0 +1,29 @@
+# Watch G7 Direct BLE Observer — Implementation Plan v1
+
+## New files
+- `Trio Watch App Extension/G7DirectBLEObserver.swift` — CoreBluetooth observer lifecycle, attach flow, auth observation, control request cadence, payload handling.
+- `Trio Watch App Extension/WatchState+G7DirectBLE.swift` — WatchState integration + observer delegate bridge + snapshot persistence path.
+- `Trio Watch Shared/TrioComplicationDataSource.swift` — source attribution model shared by app + complication data pipeline.
+
+## Existing files to modify
+- `Trio Watch Shared/TrioComplicationDataStore.swift` — extend `TrioComplicationSnapshot` with optional source attribution.
+- `Trio Watch App Extension/WatchState.swift` — observer lifecycle hooks + source tagging on existing snapshot save paths.
+- `Trio Watch App Extension/Views/GlucoseTrendView.swift` — inline BLE/source status indicator in recency area.
+- `Trio Watch App Extension/Views/TrioMainWatchView.swift` — restore source attribution when hydrating from cached snapshot.
+
+## Phase ordering
+1. Shared model extension (source attribution).
+2. Observer core implementation (central/scanning/connect/discovery/auth/control/request/reconnect).
+3. WatchState wiring (scene hooks + delegate outputs + save path).
+4. UI indicator integration in existing recency label.
+5. Static review pass over all changed files.
+6. Write implementation log and handoff notes.
+
+## Dependencies and rationale
+- Shared snapshot source support lands first to avoid temporary parallel state paths.
+- BLE core precedes UI to ensure visible status is driven by real observer state.
+- WatchState bridges all side effects through existing application state and store interfaces.
+
+## Planned tests/checks for this pass
+- Static diff review only.
+- Optional syntax-only checks were skipped because this pass explicitly excludes project wiring/buildability verification.

--- a/docs/in-progress/watch-g7-direct-ble-observer/03-implementation-log.md
+++ b/docs/in-progress/watch-g7-direct-ble-observer/03-implementation-log.md
@@ -1,0 +1,49 @@
+# Watch G7 Direct BLE Observer — Implementation Log
+
+## Branch / base
+- Working branch: `feature/watch-g7-direct-ble-observer-a`
+- Intended base: `baseline-dev-patches-01-10`.
+- Environment note: branch was created locally from current repo HEAD because no remote-tracking branches/remotes were configured in this container.
+
+## Phase log
+
+### Phase 0 — required reference fetch
+- Attempted to fetch all 34 required DiaBLE/G7SensorKit raw URLs via `curl -fsSL`.
+- Result: all requests failed with HTTP 403 in this environment.
+- Impact: proceeded with explicit risk callouts and conservative clean-room implementation using known protocol constants.
+
+### Phase 1 — shared source attribution
+- Added `TrioComplicationDataSource` enum in `Trio Watch Shared/`.
+- Extended `TrioComplicationSnapshot` with optional `source` and threaded it through save helpers.
+
+### Phase 2 — watch observer core
+- Added `G7DirectBLEObserver` implementing:
+  - eager restoration central manager
+  - connected-service retrieval + scan fallback
+  - tolerant candidate filter
+  - broad service/characteristic discovery
+  - auth observe-only posture (no auth writes)
+  - control EGV request write on auth + timer cadence
+  - reconnect with bounded backoff
+  - structured `event=g7_ble_*` logging
+
+### Phase 3 — WatchState integration
+- Added `WatchState+G7DirectBLE` delegate bridge and state surface.
+- On direct EGV, updates WatchState, tags source `.directBLE`, and saves via existing complication store.
+- Added source-tagging for existing HK and WatchConnectivity save paths.
+- Hooked observer start on active entry and scene update on inactive/background transition.
+
+### Phase 4 — UI integration
+- Updated main glucose recency line in `GlucoseTrendView` to include source, BLE status, and last direct-BLE event recency.
+- Updated cache hydration in `TrioMainWatchView` to restore `source` into watch state.
+
+## Deviations from design during implementation
+- None material; implementation followed the design plan.
+
+## Validation performed
+- Static review only; no `xcodebuild`, no `ci/local-build.sh`, no project-file edits.
+- No target-membership wiring attempted (left for human Xcode follow-up).
+
+## Final handoff state
+- Done: docs, clean-room observer source files, WatchState/store/UI integration.
+- Pending human follow-up: Xcode target membership wiring, on-device BLE validation, parser offset confirmation, battery/runtime tuning.


### PR DESCRIPTION
### Motivation
- Add a watch-only Dexcom G7 direct BLE observer so the Trio Watch App Extension can eavesdrop the Dexcom G7 watch app's same-device BLE session and deliver multiple EGV readings directly into the complication pipeline for faster updates.
- Introduce end-to-end source attribution so the UI and complication snapshot pipeline can show whether a reading came from the phone relay, HealthKit, or the new direct-BLE observer.
- Operate as an observer only (no auth ownership or J-PAKE writes) and keep changes isolated to watch-side code, docs, and the existing complication data store.

### Description
- Implemented a new observer type `G7DirectBLEObserver` in `Trio Watch App Extension/G7DirectBLEObserver.swift` that uses an eager, restoration-backed `CBCentralManager`, `retrieveConnectedPeripherals` + scan attach ladder, broad service/characteristic discovery, auth-observe-only posture, control-channel EGV request writes, a 5-minute request cadence, and reconnect/backoff logic with structured `event=g7_ble_*` logs.
- Added `WatchState+G7DirectBLE.swift` to bridge observer events into `WatchState` and to persist direct-BLE readings into the existing complication pipeline via `TrioComplicationDataStore` (no new store was created).
- Extended the complication model by adding `TrioComplicationDataSource` in `Trio Watch Shared/TrioComplicationDataSource.swift` and adding an optional `source` field to `TrioComplicationSnapshot` plus `save(..., source:)` convenience plumbing in `TrioComplicationDataStore.swift` so saves are source-attributed (`.directBLE`, `.watchConnectivity`, `.healthKit`).
- Updated UI to surface observer status and source: `GlucoseTrendView` now shows `"<recency> · <source> · BLE:<status> · <heartbeat>"`, and `TrioMainWatchView` restores `source` from cached snapshots; observer start/scene hooks were wired into `WatchState` foreground handling.
- Added design, implementation plan, and implementation log under `docs/in-progress/watch-g7-direct-ble-observer/` describing decisions (including tradeoffs) and listing open device-test items.
- No edits to `Trio.xcodeproj/project.pbxproj`, no `scripts/sync_project_files.rb` run, and no Xcode or CI builds were executed in this pass as required by the constraints.

### Testing
- Reference fetch: attempted to download the DiaBLE/G7SensorKit reference files but all raw-GitHub requests failed with HTTP 403 in this environment, and this condition is documented in the design and implementation log (fetch failed).
- Static checks: ran `git diff --check` and performed a file-by-file static review of all modified/added files, which passed (no whitespace or trivial diff errors reported).
- Commit: changes were committed on branch `feature/watch-g7-direct-ble-observer-a` (commit `8787fc17`); there were no automated unit/Xcode builds executed as part of this pass per the stated constraints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ebb81432708324a8fb694c9335bc69)